### PR TITLE
Install theme package instead of linking

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -47,7 +47,7 @@
 
     await step(`npm install ${themeDevProjectPath}`, userDir, 'Installing project dependencies - This may take a while, please be patient')
 
-    await step(`npm link ./..`, userDir, 'Linking theme package')
+    await step('npm install ./..', userDir, 'Installing theme package')
 
     async function step(command, workingDir, stepPrompt) {
         try {


### PR DESCRIPTION
Installing new nodes on the development project unlinks the theme package.
This PR fixes that by installing the theme package instead of linking it.