### PR TITLE
Stop using npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.git*
-scripts/
-template/
-*.scss
-*.css
-!*.min.css
-*.json
-!*.min.json

--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
     },
     "engines": {
         "node": ">=14.x"
-    }
+    },
+    "files": [
+        "/themes/**/*.min.*",
+        "/themes.js"
+    ]
 }


### PR DESCRIPTION
Move to using the `files` field in `package.json` as an allowlist of files that will be part of the published package.