### PR TITLE
Add Release Drafter change-template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 ---
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
+change-template: "* $TITLE ([#$NUMBER]($URL)) @$AUTHOR"
 template: |
   # What’s changed
 


### PR DESCRIPTION
Adds `change-template` to Release Drafter config as a workaround for the issue described in https://github.com/release-drafter/release-drafter/issues/1223