### PR TITLE
Remove unneeded checks

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -15,35 +15,32 @@ module.exports = function (RED) {
         const themeCustomCSS = themeName + '-custom.min.css'
         const scrollbarsCSS = 'common/scrollbars.min.css'
         const monacoFile = path.join(themePath, themeName + '-monaco.json')
-        const monacoOptions = existsSync(monacoFile) ? require(monacoFile) : {}
-        
+        const monacoOptions = require(monacoFile)
+
         if (readdirSync(themePath).length == 0) {
             console.warn('')
             console.warn(`Theme '${themeName}' not loaded. Empty directory`)
             console.warn('')
             return
         }
-        
+
         if (!existsSync(path.join(themePath, themeCSS))) {
             console.warn('')
             console.warn(`Theme '${themeName}' not loaded. CSS file is missing`)
             console.warn('')
             return
         }
-        
+
         cssArray.push(path.join(themeRelativePath, themeCSS))
-        
+
         const cssScrollArray = cssArray.slice()
         cssScrollArray.push(scrollbarsCSS)
         const cssScroll = { css: cssScrollArray }
 
-        if (existsSync(path.join(themePath, themeCustomCSS))) {
-            cssArray.push(path.join(themeRelativePath, themeCustomCSS))
-            cssScrollArray.push(path.join(themeRelativePath, themeCustomCSS))
-        }
+        cssArray.push(path.join(themeRelativePath, themeCustomCSS))
+        cssScrollArray.push(path.join(themeRelativePath, themeCustomCSS))
 
         RED.plugins.registerPlugin(themeName, Object.assign({}, type, css, monacoOptions))
-
         RED.plugins.registerPlugin(themeName + '-scroll', Object.assign({}, type, cssScroll, monacoOptions))
     })
 }


### PR DESCRIPTION
All themes have their files for Monaco Editor options and custom CSS. No need to check if they exist.