### PR TITLE
Allow running scripts from any directory

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,17 +3,18 @@ const path = require('path')
 const { readFileSync, readdirSync, writeFileSync } = require('fs')
 const { exec } = require('child_process')
 const { minify } = require('csso')
-const themesPath = path.join(__dirname, '../themes')
+const rootPath = path.join(__dirname, '..')
+const themesPath = path.join(rootPath, 'themes')
 const themes = readdirSync(themesPath)
 
 themes.forEach(themeName => {
 
-    const themePath = path.join('themes', themeName)
+    const themePath = path.join(themesPath, themeName)
     const buildIn = path.join(themePath, themeName + '.scss')
     const buildOut = path.join(themePath, themeName + '.min.css')
-    const buildSrc = './node-red'
+    const buildSrc = path.join(rootPath, 'node-red')
 
-    exec(`node ./scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
+    exec(`node ${rootPath}/scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
 
     const themeCustomCss = readFileSync(path.resolve(themePath, themeName + '-custom.css'), 'utf-8')
     const minifiedCss = minify(themeCustomCss).css

--- a/scripts/create-theme.js
+++ b/scripts/create-theme.js
@@ -3,7 +3,8 @@ const commandLineArgs = require('command-line-args')
 const options = commandLineArgs([{ name: 'themeName', type: String, defaultOption: true }])
 const path = require('path')
 const { copyFileSync, existsSync, mkdirSync } = require('fs')
-const themePath = path.join('themes/', options.themeName)
+const rootPath = path.join(__dirname, '..')
+const themePath = path.join(rootPath, 'themes', options.themeName)
 
 if (!options.themeName) {
 	showUsageAndExit(1)
@@ -22,9 +23,9 @@ if (existsSync(themePath)) {
 mkdirSync(themePath)
 
 // Copy template files to theme directory
-copyFileSync('template/template.scss', path.join(themePath, options.themeName + '.scss'))
-copyFileSync('template/template-monaco.json', path.join(themePath, options.themeName + '-monaco.json'))
-copyFileSync('template/template-custom.css', path.join(themePath, options.themeName + '-custom.css'))
+copyFileSync(path.join(rootPath, 'template/template.scss'), path.join(themePath, options.themeName + '.scss'))
+copyFileSync(path.join(rootPath, 'template/template-monaco.json'), path.join(themePath, options.themeName + '-monaco.json'))
+copyFileSync(path.join(rootPath, 'template/template-custom.css'), path.join(themePath, options.themeName + '-custom.css'))
 
 function showUsageAndExit(exitCode) {
 	console.log('')

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -7,15 +7,15 @@ const { exec } = require('child_process')
 const { minify } = require('csso')
 const nodemon = require('nodemon')
 const themeName = String(options.themeName.split('-scroll', 1))
-const themePath = path.join('themes', themeName)
+const rootPath = path.join(__dirname, '..')
+const themePath = path.join(rootPath, 'themes', themeName)
 const buildIn = path.join(themePath, themeName + '.scss')
 const buildOut = path.join(themePath, themeName + '.min.css')
-const buildSrc = './node-red'
+const buildSrc = path.join(rootPath, 'node-red')
 
 if (!options.themeName) {
     showUsageAndExit(1)
 }
-
 if (options.themeName && !existsSync(themePath)) {
     console.warn('')
     console.warn(`Theme path is not valid. Could not find '${themePath}'`)
@@ -27,7 +27,7 @@ if (options.themeName && !existsSync(themePath)) {
 }
 
 watch(path.join(themePath, themeName + '.scss'), () => {
-    exec(`node ./scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
+    exec(`node ${rootPath}/scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
 })
 
 watch(path.join(themePath, themeName + '-custom.css'), () => {
@@ -45,7 +45,7 @@ watch(path.join(themePath, themeName + '-monaco.json'), () => {
 })
 
 nodemon({
-    exec: `node-red/packages/node_modules/node-red/red.js --port 41880 --userDir .node-red --define credentialSecret=false --define editorTheme.projects.enabled=true --define editorTheme.theme=${options.themeName} theme-dev-project`,
+    exec: `${rootPath}/node-red/packages/node_modules/node-red/red.js --port 41880 --userDir ${rootPath}/.node-red --define credentialSecret=false --define editorTheme.projects.enabled=true --define editorTheme.theme=${options.themeName} theme-dev-project`,
     ext: 'js,json,css',
     watch: [
         'common/',


### PR DESCRIPTION
After merging #228, I noticed that directly running most of the scripts from outside the repository's root directory would also throw errors. This PR fixes that.