### PR TITLE
Custom accent color

### DIFF
--- a/common/common.css
+++ b/common/common.css
@@ -1,3 +1,9 @@
-input {
+input[type=checkbox],
+input[type=range],
+progress {
   accent-color: var(--red-ui-form-text-color);
+}
+
+input[type=radio] {
+  accent-color: var(--red-ui-tertiary-background);
 }

--- a/common/common.min.css
+++ b/common/common.min.css
@@ -1,1 +1,1 @@
-input{accent-color:var(--red-ui-form-text-color)}
+input[type=checkbox],input[type=range],progress{accent-color:var(--red-ui-form-text-color)}input[type=radio]{accent-color:var(--red-ui-tertiary-background)}


### PR DESCRIPTION
Customize the accent color for user-interface controls like: `<input type="checkbox">`, `<input type="radio">`, `<input type="range">` and `<progress>`.