### PR TITLE
Simplify Monaco Editor theme configuration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,8 @@ This document describes the process for creating/updating themes.
 
 With the development environment initialized, follow these steps to create a new theme:
 
+***NOTE:** Replace `<theme-name>` with the name of the theme you are working on.*
+
 1. Create the new theme directory structure
 
         npm run create-theme <theme-name>
@@ -28,19 +30,20 @@ With the development environment initialized, follow these steps to create a new
 
 4. Update the colors in `themes/<theme-name>/<theme-name>.scss` as required & save
 
-5. Update `themes/<theme-name>/<theme-name>-monaco.json` to customize the colors of the Monaco Editor. For details on the `monacoOptions` configuration, please refer to the [Node-RED documentation][theming-the-monaco-editor].
+5. ***(OPTIONAL)*** If additional customizations are needed, add them to `themes/<theme-name>/<theme-name>-custom.css`.
 
-6. ***OPTIONAL*** - If additional customizations are needed, add them to `themes/<theme-name>/<theme-name>-custom.css`.
+6. ***(OPTIONAL)*** Update `themes/<theme-name>/<theme-name>-monaco.json` to customize the colors of the Monaco Editor. This file can be configured in two different ways:
 
-7. ***OPTIONAL*** - Customize Mermaid's theme by adding `"<mermaid-theme-name>"` to `themes/<theme-name>/<theme-name>-mermaid.json`. Replace `<mermaid-theme-name>` with the name of one of the themes in this [list](https://mermaid.js.org/config/theming.html#available-themes). If the file doesn't exist, the value `"dark"` is used by default.
+   - Built-in theme - Add `"<monaco-theme-name>"` to the file. Replace `"<monaco-theme-name>"` with the name of one of the themes in this [list][monaco-editor-builtin-themes].
+   - Custom Monaco theme object - See the [`my-custom-theme-monaco-theme.json` file example][setting-a-custom-monaco-theme-from-a-json-file] in the Node-RED documentation for reference.
+
+7. ***(OPTIONAL)*** Customize Mermaid's theme by adding `"<mermaid-theme-name>"` to `themes/<theme-name>/<theme-name>-mermaid.json`. Replace `<mermaid-theme-name>` with the name of one of the themes in this [list](https://mermaid.js.org/config/theming.html#available-themes). If the file doesn't exist, the value `"dark"` is used by default.
 
 8. Refresh Node-RED in the browser to preview the changes
 
 9. Repeat steps 4 to 7 as needed. When finished, press `ctrl-D` to quit the development environment.
 
 10. Commit, push, and create a pull request.
-
-***NOTE:** Replace `<theme-name>` with the name of the theme you are working on.*
 
 ## Updating an existing theme
 
@@ -49,4 +52,5 @@ Follow the process above, skipping step 1.
 Thanks for taking the time to contribute! 😍
 
 [fork]: https://github.com/node-red-contrib-themes/theme-collection/fork
-[theming-the-monaco-editor]: https://nodered.org/docs/api/ui/themes/#theming-the-monaco-editor
+[monaco-editor-builtin-themes]: https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/editor-client/src/vendor/monaco/dist/theme
+[setting-a-custom-monaco-theme-from-a-json-file]: https://nodered.org/docs/api/ui/themes/#setting-a-custom-monaco-theme-from-a-json-file

--- a/template/template-monaco.json
+++ b/template/template-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "vs"
-    }
-}
+"tomorrow-night-bright"

--- a/themes.js
+++ b/themes.js
@@ -16,8 +16,8 @@ module.exports = function (RED) {
         const scrollbarsCSS = 'common/scrollbars.min.css'
         const mermaidTheme = existsSync(path.join(themePath, `${themeName}-mermaid.json`)) ? JSON.parse(readFileSync(path.join(themePath, `${themeName}-mermaid.json`), 'utf-8')) : "dark"
         const mermaidOptions = { mermaid: { theme: mermaidTheme } }
-        const monacoFile = path.join(themePath, themeName + '-monaco.min.json')
-        const monacoOptions = JSON.parse(readFileSync(monacoFile, 'utf-8'))
+        const monacoTheme = JSON.parse(readFileSync(path.join(themePath, `${themeName}-monaco.min.json`), 'utf-8'))
+        const monacoOptions = { monacoOptions: { theme: monacoTheme } }
 
         if (readdirSync(themePath).length == 0) {
             console.warn('')

--- a/themes/aurora/aurora-monaco.json
+++ b/themes/aurora/aurora-monaco.json
@@ -1,624 +1,620 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "base": "vs-dark",
-            "inherit": true,
-            "rules": [
-                {
-                    "foreground": "696587",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "ffb700",
-                    "token": "string"
-                },
-                {
-                    "foreground": "3f89ff",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "3f89ff",
-                    "fontStyle": " italic",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "3f89ff",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "3f89ff",
-                    "token": "constant.other"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "7877ff",
-                    "fontStyle": " italic",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "c5e400",
-                    "fontStyle": " italic ",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "d9903b",
-                    "fontStyle": " italic ",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "7877ff",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "7877ff",
-                    "fontStyle": " italic",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "7877ff",
-                    "fontStyle": "italic",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "7877ff",
-                    "fontStyle": "italic",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "e12977",
-                    "background": "c5e400",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "ffff05",
-                    "background": "e12977",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "markup.deleted.git_gutter"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "markup.inserted.git_gutter"
-                },
-                {
-                    "foreground": "7877ff",
-                    "token": "markup.changed.git_gutter"
-                },
-                {
-                    "foreground": "565656",
-                    "token": "markup.ignored.git_gutter"
-                },
-                {
-                    "foreground": "565656",
-                    "token": "markup.untracked.git_gutter"
-                },
-                {
-                    "foreground": "c5e400",
-                    "background": "171717",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "c5e400",
-                    "background": "171717",
-                    "fontStyle": "italic",
-                    "token": "markup.italic.markdown"
-                },
-                {
-                    "foreground": "c5e400",
-                    "background": "22222200",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "c5e400",
-                    "background": "22222200",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.string.begin.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.string.end.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.constant.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.separator.key-value.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.constant.begin.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.constant.end.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.bold.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.italic.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.strikethrough.markdown"
-                },
-                {
-                    "foreground": "7877ff",
-                    "background": "11111100",
-                    "token": "punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "999999",
-                    "background": "11111100",
-                    "token": "markup.list.unnumbered.markdown"
-                },
-                {
-                    "foreground": "999999",
-                    "background": "11111100",
-                    "token": "markup.list.unnumbered.markdown meta.paragraph.list.markdown"
-                },
-                {
-                    "foreground": "999999",
-                    "background": "11111100",
-                    "token": "markup.list.numbered.markdown"
-                },
-                {
-                    "foreground": "999999",
-                    "background": "11111100",
-                    "token": "markup.list.numbered.markdown meta.paragraph.list.markdown"
-                },
-                {
-                    "foreground": "ffffff",
-                    "token": "markup.list.unnumbered.markdown punctuation.definition.list_item.markdown"
-                },
-                {
-                    "foreground": "ffffff",
-                    "token": "markup.list.numbered.markdown punctuation.definition.list_item.markdown"
-                },
-                {
-                    "foreground": "808080",
-                    "token": "markup.output"
-                },
-                {
-                    "foreground": "808080",
-                    "token": "markup.raw"
-                },
-                {
-                    "foreground": "aaaaaa",
-                    "token": "markup.prompt"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "aaaaaa",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold_italic"
-                },
-                {
-                    "foreground": "aaaaaa",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold_italic.markdown"
-                },
-                {
-                    "foreground": "a7abf7",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "a7abf7",
-                    "fontStyle": "bold",
-                    "token": "markup.bold.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough constant.other.reference.link.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough entity.name.tag"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.bold"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.bold.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.italic"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.italic.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.raw.inline.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.underline.link.image.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough meta.link.inet.markdown markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough meta.link.email.lt-gt.markdown markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.bold.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.italic.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.constant.begin.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.constant.end.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.constant.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.strikethrough.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.string.begin.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.string.end.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.tag.begin.html"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough punctuation.definition.tag.end.html"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough string.other.link.description.title.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "markup.strikethrough string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "484848",
-                    "background": "222222",
-                    "token": "markup.strikethrough markup.kbd.content"
-                },
-                {
-                    "foreground": "484848",
-                    "background": "222222",
-                    "token": "markup.strikethrough markup.kbd.content.markdown"
-                },
-                {
-                    "foreground": "ececec",
-                    "background": "2c2c2c",
-                    "token": "markup.kbd.content.markdown"
-                },
-                {
-                    "foreground": "ffb700",
-                    "token": "markup.traceback"
-                },
-                {
-                    "foreground": "555555",
-                    "background": "171717",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "555555",
-                    "background": "171717",
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "555555",
-                    "background": "171717",
-                    "token": "constant.other.reference.link.markdown"
-                },
-                {
-                    "foreground": "555555",
-                    "background": "171717",
-                    "token": "meta.image.reference.markdown"
-                },
-                {
-                    "foreground": "bbbb77",
-                    "token": "meta.link.inet.markdown markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "bbbb77",
-                    "token": "meta.link.email.lt-gt.markdown markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "444444",
-                    "background": "222222",
-                    "token": "meta.header.multimarkdown"
-                },
-                {
-                    "foreground": "444444",
-                    "background": "222222",
-                    "token": "keyword.other.multimarkdown"
-                },
-                {
-                    "foreground": "444444",
-                    "background": "222222",
-                    "token": "string.unquoted.multimarkdown"
-                },
-                {
-                    "foreground": "444444",
-                    "background": "222222",
-                    "token": "punctuation.separator.key-value.multimarkdown"
-                },
-                {
-                    "foreground": "555555",
-                    "background": "44444422",
-                    "token": "meta.separator.markdown"
-                },
-                {
-                    "foreground": "666666",
-                    "token": "markup.quote.markdown"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown entity.name.tag"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown meta.tag"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown meta.tag punctuation.definition.tag"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown meta.tag string.quoted meta.string-contents"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown meta.tag string.quoted punctuation.definition.string"
-                },
-                {
-                    "foreground": "313131",
-                    "background": "131313",
-                    "token": "text.html.markdown markup.quote.markdown meta.tag entity.other.attribute-name"
-                },
-                {
-                    "foreground": "8e8e8e",
-                    "background": "1a1a1a",
-                    "token": "text.html.markdown markup.quote.markdown markup.kbd.content.markdown"
-                },
-                {
-                    "foreground": "666666",
-                    "token": "text.html.markdown markup.quote.markdown markup.bold"
-                },
-                {
-                    "foreground": "666666",
-                    "token": "text.html.markdown markup.quote.markdown markup.bold.markdown"
-                },
-                {
-                    "foreground": "3e3e3e",
-                    "background": "3e3e3e",
-                    "token": "punctuation.definition.blockquote.markdown"
-                },
-                {
-                    "foreground": "aaaaaa",
-                    "background": "212121",
-                    "token": "markup.raw.block.markdown"
-                },
-                {
-                    "background": "212121",
-                    "token": "markup.raw.inline.markdown"
-                },
-                {
-                    "foreground": "eeeeee",
-                    "background": "ffb700",
-                    "token": "block_cursor"
-                },
-                {
-                    "foreground": "dedede",
-                    "background": "ffb700",
-                    "token": "wordhighlight"
-                },
-                {
-                    "foreground": "dedede",
-                    "background": "ffb700",
-                    "token": "brackethighlighter.default"
-                },
-                {
-                    "foreground": "ffb700",
-                    "token": "meta.structure.dictionary.json string.quoted.double.json"
-                },
-                {
-                    "foreground": "b9bfff",
-                    "token": "punctuation.definition.string.begin.json - meta.structure.dictionary.value.json"
-                },
-                {
-                    "foreground": "b9bfff",
-                    "token": "punctuation.definition.string.end.json - meta.structure.dictionary.value.json"
-                },
-                {
-                    "foreground": "7877ff",
-                    "token": "meta.structure.dictionary.json string.quoted.double.json"
-                },
-                {
-                    "foreground": "ffb700",
-                    "token": "meta.structure.dictionary.value.json string.quoted.double.json"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "meta meta meta meta meta meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "d9903b",
-                    "token": "meta meta meta meta meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "meta meta meta meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "e17092",
-                    "token": "meta meta meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "meta meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "d9903b",
-                    "token": "meta meta.structure.dictionary.value string"
-                },
-                {
-                    "foreground": "75715e",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "75715e",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "e12977",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "c5e400",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "ffff05",
-                    "token": "markup.changed"
-                }
-            ],
-            "colors": {
-                "editor.foreground": "#ececec",
-                "editor.background": "#302e40",
-                "editor.selectionBackground": "#4b4959",
-                "editor.lineHighlightBackground": "#3f3d4d",
-                "editorCursor.foreground": "#ffffff",
-                "editorWhitespace.foreground": "#383838"
-            }
+    "base": "vs-dark",
+    "inherit": true,
+    "rules": [
+        {
+            "foreground": "696587",
+            "token": "comment"
+        },
+        {
+            "foreground": "ffb700",
+            "token": "string"
+        },
+        {
+            "foreground": "3f89ff",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "3f89ff",
+            "fontStyle": " italic",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "3f89ff",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "3f89ff",
+            "token": "constant.other"
+        },
+        {
+            "foreground": "e12977",
+            "token": "keyword"
+        },
+        {
+            "foreground": "e12977",
+            "token": "storage"
+        },
+        {
+            "foreground": "7877ff",
+            "fontStyle": " italic",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "c5e400",
+            "fontStyle": " italic ",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "d9903b",
+            "fontStyle": " italic ",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "e12977",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "7877ff",
+            "token": "support.function"
+        },
+        {
+            "foreground": "7877ff",
+            "fontStyle": " italic",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "7877ff",
+            "fontStyle": "italic",
+            "token": "support.type"
+        },
+        {
+            "foreground": "7877ff",
+            "fontStyle": "italic",
+            "token": "support.class"
+        },
+        {
+            "foreground": "e12977",
+            "background": "c5e400",
+            "token": "invalid"
+        },
+        {
+            "foreground": "ffff05",
+            "background": "e12977",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "e12977",
+            "token": "markup.deleted.git_gutter"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "markup.inserted.git_gutter"
+        },
+        {
+            "foreground": "7877ff",
+            "token": "markup.changed.git_gutter"
+        },
+        {
+            "foreground": "565656",
+            "token": "markup.ignored.git_gutter"
+        },
+        {
+            "foreground": "565656",
+            "token": "markup.untracked.git_gutter"
+        },
+        {
+            "foreground": "c5e400",
+            "background": "171717",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "c5e400",
+            "background": "171717",
+            "fontStyle": "italic",
+            "token": "markup.italic.markdown"
+        },
+        {
+            "foreground": "c5e400",
+            "background": "22222200",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "c5e400",
+            "background": "22222200",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.string.begin.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.string.end.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.constant.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.separator.key-value.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.constant.begin.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.constant.end.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.bold.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.italic.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.strikethrough.markdown"
+        },
+        {
+            "foreground": "7877ff",
+            "background": "11111100",
+            "token": "punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "999999",
+            "background": "11111100",
+            "token": "markup.list.unnumbered.markdown"
+        },
+        {
+            "foreground": "999999",
+            "background": "11111100",
+            "token": "markup.list.unnumbered.markdown meta.paragraph.list.markdown"
+        },
+        {
+            "foreground": "999999",
+            "background": "11111100",
+            "token": "markup.list.numbered.markdown"
+        },
+        {
+            "foreground": "999999",
+            "background": "11111100",
+            "token": "markup.list.numbered.markdown meta.paragraph.list.markdown"
+        },
+        {
+            "foreground": "ffffff",
+            "token": "markup.list.unnumbered.markdown punctuation.definition.list_item.markdown"
+        },
+        {
+            "foreground": "ffffff",
+            "token": "markup.list.numbered.markdown punctuation.definition.list_item.markdown"
+        },
+        {
+            "foreground": "808080",
+            "token": "markup.output"
+        },
+        {
+            "foreground": "808080",
+            "token": "markup.raw"
+        },
+        {
+            "foreground": "aaaaaa",
+            "token": "markup.prompt"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "aaaaaa",
+            "fontStyle": "bold italic",
+            "token": "markup.bold_italic"
+        },
+        {
+            "foreground": "aaaaaa",
+            "fontStyle": "bold italic",
+            "token": "markup.bold_italic.markdown"
+        },
+        {
+            "foreground": "a7abf7",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "a7abf7",
+            "fontStyle": "bold",
+            "token": "markup.bold.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough constant.other.reference.link.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough entity.name.tag"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.bold"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.bold.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.italic"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.italic.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.raw.inline.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.underline.link.image.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough markup.underline.link.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough meta.link.inet.markdown markup.underline.link.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough meta.link.email.lt-gt.markdown markup.underline.link.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.bold.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.italic.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.constant.begin.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.constant.end.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.constant.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.strikethrough.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.string.begin.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.string.end.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.tag.begin.html"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough punctuation.definition.tag.end.html"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough string.other.link.description.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough string.other.link.description.title.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "markup.strikethrough string.other.link.title.markdown"
+        },
+        {
+            "foreground": "484848",
+            "background": "222222",
+            "token": "markup.strikethrough markup.kbd.content"
+        },
+        {
+            "foreground": "484848",
+            "background": "222222",
+            "token": "markup.strikethrough markup.kbd.content.markdown"
+        },
+        {
+            "foreground": "ececec",
+            "background": "2c2c2c",
+            "token": "markup.kbd.content.markdown"
+        },
+        {
+            "foreground": "ffb700",
+            "token": "markup.traceback"
+        },
+        {
+            "foreground": "555555",
+            "background": "171717",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "555555",
+            "background": "171717",
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "foreground": "555555",
+            "background": "171717",
+            "token": "constant.other.reference.link.markdown"
+        },
+        {
+            "foreground": "555555",
+            "background": "171717",
+            "token": "meta.image.reference.markdown"
+        },
+        {
+            "foreground": "bbbb77",
+            "token": "meta.link.inet.markdown markup.underline.link.markdown"
+        },
+        {
+            "foreground": "bbbb77",
+            "token": "meta.link.email.lt-gt.markdown markup.underline.link.markdown"
+        },
+        {
+            "foreground": "444444",
+            "background": "222222",
+            "token": "meta.header.multimarkdown"
+        },
+        {
+            "foreground": "444444",
+            "background": "222222",
+            "token": "keyword.other.multimarkdown"
+        },
+        {
+            "foreground": "444444",
+            "background": "222222",
+            "token": "string.unquoted.multimarkdown"
+        },
+        {
+            "foreground": "444444",
+            "background": "222222",
+            "token": "punctuation.separator.key-value.multimarkdown"
+        },
+        {
+            "foreground": "555555",
+            "background": "44444422",
+            "token": "meta.separator.markdown"
+        },
+        {
+            "foreground": "666666",
+            "token": "markup.quote.markdown"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown entity.name.tag"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown meta.tag"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown meta.tag punctuation.definition.tag"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown meta.tag string.quoted meta.string-contents"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown meta.tag string.quoted punctuation.definition.string"
+        },
+        {
+            "foreground": "313131",
+            "background": "131313",
+            "token": "text.html.markdown markup.quote.markdown meta.tag entity.other.attribute-name"
+        },
+        {
+            "foreground": "8e8e8e",
+            "background": "1a1a1a",
+            "token": "text.html.markdown markup.quote.markdown markup.kbd.content.markdown"
+        },
+        {
+            "foreground": "666666",
+            "token": "text.html.markdown markup.quote.markdown markup.bold"
+        },
+        {
+            "foreground": "666666",
+            "token": "text.html.markdown markup.quote.markdown markup.bold.markdown"
+        },
+        {
+            "foreground": "3e3e3e",
+            "background": "3e3e3e",
+            "token": "punctuation.definition.blockquote.markdown"
+        },
+        {
+            "foreground": "aaaaaa",
+            "background": "212121",
+            "token": "markup.raw.block.markdown"
+        },
+        {
+            "background": "212121",
+            "token": "markup.raw.inline.markdown"
+        },
+        {
+            "foreground": "eeeeee",
+            "background": "ffb700",
+            "token": "block_cursor"
+        },
+        {
+            "foreground": "dedede",
+            "background": "ffb700",
+            "token": "wordhighlight"
+        },
+        {
+            "foreground": "dedede",
+            "background": "ffb700",
+            "token": "brackethighlighter.default"
+        },
+        {
+            "foreground": "ffb700",
+            "token": "meta.structure.dictionary.json string.quoted.double.json"
+        },
+        {
+            "foreground": "b9bfff",
+            "token": "punctuation.definition.string.begin.json - meta.structure.dictionary.value.json"
+        },
+        {
+            "foreground": "b9bfff",
+            "token": "punctuation.definition.string.end.json - meta.structure.dictionary.value.json"
+        },
+        {
+            "foreground": "7877ff",
+            "token": "meta.structure.dictionary.json string.quoted.double.json"
+        },
+        {
+            "foreground": "ffb700",
+            "token": "meta.structure.dictionary.value.json string.quoted.double.json"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "meta meta meta meta meta meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "d9903b",
+            "token": "meta meta meta meta meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "e12977",
+            "token": "meta meta meta meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "e17092",
+            "token": "meta meta meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "meta meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "d9903b",
+            "token": "meta meta.structure.dictionary.value string"
+        },
+        {
+            "foreground": "75715e",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "75715e",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "e12977",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "c5e400",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "ffff05",
+            "token": "markup.changed"
         }
+    ],
+    "colors": {
+        "editor.foreground": "#ececec",
+        "editor.background": "#302e40",
+        "editor.selectionBackground": "#4b4959",
+        "editor.lineHighlightBackground": "#3f3d4d",
+        "editorCursor.foreground": "#ffffff",
+        "editorWhitespace.foreground": "#383838"
     }
 }

--- a/themes/cobalt2/cobalt2-monaco.json
+++ b/themes/cobalt2/cobalt2-monaco.json
@@ -1,712 +1,708 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#122738",
-                "activityBar.border": "#0d3a58",
-                "activityBar.foreground": "#ffffff",
-                "activityBarBadge.background": "#ffc600",
-                "activityBarBadge.foreground": "#000000",
-                "badge.background": "#ffc600",
-                "badge.foreground": "#000000",
-                "button.background": "#0088ff",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#ff9d00",
-                "contrastBorder": "#ffffff00",
-                "debugConsole.errorForeground": "#ff5630",
-                "debugExceptionWidget.background": "#193549",
-                "debugExceptionWidget.border": "#aaaaaa",
-                "debugToolBar.background": "#193549",
-                "descriptionForeground": "#aaaaaa",
-                "diffEditor.insertedTextBackground": "#3ad90033",
-                "diffEditor.insertedTextBorder": "#00000000",
-                "diffEditor.removedTextBackground": "#ee3a4333",
-                "diffEditor.removedTextBorder": "#00000000",
-                "dropdown.background": "#193549",
-                "dropdown.border": "#15232d",
-                "dropdown.foreground": "#ffffff",
-                "editor.background": "#193549",
-                "editor.findMatchBackground": "#ff720066",
-                "editor.findMatchHighlightBackground": "#cad40f66",
-                "editor.findRangeHighlightBackground": "#243e51",
-                "editor.foreground": "#ffffff",
-                "editor.hoverHighlightBackground": "#ffc60033",
-                "editor.inactiveSelectionBackground": "#003b8b",
-                "editor.lineHighlightBackground": "#1f4662",
-                "editor.lineHighlightBorder": "#234e6d",
-                "editor.rangeHighlightBackground": "#1f4662",
-                "editor.selectionBackground": "#0050a4",
-                "editor.selectionHighlightBackground": "#0050a480",
-                "editor.wordHighlightBackground": "#ffffff21",
-                "editor.wordHighlightStrongBackground": "#ffffff21",
-                "editorBracketMatch.background": "#0d3a58",
-                "editorBracketMatch.border": "#ffc60080",
-                "editorCodeLens.foreground": "#aaaaaa",
-                "editorCursor.foreground": "#ffc600",
-                "editorError.border": "#0d3a58",
-                "editorError.foreground": "#a22929",
-                "editorGroup.border": "#122738",
-                "editorGroup.dropBackground": "#12273899",
-                "editorGroupHeader.noTabsBackground": "#193549",
-                "editorGroupHeader.tabsBackground": "#122738",
-                "editorGroupHeader.tabsBorder": "#15232d",
-                "editorGutter.addedBackground": "#3c9f4a",
-                "editorGutter.background": "#12273866",
-                "editorGutter.deletedBackground": "#a22929",
-                "editorGutter.modifiedBackground": "#26506d",
-                "editorHint.foreground": "#ffc600",
-                "editorHoverWidget.background": "#15232d",
-                "editorHoverWidget.border": "#0d3a58",
-                "editorIndentGuide.background": "#3b5364",
-                "editorInlayHint.background": "#0000001a",
-                "editorInlayHint.foreground": "#ff68b8",
-                "editorLineNumber.foreground": "#aaaaaa",
-                "editorLink.activeForeground": "#aaaaaa",
-                "editorMarkerNavigation.background": "#3b536433",
-                "editorMarkerNavigationError.background": "#a22929",
-                "editorMarkerNavigationWarning.background": "#ffc600",
-                "editorOverviewRuler.border": "#0d3a58",
-                "editorOverviewRuler.commonContentForeground": "#ffc60055",
-                "editorOverviewRuler.currentContentForeground": "#ee3a4355",
-                "editorOverviewRuler.incomingContentForeground": "#3ad90055",
-                "editorRuler.foreground": "#1f4662",
-                "editorSuggestWidget.background": "#15232d",
-                "editorSuggestWidget.border": "#15232d",
-                "editorSuggestWidget.foreground": "#aaaaaa",
-                "editorSuggestWidget.highlightForeground": "#ffc600",
-                "editorSuggestWidget.selectedBackground": "#193549",
-                "editorWarning.border": "#ffffff00",
-                "editorWarning.foreground": "#ffc600",
-                "editorWhitespace.foreground": "#ffffff52",
-                "editorWidget.background": "#15232d",
-                "editorWidget.border": "#0d3a58",
-                "errorForeground": "#a22929",
-                "extensionButton.prominentBackground": "#0088ff",
-                "extensionButton.prominentForeground": "#ffffff",
-                "extensionButton.prominentHoverBackground": "#ff9d00",
-                "focusBorder": "#0d3a58",
-                "foreground": "#aaaaaa",
-                "gitDecoration.conflictingResourceForeground": "#ff7200",
-                "gitDecoration.deletedResourceForeground": "#ff628c",
-                "gitDecoration.ignoredResourceForeground": "#808080",
-                "gitDecoration.modifiedResourceForeground": "#ffc600",
-                "gitDecoration.untrackedResourceForeground": "#3ad900",
-                "input.background": "#193549",
-                "input.border": "#0d3a58",
-                "input.foreground": "#ffc600",
-                "input.placeholderForeground": "#aaaaaa",
-                "inputOption.activeBorder": "#8dffff",
-                "inputValidation.errorBackground": "#193549",
-                "inputValidation.errorBorder": "#ffc600",
-                "inputValidation.infoBackground": "#193549",
-                "inputValidation.infoBorder": "#0d3a58",
-                "inputValidation.warningBackground": "#193549",
-                "inputValidation.warningBorder": "#ffc600",
-                "list.activeSelectionBackground": "#193549",
-                "list.activeSelectionForeground": "#aaaaaa",
-                "list.dropBackground": "#0d3a58",
-                "list.focusBackground": "#0d3a58",
-                "list.focusForeground": "#aaaaaa",
-                "list.highlightForeground": "#ffc600",
-                "list.hoverBackground": "#193549",
-                "list.hoverForeground": "#aaaaaa",
-                "list.inactiveSelectionBackground": "#0d3a58",
-                "list.inactiveSelectionForeground": "#aaaaaa",
-                "menu.background": "#122738",
-                "menu.selectionForeground": "#ffffff",
-                "menubar.selectionBackground": "#0d3a58",
-                "merge.border": "#ffffff00",
-                "merge.commonContentBackground": "#c97d0c",
-                "merge.commonHeaderBackground": "#c97d0c",
-                "merge.currentContentBackground": "#2f7366",
-                "merge.currentHeaderBackground": "#2f7366",
-                "merge.incomingContentBackground": "#185294",
-                "merge.incomingHeaderBackground": "#185294",
-                "notificationCenter.border": "#ffc600",
-                "notificationCenterHeader.background": "#122738",
-                "notificationCenterHeader.foreground": "#aaaaaa",
-                "notificationLink.foreground": "#ffc600",
-                "notificationToast.border": "#ffc600",
-                "notifications.background": "#122738",
-                "notifications.border": "#ffc600",
-                "notifications.foreground": "#aaaaaa",
-                "panel.background": "#122738",
-                "panel.border": "#ffc600",
-                "panelTitle.activeBorder": "#ffc600",
-                "panelTitle.activeForeground": "#ffc600",
-                "panelTitle.inactiveForeground": "#aaaaaa",
-                "peekView.border": "#ffc600",
-                "peekViewEditor.background": "#193549",
-                "peekViewEditor.matchHighlightBackground": "#19354900",
-                "peekViewEditorGutter.background": "#122738",
-                "peekViewResult.background": "#15232d",
-                "peekViewResult.fileForeground": "#aaaaaa",
-                "peekViewResult.lineForeground": "#ffffff",
-                "peekViewResult.matchHighlightBackground": "#0d3a58",
-                "peekViewResult.selectionBackground": "#0d3a58",
-                "peekViewResult.selectionForeground": "#ffffff",
-                "peekViewTitle.background": "#15232d",
-                "peekViewTitleDescription.foreground": "#aaaaaa",
-                "peekViewTitleLabel.foreground": "#ffc600",
-                "pickerGroup.border": "#0d3a58",
-                "pickerGroup.foreground": "#aaaaaa",
-                "progressBar.background": "#ffc600",
-                "scrollbar.shadow": "#00000000",
-                "scrollbarSlider.activeBackground": "#355166cc",
-                "scrollbarSlider.background": "#406179cc",
-                "scrollbarSlider.hoverBackground": "#437da3cc",
-                "selection.background": "#027dff",
-                "sideBar.background": "#15232d",
-                "sideBar.border": "#0d3a58",
-                "sideBar.foreground": "#aaaaaa",
-                "sideBarSectionHeader.background": "#193549",
-                "sideBarSectionHeader.foreground": "#aaaaaa",
-                "sideBarTitle.foreground": "#aaaaaa",
-                "statusBar.background": "#15232d",
-                "statusBar.border": "#0d3a58",
-                "statusBar.debuggingBackground": "#15232d",
-                "statusBar.debuggingBorder": "#ffc600",
-                "statusBar.debuggingForeground": "#ffc600",
-                "statusBar.foreground": "#aaaaaa",
-                "statusBar.noFolderBackground": "#15232d",
-                "statusBar.noFolderBorder": "#0d3a58",
-                "statusBar.noFolderForeground": "#aaaaaa",
-                "statusBarItem.activeBackground": "#0088ff",
-                "statusBarItem.hoverBackground": "#0d3a58",
-                "statusBarItem.prominentBackground": "#15232d",
-                "statusBarItem.prominentHoverBackground": "#0d3a58",
-                "statusBarItem.remoteBackground": "#15232d",
-                "statusBarItem.remoteForeground": "#aaaaaa",
-                "tab.activeBackground": "#193549",
-                "tab.activeBorder": "#ffc600",
-                "tab.activeForeground": "#ffffff",
-                "tab.border": "#15232d",
-                "tab.inactiveBackground": "#122738",
-                "tab.inactiveForeground": "#aaaaaa",
-                "tab.unfocusedActiveForeground": "#aaaaaa",
-                "tab.unfocusedInactiveForeground": "#aaaaaa",
-                "terminal.ansiBlack": "#000000",
-                "terminal.ansiBlue": "#0088ff",
-                "terminal.ansiBrightBlack": "#0050a4",
-                "terminal.ansiBrightBlue": "#0088ff",
-                "terminal.ansiBrightCyan": "#80fcff",
-                "terminal.ansiBrightGreen": "#3ad900",
-                "terminal.ansiBrightMagenta": "#fb94ff",
-                "terminal.ansiBrightRed": "#ff628c",
-                "terminal.ansiBrightWhite": "#ffffff",
-                "terminal.ansiBrightYellow": "#ffc600",
-                "terminal.ansiCyan": "#80fcff",
-                "terminal.ansiGreen": "#3ad900",
-                "terminal.ansiMagenta": "#fb94ff",
-                "terminal.ansiRed": "#ff628c",
-                "terminal.ansiWhite": "#ffffff",
-                "terminal.ansiYellow": "#ffc600",
-                "terminal.background": "#122738",
-                "terminal.foreground": "#ffffff",
-                "terminalCursor.background": "#122738",
-                "terminalCursor.foreground": "#ffc600",
-                "textBlockQuote.background": "#193549",
-                "textBlockQuote.border": "#0088ff",
-                "textCodeBlock.background": "#193549",
-                "textLink.activeForeground": "#0088ff",
-                "textLink.foreground": "#0088ff",
-                "textPreformat.foreground": "#ffc600",
-                "textSeparator.foreground": "#0d3a58",
-                "titleBar.activeBackground": "#15232d",
-                "titleBar.activeForeground": "#ffffff",
-                "titleBar.inactiveBackground": "#193549",
-                "titleBar.inactiveForeground": "#ffffff33",
-                "walkThrough.embeddedEditorBackground": "#0d3a58",
-                "widget.shadow": "#00000026"
-            },
-            "rules": [
-                {
-                    "foreground": "#0088FF",
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#0088FF",
-                    "fontStyle": "italic",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#FF628C",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "entity"
-                },
-                {
-                    "foreground": "#F44542",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": "storage.type.function"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": " storage.type.class"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": " keyword.control.default.ts"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#A5FF90CC",
-                    "token": "punctuation.definition.inserted"
-                },
-                {
-                    "foreground": "#FF628C",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#FF628C",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#FF628CCC",
-                    "token": "punctuation.definition.deleted"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "meta"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "meta.jsx.children.js"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "meta.jsx.children.tsx"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "meta.brace"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "punctuation"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "storage.type.function.arrow"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#3AD900",
-                    "token": "string.template"
-                },
-                {
-                    "foreground": "#3AD900",
-                    "token": "punctuation.definition.string.template"
-                },
-                {
-                    "foreground": "#80FFBB",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#3AD900",
-                    "token": "source.css entity"
-                },
-                {
-                    "foreground": "#3AD900",
-                    "token": "source.stylus entity"
-                },
-                {
-                    "foreground": "#FFB454",
-                    "token": "entity.other.attribute-name.id.css"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "source.css support"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "source.stylus support"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.css constant"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.css support.constant"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.stylus constant"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.stylus support.constant"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.css string"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.css punctuation.definition.string"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.stylus string"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.stylus punctuation.definition.string"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "source.css variable"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "source.stylus variable"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "text.html.basic entity.name"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "meta.toc-list.id.html"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "fontStyle": "italic",
-                    "token": "text.html.basic entity.other"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "meta.tag.metadata.script.html entity.name.tag.html"
-                },
-                {
-                    "foreground": "#92FC79",
-                    "token": "punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#92FC79",
-                    "token": " punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "source.ini entity"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "source.ini keyword"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "source.ini punctuation.definition"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "token": "source.ini punctuation.separator"
-                },
-                {
-                    "foreground": "#FB94FF",
-                    "token": "source.js storage.type.function"
-                },
-                {
-                    "foreground": "#FB94FF",
-                    "token": " source.ts storage.type.function"
-                },
-                {
-                    "foreground": "#FB94FF",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#FB94FF",
-                    "token": " entity.name.type.class.js"
-                },
-                {
-                    "foreground": "#CCCCCC",
-                    "token": "entity.other.inherited-class.js"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "variable.parameter.function.language.special.self.python"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "meta.function-call.generic.python"
-                },
-                {
-                    "foreground": "#FB94FF",
-                    "token": "meta.function-call.arguments.python"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "source.json support"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "source.json string"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "source.json punctuation.definition.string"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "fontStyle": "bold",
-                    "token": "entity.name.section.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "fontStyle": "bold",
-                    "token": "markup.heading.setext.1.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "fontStyle": "bold",
-                    "token": "markup.heading.setext.2.markdown"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "meta.paragraph.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "beginning.punctuation.definition.quote.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "fontStyle": "italic",
-                    "token": "markup.quote.markdown meta.paragraph.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "meta.separator.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "fontStyle": "bold",
-                    "token": "markup.bold.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "fontStyle": "italic",
-                    "token": "markup.italic.markdown"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "beginning.punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "#A5FF90",
-                    "token": "string.other.link.description.title.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "markup.underline.link.image.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "fenced_code.block.language"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "fenced_code.block.language"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "text.jade entity.name"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "text.jade entity.other.attribute-name.tag"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "text.jade string.interpolated"
-                },
-                {
-                    "foreground": "#80FFBB",
-                    "token": "source.ts entity.name.type"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "source.ts keyword"
-                },
-                {
-                    "foreground": "#E1EFFF",
-                    "token": "source.ts punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#FFEE80",
-                    "token": "meta.arrow.ts punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "source.php entity"
-                },
-                {
-                    "foreground": "#FFC600",
-                    "token": "variable.other.php"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#9EFFFF",
-                    "token": "entity.name.variable.property.cs"
-                },
-                {
-                    "foreground": "#80FFBB",
-                    "token": "storage.modifier.cs"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "modifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "this"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.modifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.ts"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.tsx"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#FF9D00",
-                    "fontStyle": "italic",
-                    "token": "keyword.control.export"
-                },
-                {
-                    "foreground": "#FF0088",
-                    "fontStyle": "italic",
-                    "token": "meta.return.type.ts"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#122738",
+        "activityBar.border": "#0d3a58",
+        "activityBar.foreground": "#ffffff",
+        "activityBarBadge.background": "#ffc600",
+        "activityBarBadge.foreground": "#000000",
+        "badge.background": "#ffc600",
+        "badge.foreground": "#000000",
+        "button.background": "#0088ff",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#ff9d00",
+        "contrastBorder": "#ffffff00",
+        "debugConsole.errorForeground": "#ff5630",
+        "debugExceptionWidget.background": "#193549",
+        "debugExceptionWidget.border": "#aaaaaa",
+        "debugToolBar.background": "#193549",
+        "descriptionForeground": "#aaaaaa",
+        "diffEditor.insertedTextBackground": "#3ad90033",
+        "diffEditor.insertedTextBorder": "#00000000",
+        "diffEditor.removedTextBackground": "#ee3a4333",
+        "diffEditor.removedTextBorder": "#00000000",
+        "dropdown.background": "#193549",
+        "dropdown.border": "#15232d",
+        "dropdown.foreground": "#ffffff",
+        "editor.background": "#193549",
+        "editor.findMatchBackground": "#ff720066",
+        "editor.findMatchHighlightBackground": "#cad40f66",
+        "editor.findRangeHighlightBackground": "#243e51",
+        "editor.foreground": "#ffffff",
+        "editor.hoverHighlightBackground": "#ffc60033",
+        "editor.inactiveSelectionBackground": "#003b8b",
+        "editor.lineHighlightBackground": "#1f4662",
+        "editor.lineHighlightBorder": "#234e6d",
+        "editor.rangeHighlightBackground": "#1f4662",
+        "editor.selectionBackground": "#0050a4",
+        "editor.selectionHighlightBackground": "#0050a480",
+        "editor.wordHighlightBackground": "#ffffff21",
+        "editor.wordHighlightStrongBackground": "#ffffff21",
+        "editorBracketMatch.background": "#0d3a58",
+        "editorBracketMatch.border": "#ffc60080",
+        "editorCodeLens.foreground": "#aaaaaa",
+        "editorCursor.foreground": "#ffc600",
+        "editorError.border": "#0d3a58",
+        "editorError.foreground": "#a22929",
+        "editorGroup.border": "#122738",
+        "editorGroup.dropBackground": "#12273899",
+        "editorGroupHeader.noTabsBackground": "#193549",
+        "editorGroupHeader.tabsBackground": "#122738",
+        "editorGroupHeader.tabsBorder": "#15232d",
+        "editorGutter.addedBackground": "#3c9f4a",
+        "editorGutter.background": "#12273866",
+        "editorGutter.deletedBackground": "#a22929",
+        "editorGutter.modifiedBackground": "#26506d",
+        "editorHint.foreground": "#ffc600",
+        "editorHoverWidget.background": "#15232d",
+        "editorHoverWidget.border": "#0d3a58",
+        "editorIndentGuide.background": "#3b5364",
+        "editorInlayHint.background": "#0000001a",
+        "editorInlayHint.foreground": "#ff68b8",
+        "editorLineNumber.foreground": "#aaaaaa",
+        "editorLink.activeForeground": "#aaaaaa",
+        "editorMarkerNavigation.background": "#3b536433",
+        "editorMarkerNavigationError.background": "#a22929",
+        "editorMarkerNavigationWarning.background": "#ffc600",
+        "editorOverviewRuler.border": "#0d3a58",
+        "editorOverviewRuler.commonContentForeground": "#ffc60055",
+        "editorOverviewRuler.currentContentForeground": "#ee3a4355",
+        "editorOverviewRuler.incomingContentForeground": "#3ad90055",
+        "editorRuler.foreground": "#1f4662",
+        "editorSuggestWidget.background": "#15232d",
+        "editorSuggestWidget.border": "#15232d",
+        "editorSuggestWidget.foreground": "#aaaaaa",
+        "editorSuggestWidget.highlightForeground": "#ffc600",
+        "editorSuggestWidget.selectedBackground": "#193549",
+        "editorWarning.border": "#ffffff00",
+        "editorWarning.foreground": "#ffc600",
+        "editorWhitespace.foreground": "#ffffff52",
+        "editorWidget.background": "#15232d",
+        "editorWidget.border": "#0d3a58",
+        "errorForeground": "#a22929",
+        "extensionButton.prominentBackground": "#0088ff",
+        "extensionButton.prominentForeground": "#ffffff",
+        "extensionButton.prominentHoverBackground": "#ff9d00",
+        "focusBorder": "#0d3a58",
+        "foreground": "#aaaaaa",
+        "gitDecoration.conflictingResourceForeground": "#ff7200",
+        "gitDecoration.deletedResourceForeground": "#ff628c",
+        "gitDecoration.ignoredResourceForeground": "#808080",
+        "gitDecoration.modifiedResourceForeground": "#ffc600",
+        "gitDecoration.untrackedResourceForeground": "#3ad900",
+        "input.background": "#193549",
+        "input.border": "#0d3a58",
+        "input.foreground": "#ffc600",
+        "input.placeholderForeground": "#aaaaaa",
+        "inputOption.activeBorder": "#8dffff",
+        "inputValidation.errorBackground": "#193549",
+        "inputValidation.errorBorder": "#ffc600",
+        "inputValidation.infoBackground": "#193549",
+        "inputValidation.infoBorder": "#0d3a58",
+        "inputValidation.warningBackground": "#193549",
+        "inputValidation.warningBorder": "#ffc600",
+        "list.activeSelectionBackground": "#193549",
+        "list.activeSelectionForeground": "#aaaaaa",
+        "list.dropBackground": "#0d3a58",
+        "list.focusBackground": "#0d3a58",
+        "list.focusForeground": "#aaaaaa",
+        "list.highlightForeground": "#ffc600",
+        "list.hoverBackground": "#193549",
+        "list.hoverForeground": "#aaaaaa",
+        "list.inactiveSelectionBackground": "#0d3a58",
+        "list.inactiveSelectionForeground": "#aaaaaa",
+        "menu.background": "#122738",
+        "menu.selectionForeground": "#ffffff",
+        "menubar.selectionBackground": "#0d3a58",
+        "merge.border": "#ffffff00",
+        "merge.commonContentBackground": "#c97d0c",
+        "merge.commonHeaderBackground": "#c97d0c",
+        "merge.currentContentBackground": "#2f7366",
+        "merge.currentHeaderBackground": "#2f7366",
+        "merge.incomingContentBackground": "#185294",
+        "merge.incomingHeaderBackground": "#185294",
+        "notificationCenter.border": "#ffc600",
+        "notificationCenterHeader.background": "#122738",
+        "notificationCenterHeader.foreground": "#aaaaaa",
+        "notificationLink.foreground": "#ffc600",
+        "notificationToast.border": "#ffc600",
+        "notifications.background": "#122738",
+        "notifications.border": "#ffc600",
+        "notifications.foreground": "#aaaaaa",
+        "panel.background": "#122738",
+        "panel.border": "#ffc600",
+        "panelTitle.activeBorder": "#ffc600",
+        "panelTitle.activeForeground": "#ffc600",
+        "panelTitle.inactiveForeground": "#aaaaaa",
+        "peekView.border": "#ffc600",
+        "peekViewEditor.background": "#193549",
+        "peekViewEditor.matchHighlightBackground": "#19354900",
+        "peekViewEditorGutter.background": "#122738",
+        "peekViewResult.background": "#15232d",
+        "peekViewResult.fileForeground": "#aaaaaa",
+        "peekViewResult.lineForeground": "#ffffff",
+        "peekViewResult.matchHighlightBackground": "#0d3a58",
+        "peekViewResult.selectionBackground": "#0d3a58",
+        "peekViewResult.selectionForeground": "#ffffff",
+        "peekViewTitle.background": "#15232d",
+        "peekViewTitleDescription.foreground": "#aaaaaa",
+        "peekViewTitleLabel.foreground": "#ffc600",
+        "pickerGroup.border": "#0d3a58",
+        "pickerGroup.foreground": "#aaaaaa",
+        "progressBar.background": "#ffc600",
+        "scrollbar.shadow": "#00000000",
+        "scrollbarSlider.activeBackground": "#355166cc",
+        "scrollbarSlider.background": "#406179cc",
+        "scrollbarSlider.hoverBackground": "#437da3cc",
+        "selection.background": "#027dff",
+        "sideBar.background": "#15232d",
+        "sideBar.border": "#0d3a58",
+        "sideBar.foreground": "#aaaaaa",
+        "sideBarSectionHeader.background": "#193549",
+        "sideBarSectionHeader.foreground": "#aaaaaa",
+        "sideBarTitle.foreground": "#aaaaaa",
+        "statusBar.background": "#15232d",
+        "statusBar.border": "#0d3a58",
+        "statusBar.debuggingBackground": "#15232d",
+        "statusBar.debuggingBorder": "#ffc600",
+        "statusBar.debuggingForeground": "#ffc600",
+        "statusBar.foreground": "#aaaaaa",
+        "statusBar.noFolderBackground": "#15232d",
+        "statusBar.noFolderBorder": "#0d3a58",
+        "statusBar.noFolderForeground": "#aaaaaa",
+        "statusBarItem.activeBackground": "#0088ff",
+        "statusBarItem.hoverBackground": "#0d3a58",
+        "statusBarItem.prominentBackground": "#15232d",
+        "statusBarItem.prominentHoverBackground": "#0d3a58",
+        "statusBarItem.remoteBackground": "#15232d",
+        "statusBarItem.remoteForeground": "#aaaaaa",
+        "tab.activeBackground": "#193549",
+        "tab.activeBorder": "#ffc600",
+        "tab.activeForeground": "#ffffff",
+        "tab.border": "#15232d",
+        "tab.inactiveBackground": "#122738",
+        "tab.inactiveForeground": "#aaaaaa",
+        "tab.unfocusedActiveForeground": "#aaaaaa",
+        "tab.unfocusedInactiveForeground": "#aaaaaa",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0088ff",
+        "terminal.ansiBrightBlack": "#0050a4",
+        "terminal.ansiBrightBlue": "#0088ff",
+        "terminal.ansiBrightCyan": "#80fcff",
+        "terminal.ansiBrightGreen": "#3ad900",
+        "terminal.ansiBrightMagenta": "#fb94ff",
+        "terminal.ansiBrightRed": "#ff628c",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffc600",
+        "terminal.ansiCyan": "#80fcff",
+        "terminal.ansiGreen": "#3ad900",
+        "terminal.ansiMagenta": "#fb94ff",
+        "terminal.ansiRed": "#ff628c",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffc600",
+        "terminal.background": "#122738",
+        "terminal.foreground": "#ffffff",
+        "terminalCursor.background": "#122738",
+        "terminalCursor.foreground": "#ffc600",
+        "textBlockQuote.background": "#193549",
+        "textBlockQuote.border": "#0088ff",
+        "textCodeBlock.background": "#193549",
+        "textLink.activeForeground": "#0088ff",
+        "textLink.foreground": "#0088ff",
+        "textPreformat.foreground": "#ffc600",
+        "textSeparator.foreground": "#0d3a58",
+        "titleBar.activeBackground": "#15232d",
+        "titleBar.activeForeground": "#ffffff",
+        "titleBar.inactiveBackground": "#193549",
+        "titleBar.inactiveForeground": "#ffffff33",
+        "walkThrough.embeddedEditorBackground": "#0d3a58",
+        "widget.shadow": "#00000026"
+    },
+    "rules": [
+        {
+            "foreground": "#0088FF",
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "foreground": "#0088FF",
+            "fontStyle": "italic",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#FF628C",
+            "token": "constant"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "entity"
+        },
+        {
+            "foreground": "#F44542",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": "storage.type.function"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": " storage.type.class"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": " keyword.control.default.ts"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#A5FF90CC",
+            "token": "punctuation.definition.inserted"
+        },
+        {
+            "foreground": "#FF628C",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#FF628C",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#FF628CCC",
+            "token": "punctuation.definition.deleted"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "meta"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "meta.jsx.children.js"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "meta.jsx.children.tsx"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "meta.brace"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "punctuation"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "storage"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "storage.type.function.arrow"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "string"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#3AD900",
+            "token": "string.template"
+        },
+        {
+            "foreground": "#3AD900",
+            "token": "punctuation.definition.string.template"
+        },
+        {
+            "foreground": "#80FFBB",
+            "token": "support"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "variable"
+        },
+        {
+            "foreground": "#3AD900",
+            "token": "source.css entity"
+        },
+        {
+            "foreground": "#3AD900",
+            "token": "source.stylus entity"
+        },
+        {
+            "foreground": "#FFB454",
+            "token": "entity.other.attribute-name.id.css"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "source.css support"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "source.stylus support"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.css constant"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.css support.constant"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.stylus constant"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.stylus support.constant"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.css string"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.css punctuation.definition.string"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.stylus string"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.stylus punctuation.definition.string"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "source.css variable"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "source.stylus variable"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "text.html.basic entity.name"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "meta.toc-list.id.html"
+        },
+        {
+            "foreground": "#FFC600",
+            "fontStyle": "italic",
+            "token": "text.html.basic entity.other"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "meta.tag.metadata.script.html entity.name.tag.html"
+        },
+        {
+            "foreground": "#92FC79",
+            "token": "punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#92FC79",
+            "token": " punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "source.ini entity"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "source.ini keyword"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "source.ini punctuation.definition"
+        },
+        {
+            "foreground": "#FF9D00",
+            "token": "source.ini punctuation.separator"
+        },
+        {
+            "foreground": "#FB94FF",
+            "token": "source.js storage.type.function"
+        },
+        {
+            "foreground": "#FB94FF",
+            "token": " source.ts storage.type.function"
+        },
+        {
+            "foreground": "#FB94FF",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#FB94FF",
+            "token": " entity.name.type.class.js"
+        },
+        {
+            "foreground": "#CCCCCC",
+            "token": "entity.other.inherited-class.js"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "variable.parameter.function.language.special.self.python"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "meta.function-call.generic.python"
+        },
+        {
+            "foreground": "#FB94FF",
+            "token": "meta.function-call.arguments.python"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "source.json support"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "source.json string"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "source.json punctuation.definition.string"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "fontStyle": "bold",
+            "token": "entity.name.section.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "fontStyle": "bold",
+            "token": "markup.heading.setext.1.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "fontStyle": "bold",
+            "token": "markup.heading.setext.2.markdown"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "meta.paragraph.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "beginning.punctuation.definition.quote.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "fontStyle": "italic",
+            "token": "markup.quote.markdown meta.paragraph.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "meta.separator.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "fontStyle": "bold",
+            "token": "markup.bold.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "fontStyle": "italic",
+            "token": "markup.italic.markdown"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "beginning.punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "foreground": "#A5FF90",
+            "token": "string.other.link.description.title.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "markup.underline.link.image.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "fenced_code.block.language"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "fenced_code.block.language"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "text.jade entity.name"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "text.jade entity.other.attribute-name.tag"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "text.jade string.interpolated"
+        },
+        {
+            "foreground": "#80FFBB",
+            "token": "source.ts entity.name.type"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "source.ts keyword"
+        },
+        {
+            "foreground": "#E1EFFF",
+            "token": "source.ts punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#FFEE80",
+            "token": "meta.arrow.ts punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "source.php entity"
+        },
+        {
+            "foreground": "#FFC600",
+            "token": "variable.other.php"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#9EFFFF",
+            "token": "entity.name.variable.property.cs"
+        },
+        {
+            "foreground": "#80FFBB",
+            "token": "storage.modifier.cs"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "modifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "this"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.modifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.ts"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.tsx"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#FF9D00",
+            "fontStyle": "italic",
+            "token": "keyword.control.export"
+        },
+        {
+            "foreground": "#FF0088",
+            "fontStyle": "italic",
+            "token": "meta.return.type.ts"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/dark/dark-monaco.json
+++ b/themes/dark/dark-monaco.json
@@ -1,835 +1,831 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "actionBar.toggledBackground": "#383a49",
-                "activityBar.activeBorder": "#0078d4",
-                "activityBar.background": "#181818",
-                "activityBar.border": "#2b2b2b",
-                "activityBar.foreground": "#d7d7d7",
-                "activityBar.inactiveForeground": "#868686",
-                "activityBarBadge.background": "#0078d4",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#616161",
-                "badge.foreground": "#f8f8f8",
-                "button.background": "#0078d4",
-                "button.border": "#ffffff12",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#026ec1",
-                "button.secondaryBackground": "#313131",
-                "button.secondaryForeground": "#cccccc",
-                "button.secondaryHoverBackground": "#3c3c3c",
-                "chat.slashCommandBackground": "#34414b",
-                "chat.slashCommandForeground": "#40a6ff",
-                "checkbox.background": "#313131",
-                "checkbox.border": "#3c3c3c",
-                "debugToolBar.background": "#181818",
-                "descriptionForeground": "#9d9d9d",
-                "dropdown.background": "#313131",
-                "dropdown.border": "#3c3c3c",
-                "dropdown.foreground": "#cccccc",
-                "dropdown.listBackground": "#1f1f1f",
-                "editor.background": "#1f1f1f",
-                "editor.findMatchBackground": "#9e6a03",
-                "editor.foreground": "#cccccc",
-                "editor.inactiveSelectionBackground": "#3a3d41",
-                "editor.selectionHighlightBackground": "#add6ff26",
-                "editorGroup.border": "#ffffff17",
-                "editorGroupHeader.tabsBackground": "#181818",
-                "editorGroupHeader.tabsBorder": "#2b2b2b",
-                "editorGutter.addedBackground": "#2ea043",
-                "editorGutter.deletedBackground": "#f85149",
-                "editorGutter.modifiedBackground": "#0078d4",
-                "editorIndentGuide.activeBackground": "#707070",
-                "editorIndentGuide.background": "#404040",
-                "editorLineNumber.activeForeground": "#cccccc",
-                "editorLineNumber.foreground": "#6e7681",
-                "editorOverviewRuler.border": "#010409",
-                "editorWidget.background": "#202020",
-                "errorForeground": "#f85149",
-                "focusBorder": "#0078d4",
-                "foreground": "#cccccc",
-                "icon.foreground": "#cccccc",
-                "input.background": "#313131",
-                "input.border": "#3c3c3c",
-                "input.foreground": "#cccccc",
-                "input.placeholderForeground": "#9d9d9d",
-                "inputOption.activeBackground": "#2489db82",
-                "inputOption.activeBorder": "#2488db",
-                "keybindingLabel.foreground": "#cccccc",
-                "list.activeSelectionIconForeground": "#ffffff",
-                "list.dropBackground": "#383b3d",
-                "menu.background": "#1f1f1f",
-                "menu.border": "#454545",
-                "menu.foreground": "#cccccc",
-                "menu.separatorBackground": "#454545",
-                "notificationCenterHeader.background": "#1f1f1f",
-                "notificationCenterHeader.foreground": "#cccccc",
-                "notifications.background": "#1f1f1f",
-                "notifications.border": "#2b2b2b",
-                "notifications.foreground": "#cccccc",
-                "panel.background": "#181818",
-                "panel.border": "#2b2b2b",
-                "panelInput.border": "#2b2b2b",
-                "panelTitle.activeBorder": "#0078d4",
-                "panelTitle.activeForeground": "#cccccc",
-                "panelTitle.inactiveForeground": "#9d9d9d",
-                "peekViewEditor.background": "#1f1f1f",
-                "peekViewEditor.matchHighlightBackground": "#bb800966",
-                "peekViewResult.background": "#1f1f1f",
-                "peekViewResult.matchHighlightBackground": "#bb800966",
-                "pickerGroup.border": "#3c3c3c",
-                "ports.iconRunningProcessForeground": "#369432",
-                "progressBar.background": "#0078d4",
-                "quickInput.background": "#222222",
-                "quickInput.foreground": "#cccccc",
-                "settings.dropdownBackground": "#313131",
-                "settings.dropdownBorder": "#3c3c3c",
-                "settings.headerForeground": "#ffffff",
-                "settings.modifiedItemIndicator": "#bb800966",
-                "sideBar.background": "#181818",
-                "sideBar.border": "#2b2b2b",
-                "sideBar.foreground": "#cccccc",
-                "sideBarSectionHeader.background": "#181818",
-                "sideBarSectionHeader.border": "#2b2b2b",
-                "sideBarSectionHeader.foreground": "#cccccc",
-                "sideBarTitle.foreground": "#cccccc",
-                "statusBar.background": "#181818",
-                "statusBar.border": "#2b2b2b",
-                "statusBar.debuggingBackground": "#0078d4",
-                "statusBar.debuggingForeground": "#ffffff",
-                "statusBar.focusBorder": "#0078d4",
-                "statusBar.foreground": "#cccccc",
-                "statusBar.noFolderBackground": "#1f1f1f",
-                "statusBarItem.focusBorder": "#0078d4",
-                "statusBarItem.prominentBackground": "#6e768166",
-                "statusBarItem.remoteBackground": "#0078d4",
-                "statusBarItem.remoteForeground": "#ffffff",
-                "tab.activeBackground": "#1f1f1f",
-                "tab.activeBorder": "#1f1f1f",
-                "tab.activeBorderTop": "#0078d4",
-                "tab.activeForeground": "#ffffff",
-                "tab.border": "#2b2b2b",
-                "tab.hoverBackground": "#1f1f1f",
-                "tab.inactiveBackground": "#181818",
-                "tab.inactiveForeground": "#9d9d9d",
-                "tab.lastPinnedBorder": "#cccccc33",
-                "tab.unfocusedActiveBorder": "#1f1f1f",
-                "tab.unfocusedActiveBorderTop": "#2b2b2b",
-                "tab.unfocusedHoverBackground": "#1f1f1f",
-                "terminal.foreground": "#cccccc",
-                "terminal.inactiveSelectionBackground": "#3a3d41",
-                "terminal.tab.activeBorder": "#0078d4",
-                "textBlockQuote.background": "#2b2b2b",
-                "textBlockQuote.border": "#616161",
-                "textCodeBlock.background": "#2b2b2b",
-                "textLink.activeForeground": "#40a6ff",
-                "textLink.foreground": "#40a6ff",
-                "textSeparator.foreground": "#21262d",
-                "titleBar.activeBackground": "#181818",
-                "titleBar.activeForeground": "#cccccc",
-                "titleBar.border": "#2b2b2b",
-                "titleBar.inactiveBackground": "#1f1f1f",
-                "titleBar.inactiveForeground": "#9d9d9d",
-                "welcomePage.progress.foreground": "#0078d4",
-                "welcomePage.tileBackground": "#2b2b2b",
-                "widget.border": "#313131"
-            },
-            "rules": [
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "string meta.image.inline.markdown"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "variable.legacy.builtin.python"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "emphasis"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "strong"
-                },
-                {
-                    "foreground": "#000080",
-                    "token": "header"
-                },
-                {
-                    "foreground": "#6A9955",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.operator.plus.exponent"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.operator.minus.exponent"
-                },
-                {
-                    "foreground": "#646695",
-                    "token": "constant.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.name.tag.css"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.class.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.class.mixin.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.id.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.parent-selector.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.pseudo-class.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.pseudo-element.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "source.css.less entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.scss"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "invalid"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#6A9955",
-                    "token": "punctuation.definition.quote.begin.markdown"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#808080",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "entity.name.function.preprocessor"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "meta.preprocessor.string"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "meta.preprocessor.numeric"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.structure.dictionary.key.python"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.noexcept"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "meta.embedded.assembly"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string.tag"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string.value"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.definition.template-expression.begin"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.definition.template-expression.end"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.type.vendored.property-name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.css"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.scss"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.other.less"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "source.coffee.embedded"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.expression"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.cast"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.sizeof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.alignof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.typeid"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.alignas"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.instanceof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.logical.python"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.wordlike"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.function.git-rebase"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "constant.sha.git-rebase"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "storage.modifier.import.java"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "variable.language.wildcard.java"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "storage.modifier.package.java"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "source.powershell variable.other.member"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "entity.name.operator.custom-literal"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.other.attribute"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.numeric.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.byte.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.boolean.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.string.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.uintptr.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.error.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.rune.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.modifier.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.variable.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.annotation.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.object.array.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.array.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.token.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.annotation.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.parameters.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.object.array.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.array.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "meta.type.cast.expr"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "meta.type.new.expr"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.dom"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "source.cpp keyword.operator.new"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.operator.delete"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.other.using"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.other.directive.using"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.other.operator"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "entity.name.operator"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.definition.variable.name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "entity.name.variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "foreground": "#4FC1FF",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#4FC1FF",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.media-type"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.media"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "constant.other.color.rgb-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "constant.other.rgb-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.color"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.group.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.group.assertion.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.character.set.begin.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.character.set.end.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "keyword.operator.negation.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.other.parenthesis.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.character.character-class.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.character.set.regexp"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "keyword.operator.or.regexp"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "keyword.control.anchor.regexp"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.other.option"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#C8C8C8",
-                    "token": "entity.name.label"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "actionBar.toggledBackground": "#383a49",
+        "activityBar.activeBorder": "#0078d4",
+        "activityBar.background": "#181818",
+        "activityBar.border": "#2b2b2b",
+        "activityBar.foreground": "#d7d7d7",
+        "activityBar.inactiveForeground": "#868686",
+        "activityBarBadge.background": "#0078d4",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#616161",
+        "badge.foreground": "#f8f8f8",
+        "button.background": "#0078d4",
+        "button.border": "#ffffff12",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#026ec1",
+        "button.secondaryBackground": "#313131",
+        "button.secondaryForeground": "#cccccc",
+        "button.secondaryHoverBackground": "#3c3c3c",
+        "chat.slashCommandBackground": "#34414b",
+        "chat.slashCommandForeground": "#40a6ff",
+        "checkbox.background": "#313131",
+        "checkbox.border": "#3c3c3c",
+        "debugToolBar.background": "#181818",
+        "descriptionForeground": "#9d9d9d",
+        "dropdown.background": "#313131",
+        "dropdown.border": "#3c3c3c",
+        "dropdown.foreground": "#cccccc",
+        "dropdown.listBackground": "#1f1f1f",
+        "editor.background": "#1f1f1f",
+        "editor.findMatchBackground": "#9e6a03",
+        "editor.foreground": "#cccccc",
+        "editor.inactiveSelectionBackground": "#3a3d41",
+        "editor.selectionHighlightBackground": "#add6ff26",
+        "editorGroup.border": "#ffffff17",
+        "editorGroupHeader.tabsBackground": "#181818",
+        "editorGroupHeader.tabsBorder": "#2b2b2b",
+        "editorGutter.addedBackground": "#2ea043",
+        "editorGutter.deletedBackground": "#f85149",
+        "editorGutter.modifiedBackground": "#0078d4",
+        "editorIndentGuide.activeBackground": "#707070",
+        "editorIndentGuide.background": "#404040",
+        "editorLineNumber.activeForeground": "#cccccc",
+        "editorLineNumber.foreground": "#6e7681",
+        "editorOverviewRuler.border": "#010409",
+        "editorWidget.background": "#202020",
+        "errorForeground": "#f85149",
+        "focusBorder": "#0078d4",
+        "foreground": "#cccccc",
+        "icon.foreground": "#cccccc",
+        "input.background": "#313131",
+        "input.border": "#3c3c3c",
+        "input.foreground": "#cccccc",
+        "input.placeholderForeground": "#9d9d9d",
+        "inputOption.activeBackground": "#2489db82",
+        "inputOption.activeBorder": "#2488db",
+        "keybindingLabel.foreground": "#cccccc",
+        "list.activeSelectionIconForeground": "#ffffff",
+        "list.dropBackground": "#383b3d",
+        "menu.background": "#1f1f1f",
+        "menu.border": "#454545",
+        "menu.foreground": "#cccccc",
+        "menu.separatorBackground": "#454545",
+        "notificationCenterHeader.background": "#1f1f1f",
+        "notificationCenterHeader.foreground": "#cccccc",
+        "notifications.background": "#1f1f1f",
+        "notifications.border": "#2b2b2b",
+        "notifications.foreground": "#cccccc",
+        "panel.background": "#181818",
+        "panel.border": "#2b2b2b",
+        "panelInput.border": "#2b2b2b",
+        "panelTitle.activeBorder": "#0078d4",
+        "panelTitle.activeForeground": "#cccccc",
+        "panelTitle.inactiveForeground": "#9d9d9d",
+        "peekViewEditor.background": "#1f1f1f",
+        "peekViewEditor.matchHighlightBackground": "#bb800966",
+        "peekViewResult.background": "#1f1f1f",
+        "peekViewResult.matchHighlightBackground": "#bb800966",
+        "pickerGroup.border": "#3c3c3c",
+        "ports.iconRunningProcessForeground": "#369432",
+        "progressBar.background": "#0078d4",
+        "quickInput.background": "#222222",
+        "quickInput.foreground": "#cccccc",
+        "settings.dropdownBackground": "#313131",
+        "settings.dropdownBorder": "#3c3c3c",
+        "settings.headerForeground": "#ffffff",
+        "settings.modifiedItemIndicator": "#bb800966",
+        "sideBar.background": "#181818",
+        "sideBar.border": "#2b2b2b",
+        "sideBar.foreground": "#cccccc",
+        "sideBarSectionHeader.background": "#181818",
+        "sideBarSectionHeader.border": "#2b2b2b",
+        "sideBarSectionHeader.foreground": "#cccccc",
+        "sideBarTitle.foreground": "#cccccc",
+        "statusBar.background": "#181818",
+        "statusBar.border": "#2b2b2b",
+        "statusBar.debuggingBackground": "#0078d4",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.focusBorder": "#0078d4",
+        "statusBar.foreground": "#cccccc",
+        "statusBar.noFolderBackground": "#1f1f1f",
+        "statusBarItem.focusBorder": "#0078d4",
+        "statusBarItem.prominentBackground": "#6e768166",
+        "statusBarItem.remoteBackground": "#0078d4",
+        "statusBarItem.remoteForeground": "#ffffff",
+        "tab.activeBackground": "#1f1f1f",
+        "tab.activeBorder": "#1f1f1f",
+        "tab.activeBorderTop": "#0078d4",
+        "tab.activeForeground": "#ffffff",
+        "tab.border": "#2b2b2b",
+        "tab.hoverBackground": "#1f1f1f",
+        "tab.inactiveBackground": "#181818",
+        "tab.inactiveForeground": "#9d9d9d",
+        "tab.lastPinnedBorder": "#cccccc33",
+        "tab.unfocusedActiveBorder": "#1f1f1f",
+        "tab.unfocusedActiveBorderTop": "#2b2b2b",
+        "tab.unfocusedHoverBackground": "#1f1f1f",
+        "terminal.foreground": "#cccccc",
+        "terminal.inactiveSelectionBackground": "#3a3d41",
+        "terminal.tab.activeBorder": "#0078d4",
+        "textBlockQuote.background": "#2b2b2b",
+        "textBlockQuote.border": "#616161",
+        "textCodeBlock.background": "#2b2b2b",
+        "textLink.activeForeground": "#40a6ff",
+        "textLink.foreground": "#40a6ff",
+        "textSeparator.foreground": "#21262d",
+        "titleBar.activeBackground": "#181818",
+        "titleBar.activeForeground": "#cccccc",
+        "titleBar.border": "#2b2b2b",
+        "titleBar.inactiveBackground": "#1f1f1f",
+        "titleBar.inactiveForeground": "#9d9d9d",
+        "welcomePage.progress.foreground": "#0078d4",
+        "welcomePage.tileBackground": "#2b2b2b",
+        "widget.border": "#313131"
+    },
+    "rules": [
+        {
+            "foreground": "#D4D4D4",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "string meta.image.inline.markdown"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "variable.legacy.builtin.python"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "emphasis"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "strong"
+        },
+        {
+            "foreground": "#000080",
+            "token": "header"
+        },
+        {
+            "foreground": "#6A9955",
+            "token": "comment"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.operator.plus.exponent"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.operator.minus.exponent"
+        },
+        {
+            "foreground": "#646695",
+            "token": "constant.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.name.tag.css"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.class.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.class.mixin.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.id.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.parent-selector.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.pseudo-class.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.pseudo-element.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "source.css.less entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.scss"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "invalid"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#569CD6",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#569CD6",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#6A9955",
+            "token": "punctuation.definition.quote.begin.markdown"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#808080",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "entity.name.function.preprocessor"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "meta.preprocessor.string"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "meta.preprocessor.numeric"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.structure.dictionary.key.python"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.noexcept"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "meta.embedded.assembly"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string.tag"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string.value"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.definition.template-expression.begin"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.definition.template-expression.end"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.type.vendored.property-name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.css"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.scss"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.other.less"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "source.coffee.embedded"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.expression"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.cast"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.sizeof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.alignof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.typeid"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.alignas"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.instanceof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.logical.python"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.wordlike"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.function.git-rebase"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "constant.sha.git-rebase"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "storage.modifier.import.java"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "variable.language.wildcard.java"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "storage.modifier.package.java"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "source.powershell variable.other.member"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "entity.name.operator.custom-literal"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.other.attribute"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.numeric.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.byte.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.boolean.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.string.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.uintptr.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.error.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.rune.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.modifier.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.variable.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.annotation.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.object.array.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.array.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.token.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.annotation.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.parameters.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.object.array.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.array.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "meta.type.cast.expr"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "meta.type.new.expr"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.dom"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "source.cpp keyword.operator.new"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.operator.delete"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.other.using"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.other.directive.using"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.other.operator"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "entity.name.operator"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.definition.variable.name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "entity.name.variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "foreground": "#4FC1FF",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#4FC1FF",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.media-type"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.media"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "constant.other.color.rgb-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "constant.other.rgb-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.color"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.group.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.group.assertion.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.character.set.begin.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.character.set.end.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "keyword.operator.negation.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.other.parenthesis.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.character.character-class.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.character.set.regexp"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "keyword.operator.or.regexp"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "keyword.control.anchor.regexp"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.other.option"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#C8C8C8",
+            "token": "entity.name.label"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/dracula/dracula-monaco.json
+++ b/themes/dracula/dracula-monaco.json
@@ -1,1239 +1,1235 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.activeBackground": "#bd93f910",
-                "activityBar.activeBorder": "#ff79c680",
-                "activityBar.background": "#343746",
-                "activityBar.foreground": "#f8f8f2",
-                "activityBar.inactiveForeground": "#6272a4",
-                "activityBarBadge.background": "#ff79c6",
-                "activityBarBadge.foreground": "#f8f8f2",
-                "badge.background": "#44475a",
-                "badge.foreground": "#f8f8f2",
-                "breadcrumb.activeSelectionForeground": "#f8f8f2",
-                "breadcrumb.background": "#282a36",
-                "breadcrumb.focusForeground": "#f8f8f2",
-                "breadcrumb.foreground": "#6272a4",
-                "breadcrumbPicker.background": "#191a21",
-                "button.background": "#44475a",
-                "button.foreground": "#f8f8f2",
-                "button.secondaryBackground": "#282a36",
-                "button.secondaryForeground": "#f8f8f2",
-                "button.secondaryHoverBackground": "#343746",
-                "debugToolBar.background": "#21222c",
-                "diffEditor.insertedTextBackground": "#50fa7b20",
-                "diffEditor.removedTextBackground": "#ff555550",
-                "dropdown.background": "#343746",
-                "dropdown.border": "#191a21",
-                "dropdown.foreground": "#f8f8f2",
-                "editor.background": "#282a36",
-                "editor.findMatchBackground": "#ffb86c80",
-                "editor.findMatchHighlightBackground": "#ffffff40",
-                "editor.findRangeHighlightBackground": "#44475a75",
-                "editor.foldBackground": "#21222c80",
-                "editor.foreground": "#f8f8f2",
-                "editor.hoverHighlightBackground": "#8be9fd50",
-                "editor.lineHighlightBorder": "#44475a",
-                "editor.rangeHighlightBackground": "#bd93f915",
-                "editor.selectionBackground": "#44475a",
-                "editor.selectionHighlightBackground": "#424450",
-                "editor.snippetFinalTabstopHighlightBackground": "#282a36",
-                "editor.snippetFinalTabstopHighlightBorder": "#50fa7b",
-                "editor.snippetTabstopHighlightBackground": "#282a36",
-                "editor.snippetTabstopHighlightBorder": "#6272a4",
-                "editor.wordHighlightBackground": "#8be9fd50",
-                "editor.wordHighlightStrongBackground": "#50fa7b50",
-                "editorBracketHighlight.foreground1": "#f8f8f2",
-                "editorBracketHighlight.foreground2": "#ff79c6",
-                "editorBracketHighlight.foreground3": "#8be9fd",
-                "editorBracketHighlight.foreground4": "#50fa7b",
-                "editorBracketHighlight.foreground5": "#bd93f9",
-                "editorBracketHighlight.foreground6": "#ffb86c",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#ff5555",
-                "editorCodeLens.foreground": "#6272a4",
-                "editorError.foreground": "#ff5555",
-                "editorGroup.border": "#bd93f9",
-                "editorGroup.dropBackground": "#44475a70",
-                "editorGroupHeader.tabsBackground": "#191a21",
-                "editorGutter.addedBackground": "#50fa7b80",
-                "editorGutter.deletedBackground": "#ff555580",
-                "editorGutter.modifiedBackground": "#8be9fd80",
-                "editorHoverWidget.background": "#282a36",
-                "editorHoverWidget.border": "#6272a4",
-                "editorIndentGuide.activeBackground": "#ffffff45",
-                "editorIndentGuide.background": "#ffffff1a",
-                "editorLineNumber.foreground": "#6272a4",
-                "editorLink.activeForeground": "#8be9fd",
-                "editorMarkerNavigation.background": "#21222c",
-                "editorOverviewRuler.addedForeground": "#50fa7b80",
-                "editorOverviewRuler.border": "#191a21",
-                "editorOverviewRuler.currentContentForeground": "#50fa7b",
-                "editorOverviewRuler.deletedForeground": "#ff555580",
-                "editorOverviewRuler.errorForeground": "#ff555580",
-                "editorOverviewRuler.incomingContentForeground": "#bd93f9",
-                "editorOverviewRuler.infoForeground": "#8be9fd80",
-                "editorOverviewRuler.modifiedForeground": "#8be9fd80",
-                "editorOverviewRuler.selectionHighlightForeground": "#ffb86c",
-                "editorOverviewRuler.warningForeground": "#ffb86c80",
-                "editorOverviewRuler.wordHighlightForeground": "#8be9fd",
-                "editorOverviewRuler.wordHighlightStrongForeground": "#50fa7b",
-                "editorRuler.foreground": "#ffffff1a",
-                "editorSuggestWidget.background": "#21222c",
-                "editorSuggestWidget.foreground": "#f8f8f2",
-                "editorSuggestWidget.selectedBackground": "#44475a",
-                "editorWarning.foreground": "#8be9fd",
-                "editorWhitespace.foreground": "#ffffff1a",
-                "editorWidget.background": "#21222c",
-                "errorForeground": "#ff5555",
-                "extensionButton.prominentBackground": "#50fa7b90",
-                "extensionButton.prominentForeground": "#f8f8f2",
-                "extensionButton.prominentHoverBackground": "#50fa7b60",
-                "focusBorder": "#6272a4",
-                "foreground": "#f8f8f2",
-                "gitDecoration.conflictingResourceForeground": "#ffb86c",
-                "gitDecoration.deletedResourceForeground": "#ff5555",
-                "gitDecoration.ignoredResourceForeground": "#6272a4",
-                "gitDecoration.modifiedResourceForeground": "#8be9fd",
-                "gitDecoration.untrackedResourceForeground": "#50fa7b",
-                "inlineChat.regionHighlight": "#343746",
-                "input.background": "#282a36",
-                "input.border": "#191a21",
-                "input.foreground": "#f8f8f2",
-                "input.placeholderForeground": "#6272a4",
-                "inputOption.activeBorder": "#bd93f9",
-                "inputValidation.errorBorder": "#ff5555",
-                "inputValidation.infoBorder": "#ff79c6",
-                "inputValidation.warningBorder": "#ffb86c",
-                "list.activeSelectionBackground": "#44475a",
-                "list.activeSelectionForeground": "#f8f8f2",
-                "list.dropBackground": "#44475a",
-                "list.errorForeground": "#ff5555",
-                "list.focusBackground": "#44475a75",
-                "list.highlightForeground": "#8be9fd",
-                "list.hoverBackground": "#44475a75",
-                "list.inactiveSelectionBackground": "#44475a75",
-                "list.warningForeground": "#ffb86c",
-                "listFilterWidget.background": "#343746",
-                "listFilterWidget.noMatchesOutline": "#ff5555",
-                "listFilterWidget.outline": "#424450",
-                "merge.currentHeaderBackground": "#50fa7b90",
-                "merge.incomingHeaderBackground": "#bd93f990",
-                "panel.background": "#282a36",
-                "panel.border": "#bd93f9",
-                "panelTitle.activeBorder": "#ff79c6",
-                "panelTitle.activeForeground": "#f8f8f2",
-                "panelTitle.inactiveForeground": "#6272a4",
-                "peekView.border": "#44475a",
-                "peekViewEditor.background": "#282a36",
-                "peekViewEditor.matchHighlightBackground": "#f1fa8c80",
-                "peekViewResult.background": "#21222c",
-                "peekViewResult.fileForeground": "#f8f8f2",
-                "peekViewResult.lineForeground": "#f8f8f2",
-                "peekViewResult.matchHighlightBackground": "#f1fa8c80",
-                "peekViewResult.selectionBackground": "#44475a",
-                "peekViewResult.selectionForeground": "#f8f8f2",
-                "peekViewTitle.background": "#191a21",
-                "peekViewTitleDescription.foreground": "#6272a4",
-                "peekViewTitleLabel.foreground": "#f8f8f2",
-                "pickerGroup.border": "#bd93f9",
-                "pickerGroup.foreground": "#8be9fd",
-                "progressBar.background": "#ff79c6",
-                "selection.background": "#bd93f9",
-                "settings.checkboxBackground": "#21222c",
-                "settings.checkboxBorder": "#191a21",
-                "settings.checkboxForeground": "#f8f8f2",
-                "settings.dropdownBackground": "#21222c",
-                "settings.dropdownBorder": "#191a21",
-                "settings.dropdownForeground": "#f8f8f2",
-                "settings.headerForeground": "#f8f8f2",
-                "settings.modifiedItemIndicator": "#ffb86c",
-                "settings.numberInputBackground": "#21222c",
-                "settings.numberInputBorder": "#191a21",
-                "settings.numberInputForeground": "#f8f8f2",
-                "settings.textInputBackground": "#21222c",
-                "settings.textInputBorder": "#191a21",
-                "settings.textInputForeground": "#f8f8f2",
-                "sideBar.background": "#21222c",
-                "sideBarSectionHeader.background": "#282a36",
-                "sideBarSectionHeader.border": "#191a21",
-                "sideBarTitle.foreground": "#f8f8f2",
-                "statusBar.background": "#191a21",
-                "statusBar.debuggingBackground": "#ff5555",
-                "statusBar.debuggingForeground": "#191a21",
-                "statusBar.foreground": "#f8f8f2",
-                "statusBar.noFolderBackground": "#191a21",
-                "statusBar.noFolderForeground": "#f8f8f2",
-                "statusBarItem.prominentBackground": "#ff5555",
-                "statusBarItem.prominentHoverBackground": "#ffb86c",
-                "statusBarItem.remoteBackground": "#bd93f9",
-                "statusBarItem.remoteForeground": "#282a36",
-                "tab.activeBackground": "#282a36",
-                "tab.activeBorderTop": "#ff79c680",
-                "tab.activeForeground": "#f8f8f2",
-                "tab.border": "#191a21",
-                "tab.inactiveBackground": "#21222c",
-                "tab.inactiveForeground": "#6272a4",
-                "terminal.ansiBlack": "#21222c",
-                "terminal.ansiBlue": "#bd93f9",
-                "terminal.ansiBrightBlack": "#6272a4",
-                "terminal.ansiBrightBlue": "#d6acff",
-                "terminal.ansiBrightCyan": "#a4ffff",
-                "terminal.ansiBrightGreen": "#69ff94",
-                "terminal.ansiBrightMagenta": "#ff92df",
-                "terminal.ansiBrightRed": "#ff6e6e",
-                "terminal.ansiBrightWhite": "#ffffff",
-                "terminal.ansiBrightYellow": "#ffffa5",
-                "terminal.ansiCyan": "#8be9fd",
-                "terminal.ansiGreen": "#50fa7b",
-                "terminal.ansiMagenta": "#ff79c6",
-                "terminal.ansiRed": "#ff5555",
-                "terminal.ansiWhite": "#f8f8f2",
-                "terminal.ansiYellow": "#f1fa8c",
-                "terminal.background": "#282a36",
-                "terminal.foreground": "#f8f8f2",
-                "titleBar.activeBackground": "#21222c",
-                "titleBar.activeForeground": "#f8f8f2",
-                "titleBar.inactiveBackground": "#191a21",
-                "titleBar.inactiveForeground": "#6272a4",
-                "walkThrough.embeddedEditorBackground": "#21222c"
-            },
-            "rules": [
-                {
-                    "fontStyle": "italic",
-                    "token": "emphasis"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "strong"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "header"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "fontStyle": "underline italic",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "fontStyle": "underline italic",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "entity.name.filename"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "markup.error"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "beginning.punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "beginning.punctuation.definition.quote.markdown"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "punctuation.definition.link.restructuredtext"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "markup.raw.restructuredtext"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "markup.underline.link"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "markup.underline.link.image"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.link.reference.def.restructuredtext"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.directive.restructuredtext"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "string.other.link.description"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "string.other.link.title"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "fontStyle": "italic",
-                    "token": "entity.name.directive.restructuredtext"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "fontStyle": "italic",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "meta.separator.markdown"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "fenced_code.block.language"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "markup.raw.inner.restructuredtext"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "markup.fenced_code.block.markdown punctuation.definition.markdown"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "punctuation.definition.constant.restructuredtext"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "markup.heading.markdown punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "markup.heading.markdown punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.paragraph.markdown punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.paragraph.markdown punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "normal",
-                    "token": "entity.name.type.class"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "normal",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "keyword.expressions-and-types.swift"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "keyword.other.this"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "variable.language punctuation.definition.variable.php"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "variable.other.readwrite.instance.ruby"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "italic",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "unused.comment"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "wildcard.comment"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "comment keyword.codetag.notation"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "comment.block.documentation keyword"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "comment.block.documentation storage.type.class"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation entity.name.type"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "comment.block.documentation entity.name.type punctuation.definition.bracket"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation variable"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "constant.character.string.escape"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "constant.regexp"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "entity.other.attribute-name.parent-selector"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.function-call.object"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.function-call.php"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.function-call.static"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.method-call.java meta.method"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.method.groovy"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "support.function.any-method.lua"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "keyword.operator.function.infix"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "entity.name.variable.parameter"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.at-rule.function variable"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.at-rule.mixin variable"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.function.arguments variable.other.php"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "fontStyle": "italic",
-                    "token": "meta.decorator variable.other.readwrite"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "fontStyle": "italic",
-                    "token": "meta.decorator variable.other.property"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.decorator variable.other.object"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.keyword"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.control.new"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.selector"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "regular",
-                    "token": "support.function.magic"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "regular",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "regular",
-                    "token": "variable.other.predefined"
-                },
-                {
-                    "fontStyle": "regular",
-                    "token": "support.function"
-                },
-                {
-                    "fontStyle": "regular",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "constant.other.symbol.hashkey punctuation.definition.constant.ruby"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "entity.other.attribute-name.placeholder punctuation"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "entity.other.attribute-name.pseudo-class punctuation"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "entity.other.attribute-name.pseudo-element punctuation"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.group.double.toml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.group.toml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.object-binding-pattern-variable punctuation.destructuring"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.colon.graphql"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.block.scalar.folded.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.block.scalar.literal.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.block.sequence.item.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.function.swift"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.dictionary.key-value"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.hash"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.inheritance"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.key-value.mapping.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.namespace"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.pointer-access"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.slice"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "string.unquoted.heredoc punctuation.definition.string"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "support.other.chomping-indicator.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.separator.annotation"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "keyword.operator.other.powershell"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "keyword.other.statement-separator.powershell"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.brace.round"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.function-call punctuation"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.arguments.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.arguments.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.entity.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.entity.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.tag.cs"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.type.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.type.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.scope.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.scope.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.terminator.expression.php"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "storage.type.generic.java"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "string.template meta.brace"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "string.template punctuation.accessor"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "meta.string-contents.quoted.double punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.interpolation.begin"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.interpolation.end"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.template-expression.begin"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.template-expression.end"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.section.embedded.begin"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.section.embedded.coffee"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.section.embedded.end"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.section.embedded.end source.php"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.section.embedded.end source.ruby"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.variable.makefile"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "entity.name.function.target.makefile"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "entity.name.section.toml"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "entity.name.tag.yaml"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "variable.other.key.toml"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "constant.other.date"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "constant.other.timestamp"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "fontStyle": "italic underline",
-                    "token": "variable.other.alias.yaml"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "fontStyle": "regular",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "fontStyle": "regular",
-                    "token": "meta.implementation storage.type.objc"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "fontStyle": "regular",
-                    "token": "meta.interface-or-protocol storage.type.objc"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "fontStyle": "regular",
-                    "token": "source.groovy storage.type.def"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "keyword.primitive-datatypes.swift"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "keyword.type.cs"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "meta.protocol-list.objc"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "meta.return-type.objc"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "source.go storage.type"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "source.groovy storage.type"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "source.java storage.type"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "source.powershell entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.class.std.rust"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.attribute.swift"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.c"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.core.rust"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.groovy"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.objc"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.haskell"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "fontStyle": "italic",
-                    "token": "storage.type.ocaml"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "entity.name.type.type-parameter"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "meta.indexer.mappedtype.declaration entity.name.type"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "meta.type.parameters entity.name.type"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "constant.character.escape.backslash.regexp"
-                },
-                {
-                    "foreground": "#FF79C6",
-                    "token": "punctuation.definition.group.capture.regexp"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "string.regexp punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "string.regexp punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "token": "punctuation.definition.group.regexp"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "punctuation.definition.group.assertion.regexp"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "token": "keyword.operator.negation.regexp"
-                },
-                {
-                    "foreground": "#50FA7B",
-                    "token": "meta.assertion.look-ahead.regexp"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#E9F284",
-                    "token": "punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#E9F284",
-                    "token": "punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#8BE9FE",
-                    "token": "punctuation.support.type.property-name.begin"
-                },
-                {
-                    "foreground": "#8BE9FE",
-                    "token": "punctuation.support.type.property-name.end"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "string.quoted.docstring.multi"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "string.quoted.docstring.multi.python punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "string.quoted.docstring.multi.python punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "string.quoted.docstring.multi.python constant.character.escape"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "constant.other.key.perl"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "variable.other.constant.js"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "variable.other.constant.ts"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "variable.other.constant.tsx"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.import variable.other.readwrite"
-                },
-                {
-                    "foreground": "#FFB86C",
-                    "fontStyle": "italic",
-                    "token": "meta.variable.assignment.destructured.object.coffee variable"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "fontStyle": "normal",
-                    "token": "meta.import variable.other.readwrite.alias"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "fontStyle": "normal",
-                    "token": "meta.export variable.other.readwrite.alias"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "fontStyle": "normal",
-                    "token": "meta.variable.assignment.destructured.object.coffee variable variable"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "meta.selectionset.graphql variable"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.selectionset.graphql meta.arguments variable"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "entity.name.fragment.graphql"
-                },
-                {
-                    "foreground": "#8BE9FD",
-                    "token": "variable.fragment.graphql"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "constant.other.symbol.hashkey.ruby"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "keyword.operator.dereference.java"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "keyword.operator.navigation.groovy"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.scope.for-loop.shell punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.scope.for-loop.shell punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.scope.for-loop.shell string"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.embedded.begin.tsx"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.embedded.end.tsx"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.embedded.begin.jsx"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.section.embedded.end.jsx"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.separator.list.comma.css"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "constant.language.empty-list.haskell"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "token": "source.shell variable.other"
-                },
-                {
-                    "foreground": "#BD93F9",
-                    "fontStyle": "normal",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "meta.scope.prerequisites.makefile"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "token": "meta.attribute-selector.scss"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.attribute-selector.end.bracket.square.scss"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "punctuation.definition.attribute-selector.begin.bracket.square.scss"
-                },
-                {
-                    "foreground": "#6272A4",
-                    "token": "meta.preprocessor.haskell"
-                },
-                {
-                    "foreground": "#FF5555",
-                    "fontStyle": "bold",
-                    "token": "log.error"
-                },
-                {
-                    "foreground": "#F1FA8C",
-                    "fontStyle": "bold",
-                    "token": "log.warning"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.activeBackground": "#bd93f910",
+        "activityBar.activeBorder": "#ff79c680",
+        "activityBar.background": "#343746",
+        "activityBar.foreground": "#f8f8f2",
+        "activityBar.inactiveForeground": "#6272a4",
+        "activityBarBadge.background": "#ff79c6",
+        "activityBarBadge.foreground": "#f8f8f2",
+        "badge.background": "#44475a",
+        "badge.foreground": "#f8f8f2",
+        "breadcrumb.activeSelectionForeground": "#f8f8f2",
+        "breadcrumb.background": "#282a36",
+        "breadcrumb.focusForeground": "#f8f8f2",
+        "breadcrumb.foreground": "#6272a4",
+        "breadcrumbPicker.background": "#191a21",
+        "button.background": "#44475a",
+        "button.foreground": "#f8f8f2",
+        "button.secondaryBackground": "#282a36",
+        "button.secondaryForeground": "#f8f8f2",
+        "button.secondaryHoverBackground": "#343746",
+        "debugToolBar.background": "#21222c",
+        "diffEditor.insertedTextBackground": "#50fa7b20",
+        "diffEditor.removedTextBackground": "#ff555550",
+        "dropdown.background": "#343746",
+        "dropdown.border": "#191a21",
+        "dropdown.foreground": "#f8f8f2",
+        "editor.background": "#282a36",
+        "editor.findMatchBackground": "#ffb86c80",
+        "editor.findMatchHighlightBackground": "#ffffff40",
+        "editor.findRangeHighlightBackground": "#44475a75",
+        "editor.foldBackground": "#21222c80",
+        "editor.foreground": "#f8f8f2",
+        "editor.hoverHighlightBackground": "#8be9fd50",
+        "editor.lineHighlightBorder": "#44475a",
+        "editor.rangeHighlightBackground": "#bd93f915",
+        "editor.selectionBackground": "#44475a",
+        "editor.selectionHighlightBackground": "#424450",
+        "editor.snippetFinalTabstopHighlightBackground": "#282a36",
+        "editor.snippetFinalTabstopHighlightBorder": "#50fa7b",
+        "editor.snippetTabstopHighlightBackground": "#282a36",
+        "editor.snippetTabstopHighlightBorder": "#6272a4",
+        "editor.wordHighlightBackground": "#8be9fd50",
+        "editor.wordHighlightStrongBackground": "#50fa7b50",
+        "editorBracketHighlight.foreground1": "#f8f8f2",
+        "editorBracketHighlight.foreground2": "#ff79c6",
+        "editorBracketHighlight.foreground3": "#8be9fd",
+        "editorBracketHighlight.foreground4": "#50fa7b",
+        "editorBracketHighlight.foreground5": "#bd93f9",
+        "editorBracketHighlight.foreground6": "#ffb86c",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#ff5555",
+        "editorCodeLens.foreground": "#6272a4",
+        "editorError.foreground": "#ff5555",
+        "editorGroup.border": "#bd93f9",
+        "editorGroup.dropBackground": "#44475a70",
+        "editorGroupHeader.tabsBackground": "#191a21",
+        "editorGutter.addedBackground": "#50fa7b80",
+        "editorGutter.deletedBackground": "#ff555580",
+        "editorGutter.modifiedBackground": "#8be9fd80",
+        "editorHoverWidget.background": "#282a36",
+        "editorHoverWidget.border": "#6272a4",
+        "editorIndentGuide.activeBackground": "#ffffff45",
+        "editorIndentGuide.background": "#ffffff1a",
+        "editorLineNumber.foreground": "#6272a4",
+        "editorLink.activeForeground": "#8be9fd",
+        "editorMarkerNavigation.background": "#21222c",
+        "editorOverviewRuler.addedForeground": "#50fa7b80",
+        "editorOverviewRuler.border": "#191a21",
+        "editorOverviewRuler.currentContentForeground": "#50fa7b",
+        "editorOverviewRuler.deletedForeground": "#ff555580",
+        "editorOverviewRuler.errorForeground": "#ff555580",
+        "editorOverviewRuler.incomingContentForeground": "#bd93f9",
+        "editorOverviewRuler.infoForeground": "#8be9fd80",
+        "editorOverviewRuler.modifiedForeground": "#8be9fd80",
+        "editorOverviewRuler.selectionHighlightForeground": "#ffb86c",
+        "editorOverviewRuler.warningForeground": "#ffb86c80",
+        "editorOverviewRuler.wordHighlightForeground": "#8be9fd",
+        "editorOverviewRuler.wordHighlightStrongForeground": "#50fa7b",
+        "editorRuler.foreground": "#ffffff1a",
+        "editorSuggestWidget.background": "#21222c",
+        "editorSuggestWidget.foreground": "#f8f8f2",
+        "editorSuggestWidget.selectedBackground": "#44475a",
+        "editorWarning.foreground": "#8be9fd",
+        "editorWhitespace.foreground": "#ffffff1a",
+        "editorWidget.background": "#21222c",
+        "errorForeground": "#ff5555",
+        "extensionButton.prominentBackground": "#50fa7b90",
+        "extensionButton.prominentForeground": "#f8f8f2",
+        "extensionButton.prominentHoverBackground": "#50fa7b60",
+        "focusBorder": "#6272a4",
+        "foreground": "#f8f8f2",
+        "gitDecoration.conflictingResourceForeground": "#ffb86c",
+        "gitDecoration.deletedResourceForeground": "#ff5555",
+        "gitDecoration.ignoredResourceForeground": "#6272a4",
+        "gitDecoration.modifiedResourceForeground": "#8be9fd",
+        "gitDecoration.untrackedResourceForeground": "#50fa7b",
+        "inlineChat.regionHighlight": "#343746",
+        "input.background": "#282a36",
+        "input.border": "#191a21",
+        "input.foreground": "#f8f8f2",
+        "input.placeholderForeground": "#6272a4",
+        "inputOption.activeBorder": "#bd93f9",
+        "inputValidation.errorBorder": "#ff5555",
+        "inputValidation.infoBorder": "#ff79c6",
+        "inputValidation.warningBorder": "#ffb86c",
+        "list.activeSelectionBackground": "#44475a",
+        "list.activeSelectionForeground": "#f8f8f2",
+        "list.dropBackground": "#44475a",
+        "list.errorForeground": "#ff5555",
+        "list.focusBackground": "#44475a75",
+        "list.highlightForeground": "#8be9fd",
+        "list.hoverBackground": "#44475a75",
+        "list.inactiveSelectionBackground": "#44475a75",
+        "list.warningForeground": "#ffb86c",
+        "listFilterWidget.background": "#343746",
+        "listFilterWidget.noMatchesOutline": "#ff5555",
+        "listFilterWidget.outline": "#424450",
+        "merge.currentHeaderBackground": "#50fa7b90",
+        "merge.incomingHeaderBackground": "#bd93f990",
+        "panel.background": "#282a36",
+        "panel.border": "#bd93f9",
+        "panelTitle.activeBorder": "#ff79c6",
+        "panelTitle.activeForeground": "#f8f8f2",
+        "panelTitle.inactiveForeground": "#6272a4",
+        "peekView.border": "#44475a",
+        "peekViewEditor.background": "#282a36",
+        "peekViewEditor.matchHighlightBackground": "#f1fa8c80",
+        "peekViewResult.background": "#21222c",
+        "peekViewResult.fileForeground": "#f8f8f2",
+        "peekViewResult.lineForeground": "#f8f8f2",
+        "peekViewResult.matchHighlightBackground": "#f1fa8c80",
+        "peekViewResult.selectionBackground": "#44475a",
+        "peekViewResult.selectionForeground": "#f8f8f2",
+        "peekViewTitle.background": "#191a21",
+        "peekViewTitleDescription.foreground": "#6272a4",
+        "peekViewTitleLabel.foreground": "#f8f8f2",
+        "pickerGroup.border": "#bd93f9",
+        "pickerGroup.foreground": "#8be9fd",
+        "progressBar.background": "#ff79c6",
+        "selection.background": "#bd93f9",
+        "settings.checkboxBackground": "#21222c",
+        "settings.checkboxBorder": "#191a21",
+        "settings.checkboxForeground": "#f8f8f2",
+        "settings.dropdownBackground": "#21222c",
+        "settings.dropdownBorder": "#191a21",
+        "settings.dropdownForeground": "#f8f8f2",
+        "settings.headerForeground": "#f8f8f2",
+        "settings.modifiedItemIndicator": "#ffb86c",
+        "settings.numberInputBackground": "#21222c",
+        "settings.numberInputBorder": "#191a21",
+        "settings.numberInputForeground": "#f8f8f2",
+        "settings.textInputBackground": "#21222c",
+        "settings.textInputBorder": "#191a21",
+        "settings.textInputForeground": "#f8f8f2",
+        "sideBar.background": "#21222c",
+        "sideBarSectionHeader.background": "#282a36",
+        "sideBarSectionHeader.border": "#191a21",
+        "sideBarTitle.foreground": "#f8f8f2",
+        "statusBar.background": "#191a21",
+        "statusBar.debuggingBackground": "#ff5555",
+        "statusBar.debuggingForeground": "#191a21",
+        "statusBar.foreground": "#f8f8f2",
+        "statusBar.noFolderBackground": "#191a21",
+        "statusBar.noFolderForeground": "#f8f8f2",
+        "statusBarItem.prominentBackground": "#ff5555",
+        "statusBarItem.prominentHoverBackground": "#ffb86c",
+        "statusBarItem.remoteBackground": "#bd93f9",
+        "statusBarItem.remoteForeground": "#282a36",
+        "tab.activeBackground": "#282a36",
+        "tab.activeBorderTop": "#ff79c680",
+        "tab.activeForeground": "#f8f8f2",
+        "tab.border": "#191a21",
+        "tab.inactiveBackground": "#21222c",
+        "tab.inactiveForeground": "#6272a4",
+        "terminal.ansiBlack": "#21222c",
+        "terminal.ansiBlue": "#bd93f9",
+        "terminal.ansiBrightBlack": "#6272a4",
+        "terminal.ansiBrightBlue": "#d6acff",
+        "terminal.ansiBrightCyan": "#a4ffff",
+        "terminal.ansiBrightGreen": "#69ff94",
+        "terminal.ansiBrightMagenta": "#ff92df",
+        "terminal.ansiBrightRed": "#ff6e6e",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffffa5",
+        "terminal.ansiCyan": "#8be9fd",
+        "terminal.ansiGreen": "#50fa7b",
+        "terminal.ansiMagenta": "#ff79c6",
+        "terminal.ansiRed": "#ff5555",
+        "terminal.ansiWhite": "#f8f8f2",
+        "terminal.ansiYellow": "#f1fa8c",
+        "terminal.background": "#282a36",
+        "terminal.foreground": "#f8f8f2",
+        "titleBar.activeBackground": "#21222c",
+        "titleBar.activeForeground": "#f8f8f2",
+        "titleBar.inactiveBackground": "#191a21",
+        "titleBar.inactiveForeground": "#6272a4",
+        "walkThrough.embeddedEditorBackground": "#21222c"
+    },
+    "rules": [
+        {
+            "fontStyle": "italic",
+            "token": "emphasis"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "strong"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "header"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#FF5555",
+            "fontStyle": "underline italic",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "fontStyle": "underline italic",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "entity.name.filename"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "markup.error"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "beginning.punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "beginning.punctuation.definition.quote.markdown"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "punctuation.definition.link.restructuredtext"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "markup.raw.restructuredtext"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "markup.underline.link"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "markup.underline.link.image"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.link.reference.def.restructuredtext"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.directive.restructuredtext"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "string.other.link.description"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "string.other.link.title"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "fontStyle": "italic",
+            "token": "entity.name.directive.restructuredtext"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "fontStyle": "italic",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "meta.separator.markdown"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "fenced_code.block.language"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "markup.raw.inner.restructuredtext"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "markup.fenced_code.block.markdown punctuation.definition.markdown"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "punctuation.definition.constant.restructuredtext"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "markup.heading.markdown punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "markup.heading.markdown punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.paragraph.markdown punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.paragraph.markdown punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "markup.quote.markdown meta.paragraph.markdown punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "normal",
+            "token": "entity.name.type.class"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "normal",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "keyword.expressions-and-types.swift"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "keyword.other.this"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "variable.language punctuation.definition.variable.php"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "variable.other.readwrite.instance.ruby"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "italic",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "comment"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "unused.comment"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "wildcard.comment"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "comment keyword.codetag.notation"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "comment.block.documentation keyword"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "comment.block.documentation storage.type.class"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "comment.block.documentation entity.name.type"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "comment.block.documentation entity.name.type punctuation.definition.bracket"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "comment.block.documentation variable"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "constant"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "constant.character.string.escape"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "constant.regexp"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "entity.other.attribute-name.parent-selector"
+        },
+        {
+            "foreground": "#50FA7B",
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.function-call.object"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.function-call.php"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.function-call.static"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.method-call.java meta.method"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.method.groovy"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "support.function.any-method.lua"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "keyword.operator.function.infix"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "entity.name.variable.parameter"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.at-rule.function variable"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.at-rule.mixin variable"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.function.arguments variable.other.php"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#50FA7B",
+            "fontStyle": "italic",
+            "token": "meta.decorator variable.other.readwrite"
+        },
+        {
+            "foreground": "#50FA7B",
+            "fontStyle": "italic",
+            "token": "meta.decorator variable.other.property"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.decorator variable.other.object"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.keyword"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.control.new"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.selector"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "support"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "regular",
+            "token": "support.function.magic"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "regular",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "regular",
+            "token": "variable.other.predefined"
+        },
+        {
+            "fontStyle": "regular",
+            "token": "support.function"
+        },
+        {
+            "fontStyle": "regular",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "constant.other.symbol.hashkey punctuation.definition.constant.ruby"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "entity.other.attribute-name.placeholder punctuation"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "entity.other.attribute-name.pseudo-class punctuation"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "entity.other.attribute-name.pseudo-element punctuation"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.group.double.toml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.group.toml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.object-binding-pattern-variable punctuation.destructuring"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.colon.graphql"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.block.scalar.folded.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.block.scalar.literal.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.block.sequence.item.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.entity.other.inherited-class"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.function.swift"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.dictionary.key-value"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.hash"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.inheritance"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.key-value.mapping.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.namespace"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.pointer-access"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.slice"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "string.unquoted.heredoc punctuation.definition.string"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "support.other.chomping-indicator.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.separator.annotation"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "keyword.operator.other.powershell"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "keyword.other.statement-separator.powershell"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.brace.round"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.function-call punctuation"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.arguments.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.arguments.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.entity.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.entity.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.tag.cs"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.type.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.type.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.scope.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.scope.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.terminator.expression.php"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "storage.type.generic.java"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "string.template meta.brace"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "string.template punctuation.accessor"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "meta.string-contents.quoted.double punctuation.definition.variable"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.interpolation.begin"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.interpolation.end"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.template-expression.begin"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.template-expression.end"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.section.embedded.begin"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.section.embedded.coffee"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.section.embedded.end"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.section.embedded.end source.php"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.section.embedded.end source.ruby"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.variable.makefile"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "entity.name.function.target.makefile"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "entity.name.section.toml"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "entity.name.tag.yaml"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "variable.other.key.toml"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "constant.other.date"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "constant.other.timestamp"
+        },
+        {
+            "foreground": "#50FA7B",
+            "fontStyle": "italic underline",
+            "token": "variable.other.alias.yaml"
+        },
+        {
+            "foreground": "#FF79C6",
+            "fontStyle": "regular",
+            "token": "storage"
+        },
+        {
+            "foreground": "#FF79C6",
+            "fontStyle": "regular",
+            "token": "meta.implementation storage.type.objc"
+        },
+        {
+            "foreground": "#FF79C6",
+            "fontStyle": "regular",
+            "token": "meta.interface-or-protocol storage.type.objc"
+        },
+        {
+            "foreground": "#FF79C6",
+            "fontStyle": "regular",
+            "token": "source.groovy storage.type.def"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "keyword.primitive-datatypes.swift"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "keyword.type.cs"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "meta.protocol-list.objc"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "meta.return-type.objc"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "source.go storage.type"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "source.groovy storage.type"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "source.java storage.type"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "source.powershell entity.other.attribute-name"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.class.std.rust"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.attribute.swift"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.c"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.core.rust"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.groovy"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.objc"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.haskell"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "fontStyle": "italic",
+            "token": "storage.type.ocaml"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "entity.name.type.type-parameter"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "meta.indexer.mappedtype.declaration entity.name.type"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "meta.type.parameters entity.name.type"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "constant.character.escape.backslash.regexp"
+        },
+        {
+            "foreground": "#FF79C6",
+            "token": "punctuation.definition.group.capture.regexp"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "string.regexp punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "string.regexp punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#FFB86C",
+            "token": "punctuation.definition.group.regexp"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "punctuation.definition.group.assertion.regexp"
+        },
+        {
+            "foreground": "#FF5555",
+            "token": "keyword.operator.negation.regexp"
+        },
+        {
+            "foreground": "#50FA7B",
+            "token": "meta.assertion.look-ahead.regexp"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "string"
+        },
+        {
+            "foreground": "#E9F284",
+            "token": "punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#E9F284",
+            "token": "punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#8BE9FE",
+            "token": "punctuation.support.type.property-name.begin"
+        },
+        {
+            "foreground": "#8BE9FE",
+            "token": "punctuation.support.type.property-name.end"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "string.quoted.docstring.multi"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "string.quoted.docstring.multi.python punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "string.quoted.docstring.multi.python punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "string.quoted.docstring.multi.python constant.character.escape"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "variable"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "constant.other.key.perl"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "variable.other.constant.js"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "variable.other.constant.ts"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "variable.other.constant.tsx"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.import variable.other.readwrite"
+        },
+        {
+            "foreground": "#FFB86C",
+            "fontStyle": "italic",
+            "token": "meta.variable.assignment.destructured.object.coffee variable"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "fontStyle": "normal",
+            "token": "meta.import variable.other.readwrite.alias"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "fontStyle": "normal",
+            "token": "meta.export variable.other.readwrite.alias"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "fontStyle": "normal",
+            "token": "meta.variable.assignment.destructured.object.coffee variable variable"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "meta.selectionset.graphql variable"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.selectionset.graphql meta.arguments variable"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "entity.name.fragment.graphql"
+        },
+        {
+            "foreground": "#8BE9FD",
+            "token": "variable.fragment.graphql"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "constant.other.symbol.hashkey.ruby"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "keyword.operator.dereference.java"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "keyword.operator.navigation.groovy"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.scope.for-loop.shell punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.scope.for-loop.shell punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.scope.for-loop.shell string"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "storage.modifier.import"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.embedded.begin.tsx"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.embedded.end.tsx"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.embedded.begin.jsx"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.section.embedded.end.jsx"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.separator.list.comma.css"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "constant.language.empty-list.haskell"
+        },
+        {
+            "foreground": "#BD93F9",
+            "token": "source.shell variable.other"
+        },
+        {
+            "foreground": "#BD93F9",
+            "fontStyle": "normal",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "meta.scope.prerequisites.makefile"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "token": "meta.attribute-selector.scss"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.attribute-selector.end.bracket.square.scss"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "punctuation.definition.attribute-selector.begin.bracket.square.scss"
+        },
+        {
+            "foreground": "#6272A4",
+            "token": "meta.preprocessor.haskell"
+        },
+        {
+            "foreground": "#FF5555",
+            "fontStyle": "bold",
+            "token": "log.error"
+        },
+        {
+            "foreground": "#F1FA8C",
+            "fontStyle": "bold",
+            "token": "log.warning"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/espresso-libre/espresso-libre-monaco.json
+++ b/themes/espresso-libre/espresso-libre-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "espresso-libre"
-    }
-}
+"espresso-libre"

--- a/themes/github-dark-default/github-dark-default-monaco.json
+++ b/themes/github-dark-default/github-dark-default-monaco.json
@@ -1,635 +1,631 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.activeBorder": "#f78166",
-                "activityBar.background": "#0d1117",
-                "activityBar.border": "#30363d",
-                "activityBar.foreground": "#e6edf3",
-                "activityBar.inactiveForeground": "#7d8590",
-                "activityBarBadge.background": "#1f6feb",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#1f6feb",
-                "badge.foreground": "#ffffff",
-                "breadcrumb.activeSelectionForeground": "#7d8590",
-                "breadcrumb.focusForeground": "#e6edf3",
-                "breadcrumb.foreground": "#7d8590",
-                "breadcrumbPicker.background": "#161b22",
-                "button.background": "#238636",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#2ea043",
-                "button.secondaryBackground": "#282e33",
-                "button.secondaryForeground": "#c9d1d9",
-                "button.secondaryHoverBackground": "#30363d",
-                "checkbox.background": "#161b22",
-                "checkbox.border": "#30363d",
-                "debugConsole.errorForeground": "#ffa198",
-                "debugConsole.infoForeground": "#8b949e",
-                "debugConsole.sourceForeground": "#e3b341",
-                "debugConsole.warningForeground": "#d29922",
-                "debugConsoleInputIcon.foreground": "#bc8cff",
-                "debugIcon.breakpointForeground": "#f85149",
-                "debugTokenExpression.boolean": "#56d364",
-                "debugTokenExpression.error": "#ffa198",
-                "debugTokenExpression.name": "#79c0ff",
-                "debugTokenExpression.number": "#56d364",
-                "debugTokenExpression.string": "#a5d6ff",
-                "debugTokenExpression.value": "#a5d6ff",
-                "debugToolBar.background": "#161b22",
-                "descriptionForeground": "#7d8590",
-                "diffEditor.insertedLineBackground": "#23863626",
-                "diffEditor.insertedTextBackground": "#3fb9504d",
-                "diffEditor.removedLineBackground": "#da363326",
-                "diffEditor.removedTextBackground": "#ff7b724d",
-                "dropdown.background": "#161b22",
-                "dropdown.border": "#30363d",
-                "dropdown.foreground": "#e6edf3",
-                "dropdown.listBackground": "#161b22",
-                "editor.background": "#0d1117",
-                "editor.findMatchBackground": "#9e6a03",
-                "editor.findMatchHighlightBackground": "#f2cc6080",
-                "editor.focusedStackFrameHighlightBackground": "#2ea04366",
-                "editor.foldBackground": "#6e76811a",
-                "editor.foreground": "#e6edf3",
-                "editor.lineHighlightBackground": "#6e76811a",
-                "editor.linkedEditingBackground": "#2f81f712",
-                "editor.selectionHighlightBackground": "#3fb95040",
-                "editor.stackFrameHighlightBackground": "#bb800966",
-                "editor.wordHighlightBackground": "#6e768180",
-                "editor.wordHighlightBorder": "#6e768199",
-                "editor.wordHighlightStrongBackground": "#6e76814d",
-                "editor.wordHighlightStrongBorder": "#6e768199",
-                "editorBracketHighlight.foreground1": "#79c0ff",
-                "editorBracketHighlight.foreground2": "#56d364",
-                "editorBracketHighlight.foreground3": "#e3b341",
-                "editorBracketHighlight.foreground4": "#ffa198",
-                "editorBracketHighlight.foreground5": "#ff9bce",
-                "editorBracketHighlight.foreground6": "#d2a8ff",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#7d8590",
-                "editorBracketMatch.background": "#3fb95040",
-                "editorBracketMatch.border": "#3fb95099",
-                "editorCursor.foreground": "#2f81f7",
-                "editorGroup.border": "#30363d",
-                "editorGroupHeader.tabsBackground": "#010409",
-                "editorGroupHeader.tabsBorder": "#30363d",
-                "editorGutter.addedBackground": "#2ea04366",
-                "editorGutter.deletedBackground": "#f8514966",
-                "editorGutter.modifiedBackground": "#bb800966",
-                "editorIndentGuide.activeBackground": "#e6edf33d",
-                "editorIndentGuide.background": "#e6edf31f",
-                "editorInlayHint.background": "#8b949e33",
-                "editorInlayHint.foreground": "#7d8590",
-                "editorInlayHint.typeBackground": "#8b949e33",
-                "editorInlayHint.typeForeground": "#7d8590",
-                "editorLineNumber.activeForeground": "#e6edf3",
-                "editorLineNumber.foreground": "#6e7681",
-                "editorOverviewRuler.border": "#010409",
-                "editorWhitespace.foreground": "#484f58",
-                "editorWidget.background": "#161b22",
-                "errorForeground": "#f85149",
-                "focusBorder": "#1f6feb",
-                "foreground": "#e6edf3",
-                "gitDecoration.addedResourceForeground": "#3fb950",
-                "gitDecoration.conflictingResourceForeground": "#db6d28",
-                "gitDecoration.deletedResourceForeground": "#f85149",
-                "gitDecoration.ignoredResourceForeground": "#6e7681",
-                "gitDecoration.modifiedResourceForeground": "#d29922",
-                "gitDecoration.submoduleResourceForeground": "#7d8590",
-                "gitDecoration.untrackedResourceForeground": "#3fb950",
-                "icon.foreground": "#7d8590",
-                "input.background": "#0d1117",
-                "input.border": "#30363d",
-                "input.foreground": "#e6edf3",
-                "input.placeholderForeground": "#6e7681",
-                "keybindingLabel.foreground": "#e6edf3",
-                "list.activeSelectionBackground": "#6e768166",
-                "list.activeSelectionForeground": "#e6edf3",
-                "list.focusBackground": "#388bfd26",
-                "list.focusForeground": "#e6edf3",
-                "list.highlightForeground": "#2f81f7",
-                "list.hoverBackground": "#6e76811a",
-                "list.hoverForeground": "#e6edf3",
-                "list.inactiveFocusBackground": "#388bfd26",
-                "list.inactiveSelectionBackground": "#6e768166",
-                "list.inactiveSelectionForeground": "#e6edf3",
-                "minimapSlider.activeBackground": "#8b949e47",
-                "minimapSlider.background": "#8b949e33",
-                "minimapSlider.hoverBackground": "#8b949e3d",
-                "notificationCenterHeader.background": "#161b22",
-                "notificationCenterHeader.foreground": "#7d8590",
-                "notifications.background": "#161b22",
-                "notifications.border": "#30363d",
-                "notifications.foreground": "#e6edf3",
-                "notificationsErrorIcon.foreground": "#f85149",
-                "notificationsInfoIcon.foreground": "#2f81f7",
-                "notificationsWarningIcon.foreground": "#d29922",
-                "panel.background": "#010409",
-                "panel.border": "#30363d",
-                "panelInput.border": "#30363d",
-                "panelTitle.activeBorder": "#f78166",
-                "panelTitle.activeForeground": "#e6edf3",
-                "panelTitle.inactiveForeground": "#7d8590",
-                "peekViewEditor.background": "#6e76811a",
-                "peekViewEditor.matchHighlightBackground": "#bb800966",
-                "peekViewResult.background": "#0d1117",
-                "peekViewResult.matchHighlightBackground": "#bb800966",
-                "pickerGroup.border": "#30363d",
-                "pickerGroup.foreground": "#7d8590",
-                "progressBar.background": "#1f6feb",
-                "quickInput.background": "#161b22",
-                "quickInput.foreground": "#e6edf3",
-                "scrollbar.shadow": "#484f5833",
-                "scrollbarSlider.activeBackground": "#8b949e47",
-                "scrollbarSlider.background": "#8b949e33",
-                "scrollbarSlider.hoverBackground": "#8b949e3d",
-                "settings.headerForeground": "#e6edf3",
-                "settings.modifiedItemIndicator": "#bb800966",
-                "sideBar.background": "#010409",
-                "sideBar.border": "#30363d",
-                "sideBar.foreground": "#e6edf3",
-                "sideBarSectionHeader.background": "#010409",
-                "sideBarSectionHeader.border": "#30363d",
-                "sideBarSectionHeader.foreground": "#e6edf3",
-                "sideBarTitle.foreground": "#e6edf3",
-                "statusBar.background": "#0d1117",
-                "statusBar.border": "#30363d",
-                "statusBar.debuggingBackground": "#da3633",
-                "statusBar.debuggingForeground": "#ffffff",
-                "statusBar.focusBorder": "#1f6feb80",
-                "statusBar.foreground": "#7d8590",
-                "statusBar.noFolderBackground": "#0d1117",
-                "statusBarItem.activeBackground": "#e6edf31f",
-                "statusBarItem.focusBorder": "#1f6feb",
-                "statusBarItem.hoverBackground": "#e6edf314",
-                "statusBarItem.prominentBackground": "#6e768166",
-                "statusBarItem.remoteBackground": "#30363d",
-                "statusBarItem.remoteForeground": "#e6edf3",
-                "symbolIcon.arrayForeground": "#f0883e",
-                "symbolIcon.booleanForeground": "#58a6ff",
-                "symbolIcon.classForeground": "#f0883e",
-                "symbolIcon.colorForeground": "#79c0ff",
-                "symbolIcon.constructorForeground": "#d2a8ff",
-                "symbolIcon.enumeratorForeground": "#f0883e",
-                "symbolIcon.enumeratorMemberForeground": "#58a6ff",
-                "symbolIcon.eventForeground": "#6e7681",
-                "symbolIcon.fieldForeground": "#f0883e",
-                "symbolIcon.fileForeground": "#d29922",
-                "symbolIcon.folderForeground": "#d29922",
-                "symbolIcon.functionForeground": "#bc8cff",
-                "symbolIcon.interfaceForeground": "#f0883e",
-                "symbolIcon.keyForeground": "#58a6ff",
-                "symbolIcon.keywordForeground": "#ff7b72",
-                "symbolIcon.methodForeground": "#bc8cff",
-                "symbolIcon.moduleForeground": "#ff7b72",
-                "symbolIcon.namespaceForeground": "#ff7b72",
-                "symbolIcon.nullForeground": "#58a6ff",
-                "symbolIcon.numberForeground": "#3fb950",
-                "symbolIcon.objectForeground": "#f0883e",
-                "symbolIcon.operatorForeground": "#79c0ff",
-                "symbolIcon.packageForeground": "#f0883e",
-                "symbolIcon.propertyForeground": "#f0883e",
-                "symbolIcon.referenceForeground": "#58a6ff",
-                "symbolIcon.snippetForeground": "#58a6ff",
-                "symbolIcon.stringForeground": "#79c0ff",
-                "symbolIcon.structForeground": "#f0883e",
-                "symbolIcon.textForeground": "#79c0ff",
-                "symbolIcon.typeParameterForeground": "#79c0ff",
-                "symbolIcon.unitForeground": "#58a6ff",
-                "symbolIcon.variableForeground": "#f0883e",
-                "tab.activeBackground": "#0d1117",
-                "tab.activeBorder": "#0d1117",
-                "tab.activeBorderTop": "#f78166",
-                "tab.activeForeground": "#e6edf3",
-                "tab.border": "#30363d",
-                "tab.hoverBackground": "#0d1117",
-                "tab.inactiveBackground": "#010409",
-                "tab.inactiveForeground": "#7d8590",
-                "tab.unfocusedActiveBorder": "#0d1117",
-                "tab.unfocusedActiveBorderTop": "#30363d",
-                "tab.unfocusedHoverBackground": "#6e76811a",
-                "terminal.ansiBlack": "#484f58",
-                "terminal.ansiBlue": "#58a6ff",
-                "terminal.ansiBrightBlack": "#6e7681",
-                "terminal.ansiBrightBlue": "#79c0ff",
-                "terminal.ansiBrightCyan": "#56d4dd",
-                "terminal.ansiBrightGreen": "#56d364",
-                "terminal.ansiBrightMagenta": "#d2a8ff",
-                "terminal.ansiBrightRed": "#ffa198",
-                "terminal.ansiBrightWhite": "#ffffff",
-                "terminal.ansiBrightYellow": "#e3b341",
-                "terminal.ansiCyan": "#39c5cf",
-                "terminal.ansiGreen": "#3fb950",
-                "terminal.ansiMagenta": "#bc8cff",
-                "terminal.ansiRed": "#ff7b72",
-                "terminal.ansiWhite": "#b1bac4",
-                "terminal.ansiYellow": "#d29922",
-                "terminal.foreground": "#e6edf3",
-                "textBlockQuote.background": "#010409",
-                "textBlockQuote.border": "#30363d",
-                "textCodeBlock.background": "#6e768166",
-                "textLink.activeForeground": "#2f81f7",
-                "textLink.foreground": "#2f81f7",
-                "textPreformat.foreground": "#7d8590",
-                "textSeparator.foreground": "#21262d",
-                "titleBar.activeBackground": "#0d1117",
-                "titleBar.activeForeground": "#7d8590",
-                "titleBar.border": "#30363d",
-                "titleBar.inactiveBackground": "#010409",
-                "titleBar.inactiveForeground": "#7d8590",
-                "tree.indentGuidesStroke": "#21262d"
-            },
-            "rules": [
-                {
-                    "foreground": "#8B949E",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "string.comment"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "entity.name.constant"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "entity"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "token": "meta.export.default"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "token": "meta.definition.variable"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "variable.parameter.function"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "meta.block"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "meta.tag.attributes"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "entity.name.constant"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "meta.object.member"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "meta.embedded.expression"
-                },
-                {
-                    "foreground": "#D2A8FF",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "token": "support.class.component"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "storage.modifier.package"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string punctuation.section.embedded source"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "meta.property-name"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "fontStyle": "italic",
-                    "token": "invalid.broken"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "fontStyle": "italic",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "fontStyle": "italic",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "fontStyle": "italic",
-                    "token": "invalid.unimplemented"
-                },
-                {
-                    "foreground": "#F0F6FC",
-                    "background": "#FF7B72",
-                    "fontStyle": "italic underline",
-                    "token": "carriage-return"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "token": "message.error"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "string variable"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "source.regexp"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.regexp.character-class"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.regexp source.ruby.embedded"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.regexp string.regexp.arbitrary-repitition"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "fontStyle": "bold",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "token": "support.type.property-name.json"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "meta.module-reference"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading entity.name"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#E6EDF3",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "background": "#490202",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "background": "#490202",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "background": "#490202",
-                    "token": "punctuation.definition.deleted"
-                },
-                {
-                    "foreground": "#FF7B72",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "background": "#04260F",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "background": "#04260F",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#7EE787",
-                    "background": "#04260F",
-                    "token": "punctuation.definition.inserted"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "background": "#5A1E02",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#FFA657",
-                    "background": "#5A1E02",
-                    "token": "punctuation.definition.changed"
-                },
-                {
-                    "foreground": "#161B22",
-                    "background": "#79C0FF",
-                    "token": "markup.ignored"
-                },
-                {
-                    "foreground": "#161B22",
-                    "background": "#79C0FF",
-                    "token": "markup.untracked"
-                },
-                {
-                    "foreground": "#D2A8FF",
-                    "fontStyle": "bold",
-                    "token": "meta.diff.range"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#79C0FF",
-                    "token": "meta.output"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.tag"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.curly"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.round"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.square"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.angle"
-                },
-                {
-                    "foreground": "#8B949E",
-                    "token": "brackethighlighter.quote"
-                },
-                {
-                    "foreground": "#FFA198",
-                    "token": "brackethighlighter.unmatched"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "constant.other.reference.link"
-                },
-                {
-                    "foreground": "#A5D6FF",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.activeBorder": "#f78166",
+        "activityBar.background": "#0d1117",
+        "activityBar.border": "#30363d",
+        "activityBar.foreground": "#e6edf3",
+        "activityBar.inactiveForeground": "#7d8590",
+        "activityBarBadge.background": "#1f6feb",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#1f6feb",
+        "badge.foreground": "#ffffff",
+        "breadcrumb.activeSelectionForeground": "#7d8590",
+        "breadcrumb.focusForeground": "#e6edf3",
+        "breadcrumb.foreground": "#7d8590",
+        "breadcrumbPicker.background": "#161b22",
+        "button.background": "#238636",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#2ea043",
+        "button.secondaryBackground": "#282e33",
+        "button.secondaryForeground": "#c9d1d9",
+        "button.secondaryHoverBackground": "#30363d",
+        "checkbox.background": "#161b22",
+        "checkbox.border": "#30363d",
+        "debugConsole.errorForeground": "#ffa198",
+        "debugConsole.infoForeground": "#8b949e",
+        "debugConsole.sourceForeground": "#e3b341",
+        "debugConsole.warningForeground": "#d29922",
+        "debugConsoleInputIcon.foreground": "#bc8cff",
+        "debugIcon.breakpointForeground": "#f85149",
+        "debugTokenExpression.boolean": "#56d364",
+        "debugTokenExpression.error": "#ffa198",
+        "debugTokenExpression.name": "#79c0ff",
+        "debugTokenExpression.number": "#56d364",
+        "debugTokenExpression.string": "#a5d6ff",
+        "debugTokenExpression.value": "#a5d6ff",
+        "debugToolBar.background": "#161b22",
+        "descriptionForeground": "#7d8590",
+        "diffEditor.insertedLineBackground": "#23863626",
+        "diffEditor.insertedTextBackground": "#3fb9504d",
+        "diffEditor.removedLineBackground": "#da363326",
+        "diffEditor.removedTextBackground": "#ff7b724d",
+        "dropdown.background": "#161b22",
+        "dropdown.border": "#30363d",
+        "dropdown.foreground": "#e6edf3",
+        "dropdown.listBackground": "#161b22",
+        "editor.background": "#0d1117",
+        "editor.findMatchBackground": "#9e6a03",
+        "editor.findMatchHighlightBackground": "#f2cc6080",
+        "editor.focusedStackFrameHighlightBackground": "#2ea04366",
+        "editor.foldBackground": "#6e76811a",
+        "editor.foreground": "#e6edf3",
+        "editor.lineHighlightBackground": "#6e76811a",
+        "editor.linkedEditingBackground": "#2f81f712",
+        "editor.selectionHighlightBackground": "#3fb95040",
+        "editor.stackFrameHighlightBackground": "#bb800966",
+        "editor.wordHighlightBackground": "#6e768180",
+        "editor.wordHighlightBorder": "#6e768199",
+        "editor.wordHighlightStrongBackground": "#6e76814d",
+        "editor.wordHighlightStrongBorder": "#6e768199",
+        "editorBracketHighlight.foreground1": "#79c0ff",
+        "editorBracketHighlight.foreground2": "#56d364",
+        "editorBracketHighlight.foreground3": "#e3b341",
+        "editorBracketHighlight.foreground4": "#ffa198",
+        "editorBracketHighlight.foreground5": "#ff9bce",
+        "editorBracketHighlight.foreground6": "#d2a8ff",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#7d8590",
+        "editorBracketMatch.background": "#3fb95040",
+        "editorBracketMatch.border": "#3fb95099",
+        "editorCursor.foreground": "#2f81f7",
+        "editorGroup.border": "#30363d",
+        "editorGroupHeader.tabsBackground": "#010409",
+        "editorGroupHeader.tabsBorder": "#30363d",
+        "editorGutter.addedBackground": "#2ea04366",
+        "editorGutter.deletedBackground": "#f8514966",
+        "editorGutter.modifiedBackground": "#bb800966",
+        "editorIndentGuide.activeBackground": "#e6edf33d",
+        "editorIndentGuide.background": "#e6edf31f",
+        "editorInlayHint.background": "#8b949e33",
+        "editorInlayHint.foreground": "#7d8590",
+        "editorInlayHint.typeBackground": "#8b949e33",
+        "editorInlayHint.typeForeground": "#7d8590",
+        "editorLineNumber.activeForeground": "#e6edf3",
+        "editorLineNumber.foreground": "#6e7681",
+        "editorOverviewRuler.border": "#010409",
+        "editorWhitespace.foreground": "#484f58",
+        "editorWidget.background": "#161b22",
+        "errorForeground": "#f85149",
+        "focusBorder": "#1f6feb",
+        "foreground": "#e6edf3",
+        "gitDecoration.addedResourceForeground": "#3fb950",
+        "gitDecoration.conflictingResourceForeground": "#db6d28",
+        "gitDecoration.deletedResourceForeground": "#f85149",
+        "gitDecoration.ignoredResourceForeground": "#6e7681",
+        "gitDecoration.modifiedResourceForeground": "#d29922",
+        "gitDecoration.submoduleResourceForeground": "#7d8590",
+        "gitDecoration.untrackedResourceForeground": "#3fb950",
+        "icon.foreground": "#7d8590",
+        "input.background": "#0d1117",
+        "input.border": "#30363d",
+        "input.foreground": "#e6edf3",
+        "input.placeholderForeground": "#6e7681",
+        "keybindingLabel.foreground": "#e6edf3",
+        "list.activeSelectionBackground": "#6e768166",
+        "list.activeSelectionForeground": "#e6edf3",
+        "list.focusBackground": "#388bfd26",
+        "list.focusForeground": "#e6edf3",
+        "list.highlightForeground": "#2f81f7",
+        "list.hoverBackground": "#6e76811a",
+        "list.hoverForeground": "#e6edf3",
+        "list.inactiveFocusBackground": "#388bfd26",
+        "list.inactiveSelectionBackground": "#6e768166",
+        "list.inactiveSelectionForeground": "#e6edf3",
+        "minimapSlider.activeBackground": "#8b949e47",
+        "minimapSlider.background": "#8b949e33",
+        "minimapSlider.hoverBackground": "#8b949e3d",
+        "notificationCenterHeader.background": "#161b22",
+        "notificationCenterHeader.foreground": "#7d8590",
+        "notifications.background": "#161b22",
+        "notifications.border": "#30363d",
+        "notifications.foreground": "#e6edf3",
+        "notificationsErrorIcon.foreground": "#f85149",
+        "notificationsInfoIcon.foreground": "#2f81f7",
+        "notificationsWarningIcon.foreground": "#d29922",
+        "panel.background": "#010409",
+        "panel.border": "#30363d",
+        "panelInput.border": "#30363d",
+        "panelTitle.activeBorder": "#f78166",
+        "panelTitle.activeForeground": "#e6edf3",
+        "panelTitle.inactiveForeground": "#7d8590",
+        "peekViewEditor.background": "#6e76811a",
+        "peekViewEditor.matchHighlightBackground": "#bb800966",
+        "peekViewResult.background": "#0d1117",
+        "peekViewResult.matchHighlightBackground": "#bb800966",
+        "pickerGroup.border": "#30363d",
+        "pickerGroup.foreground": "#7d8590",
+        "progressBar.background": "#1f6feb",
+        "quickInput.background": "#161b22",
+        "quickInput.foreground": "#e6edf3",
+        "scrollbar.shadow": "#484f5833",
+        "scrollbarSlider.activeBackground": "#8b949e47",
+        "scrollbarSlider.background": "#8b949e33",
+        "scrollbarSlider.hoverBackground": "#8b949e3d",
+        "settings.headerForeground": "#e6edf3",
+        "settings.modifiedItemIndicator": "#bb800966",
+        "sideBar.background": "#010409",
+        "sideBar.border": "#30363d",
+        "sideBar.foreground": "#e6edf3",
+        "sideBarSectionHeader.background": "#010409",
+        "sideBarSectionHeader.border": "#30363d",
+        "sideBarSectionHeader.foreground": "#e6edf3",
+        "sideBarTitle.foreground": "#e6edf3",
+        "statusBar.background": "#0d1117",
+        "statusBar.border": "#30363d",
+        "statusBar.debuggingBackground": "#da3633",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.focusBorder": "#1f6feb80",
+        "statusBar.foreground": "#7d8590",
+        "statusBar.noFolderBackground": "#0d1117",
+        "statusBarItem.activeBackground": "#e6edf31f",
+        "statusBarItem.focusBorder": "#1f6feb",
+        "statusBarItem.hoverBackground": "#e6edf314",
+        "statusBarItem.prominentBackground": "#6e768166",
+        "statusBarItem.remoteBackground": "#30363d",
+        "statusBarItem.remoteForeground": "#e6edf3",
+        "symbolIcon.arrayForeground": "#f0883e",
+        "symbolIcon.booleanForeground": "#58a6ff",
+        "symbolIcon.classForeground": "#f0883e",
+        "symbolIcon.colorForeground": "#79c0ff",
+        "symbolIcon.constructorForeground": "#d2a8ff",
+        "symbolIcon.enumeratorForeground": "#f0883e",
+        "symbolIcon.enumeratorMemberForeground": "#58a6ff",
+        "symbolIcon.eventForeground": "#6e7681",
+        "symbolIcon.fieldForeground": "#f0883e",
+        "symbolIcon.fileForeground": "#d29922",
+        "symbolIcon.folderForeground": "#d29922",
+        "symbolIcon.functionForeground": "#bc8cff",
+        "symbolIcon.interfaceForeground": "#f0883e",
+        "symbolIcon.keyForeground": "#58a6ff",
+        "symbolIcon.keywordForeground": "#ff7b72",
+        "symbolIcon.methodForeground": "#bc8cff",
+        "symbolIcon.moduleForeground": "#ff7b72",
+        "symbolIcon.namespaceForeground": "#ff7b72",
+        "symbolIcon.nullForeground": "#58a6ff",
+        "symbolIcon.numberForeground": "#3fb950",
+        "symbolIcon.objectForeground": "#f0883e",
+        "symbolIcon.operatorForeground": "#79c0ff",
+        "symbolIcon.packageForeground": "#f0883e",
+        "symbolIcon.propertyForeground": "#f0883e",
+        "symbolIcon.referenceForeground": "#58a6ff",
+        "symbolIcon.snippetForeground": "#58a6ff",
+        "symbolIcon.stringForeground": "#79c0ff",
+        "symbolIcon.structForeground": "#f0883e",
+        "symbolIcon.textForeground": "#79c0ff",
+        "symbolIcon.typeParameterForeground": "#79c0ff",
+        "symbolIcon.unitForeground": "#58a6ff",
+        "symbolIcon.variableForeground": "#f0883e",
+        "tab.activeBackground": "#0d1117",
+        "tab.activeBorder": "#0d1117",
+        "tab.activeBorderTop": "#f78166",
+        "tab.activeForeground": "#e6edf3",
+        "tab.border": "#30363d",
+        "tab.hoverBackground": "#0d1117",
+        "tab.inactiveBackground": "#010409",
+        "tab.inactiveForeground": "#7d8590",
+        "tab.unfocusedActiveBorder": "#0d1117",
+        "tab.unfocusedActiveBorderTop": "#30363d",
+        "tab.unfocusedHoverBackground": "#6e76811a",
+        "terminal.ansiBlack": "#484f58",
+        "terminal.ansiBlue": "#58a6ff",
+        "terminal.ansiBrightBlack": "#6e7681",
+        "terminal.ansiBrightBlue": "#79c0ff",
+        "terminal.ansiBrightCyan": "#56d4dd",
+        "terminal.ansiBrightGreen": "#56d364",
+        "terminal.ansiBrightMagenta": "#d2a8ff",
+        "terminal.ansiBrightRed": "#ffa198",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e3b341",
+        "terminal.ansiCyan": "#39c5cf",
+        "terminal.ansiGreen": "#3fb950",
+        "terminal.ansiMagenta": "#bc8cff",
+        "terminal.ansiRed": "#ff7b72",
+        "terminal.ansiWhite": "#b1bac4",
+        "terminal.ansiYellow": "#d29922",
+        "terminal.foreground": "#e6edf3",
+        "textBlockQuote.background": "#010409",
+        "textBlockQuote.border": "#30363d",
+        "textCodeBlock.background": "#6e768166",
+        "textLink.activeForeground": "#2f81f7",
+        "textLink.foreground": "#2f81f7",
+        "textPreformat.foreground": "#7d8590",
+        "textSeparator.foreground": "#21262d",
+        "titleBar.activeBackground": "#0d1117",
+        "titleBar.activeForeground": "#7d8590",
+        "titleBar.border": "#30363d",
+        "titleBar.inactiveBackground": "#010409",
+        "titleBar.inactiveForeground": "#7d8590",
+        "tree.indentGuidesStroke": "#21262d"
+    },
+    "rules": [
+        {
+            "foreground": "#8B949E",
+            "token": "comment"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "string.comment"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "constant"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "entity.name.constant"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "entity"
+        },
+        {
+            "foreground": "#FFA657",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#FFA657",
+            "token": "meta.export.default"
+        },
+        {
+            "foreground": "#FFA657",
+            "token": "meta.definition.variable"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "variable.parameter.function"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "meta.block"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "meta.tag.attributes"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "entity.name.constant"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "meta.object.member"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "meta.embedded.expression"
+        },
+        {
+            "foreground": "#D2A8FF",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#7EE787",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#7EE787",
+            "token": "support.class.component"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "storage"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "storage.modifier.package"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "storage.modifier.import"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string punctuation.section.embedded source"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "support"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "meta.property-name"
+        },
+        {
+            "foreground": "#FFA657",
+            "token": "variable"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#FFA198",
+            "fontStyle": "italic",
+            "token": "invalid.broken"
+        },
+        {
+            "foreground": "#FFA198",
+            "fontStyle": "italic",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#FFA198",
+            "fontStyle": "italic",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#FFA198",
+            "fontStyle": "italic",
+            "token": "invalid.unimplemented"
+        },
+        {
+            "foreground": "#F0F6FC",
+            "background": "#FF7B72",
+            "fontStyle": "italic underline",
+            "token": "carriage-return"
+        },
+        {
+            "foreground": "#FFA198",
+            "token": "message.error"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "string variable"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "source.regexp"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.regexp.character-class"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.regexp source.ruby.embedded"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.regexp string.regexp.arbitrary-repitition"
+        },
+        {
+            "foreground": "#7EE787",
+            "fontStyle": "bold",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#7EE787",
+            "token": "support.type.property-name.json"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "meta.module-reference"
+        },
+        {
+            "foreground": "#FFA657",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#79C0FF",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#79C0FF",
+            "fontStyle": "bold",
+            "token": "markup.heading entity.name"
+        },
+        {
+            "foreground": "#7EE787",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#E6EDF3",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#FFA198",
+            "background": "#490202",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#FFA198",
+            "background": "#490202",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#FFA198",
+            "background": "#490202",
+            "token": "punctuation.definition.deleted"
+        },
+        {
+            "foreground": "#FF7B72",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#7EE787",
+            "background": "#04260F",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#7EE787",
+            "background": "#04260F",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#7EE787",
+            "background": "#04260F",
+            "token": "punctuation.definition.inserted"
+        },
+        {
+            "foreground": "#FFA657",
+            "background": "#5A1E02",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#FFA657",
+            "background": "#5A1E02",
+            "token": "punctuation.definition.changed"
+        },
+        {
+            "foreground": "#161B22",
+            "background": "#79C0FF",
+            "token": "markup.ignored"
+        },
+        {
+            "foreground": "#161B22",
+            "background": "#79C0FF",
+            "token": "markup.untracked"
+        },
+        {
+            "foreground": "#D2A8FF",
+            "fontStyle": "bold",
+            "token": "meta.diff.range"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#79C0FF",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#79C0FF",
+            "token": "meta.output"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.tag"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.curly"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.round"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.square"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.angle"
+        },
+        {
+            "foreground": "#8B949E",
+            "token": "brackethighlighter.quote"
+        },
+        {
+            "foreground": "#FFA198",
+            "token": "brackethighlighter.unmatched"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "constant.other.reference.link"
+        },
+        {
+            "foreground": "#A5D6FF",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/github-dark-dimmed/github-dark-dimmed-monaco.json
+++ b/themes/github-dark-dimmed/github-dark-dimmed-monaco.json
@@ -1,635 +1,631 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.activeBorder": "#ec775c",
-                "activityBar.background": "#22272e",
-                "activityBar.border": "#444c56",
-                "activityBar.foreground": "#adbac7",
-                "activityBar.inactiveForeground": "#768390",
-                "activityBarBadge.background": "#316dca",
-                "activityBarBadge.foreground": "#cdd9e5",
-                "badge.background": "#316dca",
-                "badge.foreground": "#cdd9e5",
-                "breadcrumb.activeSelectionForeground": "#768390",
-                "breadcrumb.focusForeground": "#adbac7",
-                "breadcrumb.foreground": "#768390",
-                "breadcrumbPicker.background": "#2d333b",
-                "button.background": "#347d39",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#46954a",
-                "button.secondaryBackground": "#3d444d",
-                "button.secondaryForeground": "#adbac7",
-                "button.secondaryHoverBackground": "#444c56",
-                "checkbox.background": "#2d333b",
-                "checkbox.border": "#444c56",
-                "debugConsole.errorForeground": "#ff938a",
-                "debugConsole.infoForeground": "#768390",
-                "debugConsole.sourceForeground": "#daaa3f",
-                "debugConsole.warningForeground": "#c69026",
-                "debugConsoleInputIcon.foreground": "#b083f0",
-                "debugIcon.breakpointForeground": "#e5534b",
-                "debugTokenExpression.boolean": "#6bc46d",
-                "debugTokenExpression.error": "#ff938a",
-                "debugTokenExpression.name": "#6cb6ff",
-                "debugTokenExpression.number": "#6bc46d",
-                "debugTokenExpression.string": "#96d0ff",
-                "debugTokenExpression.value": "#96d0ff",
-                "debugToolBar.background": "#2d333b",
-                "descriptionForeground": "#768390",
-                "diffEditor.insertedLineBackground": "#347d3926",
-                "diffEditor.insertedTextBackground": "#57ab5a4d",
-                "diffEditor.removedLineBackground": "#c93c3726",
-                "diffEditor.removedTextBackground": "#f470674d",
-                "dropdown.background": "#2d333b",
-                "dropdown.border": "#444c56",
-                "dropdown.foreground": "#adbac7",
-                "dropdown.listBackground": "#2d333b",
-                "editor.background": "#22272e",
-                "editor.findMatchBackground": "#966600",
-                "editor.findMatchHighlightBackground": "#eac55f80",
-                "editor.focusedStackFrameHighlightBackground": "#46954a66",
-                "editor.foldBackground": "#636e7b1a",
-                "editor.foreground": "#adbac7",
-                "editor.lineHighlightBackground": "#636e7b1a",
-                "editor.linkedEditingBackground": "#539bf512",
-                "editor.selectionHighlightBackground": "#57ab5a40",
-                "editor.stackFrameHighlightBackground": "#ae7c1466",
-                "editor.wordHighlightBackground": "#636e7b80",
-                "editor.wordHighlightBorder": "#636e7b99",
-                "editor.wordHighlightStrongBackground": "#636e7b4d",
-                "editor.wordHighlightStrongBorder": "#636e7b99",
-                "editorBracketHighlight.foreground1": "#6cb6ff",
-                "editorBracketHighlight.foreground2": "#6bc46d",
-                "editorBracketHighlight.foreground3": "#daaa3f",
-                "editorBracketHighlight.foreground4": "#ff938a",
-                "editorBracketHighlight.foreground5": "#fc8dc7",
-                "editorBracketHighlight.foreground6": "#dcbdfb",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#768390",
-                "editorBracketMatch.background": "#57ab5a40",
-                "editorBracketMatch.border": "#57ab5a99",
-                "editorCursor.foreground": "#539bf5",
-                "editorGroup.border": "#444c56",
-                "editorGroupHeader.tabsBackground": "#1c2128",
-                "editorGroupHeader.tabsBorder": "#444c56",
-                "editorGutter.addedBackground": "#46954a66",
-                "editorGutter.deletedBackground": "#e5534b66",
-                "editorGutter.modifiedBackground": "#ae7c1466",
-                "editorIndentGuide.activeBackground": "#adbac73d",
-                "editorIndentGuide.background": "#adbac71f",
-                "editorInlayHint.background": "#76839033",
-                "editorInlayHint.foreground": "#768390",
-                "editorInlayHint.typeBackground": "#76839033",
-                "editorInlayHint.typeForeground": "#768390",
-                "editorLineNumber.activeForeground": "#adbac7",
-                "editorLineNumber.foreground": "#636e7b",
-                "editorOverviewRuler.border": "#1c2128",
-                "editorWhitespace.foreground": "#545d68",
-                "editorWidget.background": "#2d333b",
-                "errorForeground": "#e5534b",
-                "focusBorder": "#316dca",
-                "foreground": "#adbac7",
-                "gitDecoration.addedResourceForeground": "#57ab5a",
-                "gitDecoration.conflictingResourceForeground": "#cc6b2c",
-                "gitDecoration.deletedResourceForeground": "#e5534b",
-                "gitDecoration.ignoredResourceForeground": "#636e7b",
-                "gitDecoration.modifiedResourceForeground": "#c69026",
-                "gitDecoration.submoduleResourceForeground": "#768390",
-                "gitDecoration.untrackedResourceForeground": "#57ab5a",
-                "icon.foreground": "#768390",
-                "input.background": "#22272e",
-                "input.border": "#444c56",
-                "input.foreground": "#adbac7",
-                "input.placeholderForeground": "#636e7b",
-                "keybindingLabel.foreground": "#adbac7",
-                "list.activeSelectionBackground": "#636e7b66",
-                "list.activeSelectionForeground": "#adbac7",
-                "list.focusBackground": "#4184e426",
-                "list.focusForeground": "#adbac7",
-                "list.highlightForeground": "#539bf5",
-                "list.hoverBackground": "#636e7b1a",
-                "list.hoverForeground": "#adbac7",
-                "list.inactiveFocusBackground": "#4184e426",
-                "list.inactiveSelectionBackground": "#636e7b66",
-                "list.inactiveSelectionForeground": "#adbac7",
-                "minimapSlider.activeBackground": "#76839047",
-                "minimapSlider.background": "#76839033",
-                "minimapSlider.hoverBackground": "#7683903d",
-                "notificationCenterHeader.background": "#2d333b",
-                "notificationCenterHeader.foreground": "#768390",
-                "notifications.background": "#2d333b",
-                "notifications.border": "#444c56",
-                "notifications.foreground": "#adbac7",
-                "notificationsErrorIcon.foreground": "#e5534b",
-                "notificationsInfoIcon.foreground": "#539bf5",
-                "notificationsWarningIcon.foreground": "#c69026",
-                "panel.background": "#1c2128",
-                "panel.border": "#444c56",
-                "panelInput.border": "#444c56",
-                "panelTitle.activeBorder": "#ec775c",
-                "panelTitle.activeForeground": "#adbac7",
-                "panelTitle.inactiveForeground": "#768390",
-                "peekViewEditor.background": "#636e7b1a",
-                "peekViewEditor.matchHighlightBackground": "#ae7c1466",
-                "peekViewResult.background": "#22272e",
-                "peekViewResult.matchHighlightBackground": "#ae7c1466",
-                "pickerGroup.border": "#444c56",
-                "pickerGroup.foreground": "#768390",
-                "progressBar.background": "#316dca",
-                "quickInput.background": "#2d333b",
-                "quickInput.foreground": "#adbac7",
-                "scrollbar.shadow": "#545d6833",
-                "scrollbarSlider.activeBackground": "#76839047",
-                "scrollbarSlider.background": "#76839033",
-                "scrollbarSlider.hoverBackground": "#7683903d",
-                "settings.headerForeground": "#adbac7",
-                "settings.modifiedItemIndicator": "#ae7c1466",
-                "sideBar.background": "#1c2128",
-                "sideBar.border": "#444c56",
-                "sideBar.foreground": "#adbac7",
-                "sideBarSectionHeader.background": "#1c2128",
-                "sideBarSectionHeader.border": "#444c56",
-                "sideBarSectionHeader.foreground": "#adbac7",
-                "sideBarTitle.foreground": "#adbac7",
-                "statusBar.background": "#22272e",
-                "statusBar.border": "#444c56",
-                "statusBar.debuggingBackground": "#c93c37",
-                "statusBar.debuggingForeground": "#cdd9e5",
-                "statusBar.focusBorder": "#316dca80",
-                "statusBar.foreground": "#768390",
-                "statusBar.noFolderBackground": "#22272e",
-                "statusBarItem.activeBackground": "#adbac71f",
-                "statusBarItem.focusBorder": "#316dca",
-                "statusBarItem.hoverBackground": "#adbac714",
-                "statusBarItem.prominentBackground": "#636e7b66",
-                "statusBarItem.remoteBackground": "#444c56",
-                "statusBarItem.remoteForeground": "#adbac7",
-                "symbolIcon.arrayForeground": "#e0823d",
-                "symbolIcon.booleanForeground": "#539bf5",
-                "symbolIcon.classForeground": "#e0823d",
-                "symbolIcon.colorForeground": "#6cb6ff",
-                "symbolIcon.constructorForeground": "#dcbdfb",
-                "symbolIcon.enumeratorForeground": "#e0823d",
-                "symbolIcon.enumeratorMemberForeground": "#539bf5",
-                "symbolIcon.eventForeground": "#636e7b",
-                "symbolIcon.fieldForeground": "#e0823d",
-                "symbolIcon.fileForeground": "#c69026",
-                "symbolIcon.folderForeground": "#c69026",
-                "symbolIcon.functionForeground": "#b083f0",
-                "symbolIcon.interfaceForeground": "#e0823d",
-                "symbolIcon.keyForeground": "#539bf5",
-                "symbolIcon.keywordForeground": "#f47067",
-                "symbolIcon.methodForeground": "#b083f0",
-                "symbolIcon.moduleForeground": "#f47067",
-                "symbolIcon.namespaceForeground": "#f47067",
-                "symbolIcon.nullForeground": "#539bf5",
-                "symbolIcon.numberForeground": "#57ab5a",
-                "symbolIcon.objectForeground": "#e0823d",
-                "symbolIcon.operatorForeground": "#6cb6ff",
-                "symbolIcon.packageForeground": "#e0823d",
-                "symbolIcon.propertyForeground": "#e0823d",
-                "symbolIcon.referenceForeground": "#539bf5",
-                "symbolIcon.snippetForeground": "#539bf5",
-                "symbolIcon.stringForeground": "#6cb6ff",
-                "symbolIcon.structForeground": "#e0823d",
-                "symbolIcon.textForeground": "#6cb6ff",
-                "symbolIcon.typeParameterForeground": "#6cb6ff",
-                "symbolIcon.unitForeground": "#539bf5",
-                "symbolIcon.variableForeground": "#e0823d",
-                "tab.activeBackground": "#22272e",
-                "tab.activeBorder": "#22272e",
-                "tab.activeBorderTop": "#ec775c",
-                "tab.activeForeground": "#adbac7",
-                "tab.border": "#444c56",
-                "tab.hoverBackground": "#22272e",
-                "tab.inactiveBackground": "#1c2128",
-                "tab.inactiveForeground": "#768390",
-                "tab.unfocusedActiveBorder": "#22272e",
-                "tab.unfocusedActiveBorderTop": "#444c56",
-                "tab.unfocusedHoverBackground": "#636e7b1a",
-                "terminal.ansiBlack": "#545d68",
-                "terminal.ansiBlue": "#539bf5",
-                "terminal.ansiBrightBlack": "#636e7b",
-                "terminal.ansiBrightBlue": "#6cb6ff",
-                "terminal.ansiBrightCyan": "#56d4dd",
-                "terminal.ansiBrightGreen": "#6bc46d",
-                "terminal.ansiBrightMagenta": "#dcbdfb",
-                "terminal.ansiBrightRed": "#ff938a",
-                "terminal.ansiBrightWhite": "#cdd9e5",
-                "terminal.ansiBrightYellow": "#daaa3f",
-                "terminal.ansiCyan": "#39c5cf",
-                "terminal.ansiGreen": "#57ab5a",
-                "terminal.ansiMagenta": "#b083f0",
-                "terminal.ansiRed": "#f47067",
-                "terminal.ansiWhite": "#909dab",
-                "terminal.ansiYellow": "#c69026",
-                "terminal.foreground": "#adbac7",
-                "textBlockQuote.background": "#1c2128",
-                "textBlockQuote.border": "#444c56",
-                "textCodeBlock.background": "#636e7b66",
-                "textLink.activeForeground": "#539bf5",
-                "textLink.foreground": "#539bf5",
-                "textPreformat.foreground": "#768390",
-                "textSeparator.foreground": "#373e47",
-                "titleBar.activeBackground": "#22272e",
-                "titleBar.activeForeground": "#768390",
-                "titleBar.border": "#444c56",
-                "titleBar.inactiveBackground": "#1c2128",
-                "titleBar.inactiveForeground": "#768390",
-                "tree.indentGuidesStroke": "#373e47"
-            },
-            "rules": [
-                {
-                    "foreground": "#768390",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "string.comment"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "entity.name.constant"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "entity"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "token": "meta.export.default"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "token": "meta.definition.variable"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "variable.parameter.function"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "meta.block"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "meta.tag.attributes"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "entity.name.constant"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "meta.object.member"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "meta.embedded.expression"
-                },
-                {
-                    "foreground": "#DCBDFB",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "token": "support.class.component"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "storage.modifier.package"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string punctuation.section.embedded source"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "meta.property-name"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "fontStyle": "italic",
-                    "token": "invalid.broken"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "fontStyle": "italic",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "fontStyle": "italic",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "fontStyle": "italic",
-                    "token": "invalid.unimplemented"
-                },
-                {
-                    "foreground": "#CDD9E5",
-                    "background": "#F47067",
-                    "fontStyle": "italic underline",
-                    "token": "carriage-return"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "token": "message.error"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "string variable"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "source.regexp"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.regexp.character-class"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.regexp source.ruby.embedded"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.regexp string.regexp.arbitrary-repitition"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "fontStyle": "bold",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "token": "support.type.property-name.json"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "meta.module-reference"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading entity.name"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#ADBAC7",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "background": "#5D0F12",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "background": "#5D0F12",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "background": "#5D0F12",
-                    "token": "punctuation.definition.deleted"
-                },
-                {
-                    "foreground": "#F47067",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "background": "#113417",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "background": "#113417",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#8DDB8C",
-                    "background": "#113417",
-                    "token": "punctuation.definition.inserted"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "background": "#682D0F",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#F69D50",
-                    "background": "#682D0F",
-                    "token": "punctuation.definition.changed"
-                },
-                {
-                    "foreground": "#2D333B",
-                    "background": "#6CB6FF",
-                    "token": "markup.ignored"
-                },
-                {
-                    "foreground": "#2D333B",
-                    "background": "#6CB6FF",
-                    "token": "markup.untracked"
-                },
-                {
-                    "foreground": "#DCBDFB",
-                    "fontStyle": "bold",
-                    "token": "meta.diff.range"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#6CB6FF",
-                    "token": "meta.output"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.tag"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.curly"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.round"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.square"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.angle"
-                },
-                {
-                    "foreground": "#768390",
-                    "token": "brackethighlighter.quote"
-                },
-                {
-                    "foreground": "#FF938A",
-                    "token": "brackethighlighter.unmatched"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "constant.other.reference.link"
-                },
-                {
-                    "foreground": "#96D0FF",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.activeBorder": "#ec775c",
+        "activityBar.background": "#22272e",
+        "activityBar.border": "#444c56",
+        "activityBar.foreground": "#adbac7",
+        "activityBar.inactiveForeground": "#768390",
+        "activityBarBadge.background": "#316dca",
+        "activityBarBadge.foreground": "#cdd9e5",
+        "badge.background": "#316dca",
+        "badge.foreground": "#cdd9e5",
+        "breadcrumb.activeSelectionForeground": "#768390",
+        "breadcrumb.focusForeground": "#adbac7",
+        "breadcrumb.foreground": "#768390",
+        "breadcrumbPicker.background": "#2d333b",
+        "button.background": "#347d39",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#46954a",
+        "button.secondaryBackground": "#3d444d",
+        "button.secondaryForeground": "#adbac7",
+        "button.secondaryHoverBackground": "#444c56",
+        "checkbox.background": "#2d333b",
+        "checkbox.border": "#444c56",
+        "debugConsole.errorForeground": "#ff938a",
+        "debugConsole.infoForeground": "#768390",
+        "debugConsole.sourceForeground": "#daaa3f",
+        "debugConsole.warningForeground": "#c69026",
+        "debugConsoleInputIcon.foreground": "#b083f0",
+        "debugIcon.breakpointForeground": "#e5534b",
+        "debugTokenExpression.boolean": "#6bc46d",
+        "debugTokenExpression.error": "#ff938a",
+        "debugTokenExpression.name": "#6cb6ff",
+        "debugTokenExpression.number": "#6bc46d",
+        "debugTokenExpression.string": "#96d0ff",
+        "debugTokenExpression.value": "#96d0ff",
+        "debugToolBar.background": "#2d333b",
+        "descriptionForeground": "#768390",
+        "diffEditor.insertedLineBackground": "#347d3926",
+        "diffEditor.insertedTextBackground": "#57ab5a4d",
+        "diffEditor.removedLineBackground": "#c93c3726",
+        "diffEditor.removedTextBackground": "#f470674d",
+        "dropdown.background": "#2d333b",
+        "dropdown.border": "#444c56",
+        "dropdown.foreground": "#adbac7",
+        "dropdown.listBackground": "#2d333b",
+        "editor.background": "#22272e",
+        "editor.findMatchBackground": "#966600",
+        "editor.findMatchHighlightBackground": "#eac55f80",
+        "editor.focusedStackFrameHighlightBackground": "#46954a66",
+        "editor.foldBackground": "#636e7b1a",
+        "editor.foreground": "#adbac7",
+        "editor.lineHighlightBackground": "#636e7b1a",
+        "editor.linkedEditingBackground": "#539bf512",
+        "editor.selectionHighlightBackground": "#57ab5a40",
+        "editor.stackFrameHighlightBackground": "#ae7c1466",
+        "editor.wordHighlightBackground": "#636e7b80",
+        "editor.wordHighlightBorder": "#636e7b99",
+        "editor.wordHighlightStrongBackground": "#636e7b4d",
+        "editor.wordHighlightStrongBorder": "#636e7b99",
+        "editorBracketHighlight.foreground1": "#6cb6ff",
+        "editorBracketHighlight.foreground2": "#6bc46d",
+        "editorBracketHighlight.foreground3": "#daaa3f",
+        "editorBracketHighlight.foreground4": "#ff938a",
+        "editorBracketHighlight.foreground5": "#fc8dc7",
+        "editorBracketHighlight.foreground6": "#dcbdfb",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#768390",
+        "editorBracketMatch.background": "#57ab5a40",
+        "editorBracketMatch.border": "#57ab5a99",
+        "editorCursor.foreground": "#539bf5",
+        "editorGroup.border": "#444c56",
+        "editorGroupHeader.tabsBackground": "#1c2128",
+        "editorGroupHeader.tabsBorder": "#444c56",
+        "editorGutter.addedBackground": "#46954a66",
+        "editorGutter.deletedBackground": "#e5534b66",
+        "editorGutter.modifiedBackground": "#ae7c1466",
+        "editorIndentGuide.activeBackground": "#adbac73d",
+        "editorIndentGuide.background": "#adbac71f",
+        "editorInlayHint.background": "#76839033",
+        "editorInlayHint.foreground": "#768390",
+        "editorInlayHint.typeBackground": "#76839033",
+        "editorInlayHint.typeForeground": "#768390",
+        "editorLineNumber.activeForeground": "#adbac7",
+        "editorLineNumber.foreground": "#636e7b",
+        "editorOverviewRuler.border": "#1c2128",
+        "editorWhitespace.foreground": "#545d68",
+        "editorWidget.background": "#2d333b",
+        "errorForeground": "#e5534b",
+        "focusBorder": "#316dca",
+        "foreground": "#adbac7",
+        "gitDecoration.addedResourceForeground": "#57ab5a",
+        "gitDecoration.conflictingResourceForeground": "#cc6b2c",
+        "gitDecoration.deletedResourceForeground": "#e5534b",
+        "gitDecoration.ignoredResourceForeground": "#636e7b",
+        "gitDecoration.modifiedResourceForeground": "#c69026",
+        "gitDecoration.submoduleResourceForeground": "#768390",
+        "gitDecoration.untrackedResourceForeground": "#57ab5a",
+        "icon.foreground": "#768390",
+        "input.background": "#22272e",
+        "input.border": "#444c56",
+        "input.foreground": "#adbac7",
+        "input.placeholderForeground": "#636e7b",
+        "keybindingLabel.foreground": "#adbac7",
+        "list.activeSelectionBackground": "#636e7b66",
+        "list.activeSelectionForeground": "#adbac7",
+        "list.focusBackground": "#4184e426",
+        "list.focusForeground": "#adbac7",
+        "list.highlightForeground": "#539bf5",
+        "list.hoverBackground": "#636e7b1a",
+        "list.hoverForeground": "#adbac7",
+        "list.inactiveFocusBackground": "#4184e426",
+        "list.inactiveSelectionBackground": "#636e7b66",
+        "list.inactiveSelectionForeground": "#adbac7",
+        "minimapSlider.activeBackground": "#76839047",
+        "minimapSlider.background": "#76839033",
+        "minimapSlider.hoverBackground": "#7683903d",
+        "notificationCenterHeader.background": "#2d333b",
+        "notificationCenterHeader.foreground": "#768390",
+        "notifications.background": "#2d333b",
+        "notifications.border": "#444c56",
+        "notifications.foreground": "#adbac7",
+        "notificationsErrorIcon.foreground": "#e5534b",
+        "notificationsInfoIcon.foreground": "#539bf5",
+        "notificationsWarningIcon.foreground": "#c69026",
+        "panel.background": "#1c2128",
+        "panel.border": "#444c56",
+        "panelInput.border": "#444c56",
+        "panelTitle.activeBorder": "#ec775c",
+        "panelTitle.activeForeground": "#adbac7",
+        "panelTitle.inactiveForeground": "#768390",
+        "peekViewEditor.background": "#636e7b1a",
+        "peekViewEditor.matchHighlightBackground": "#ae7c1466",
+        "peekViewResult.background": "#22272e",
+        "peekViewResult.matchHighlightBackground": "#ae7c1466",
+        "pickerGroup.border": "#444c56",
+        "pickerGroup.foreground": "#768390",
+        "progressBar.background": "#316dca",
+        "quickInput.background": "#2d333b",
+        "quickInput.foreground": "#adbac7",
+        "scrollbar.shadow": "#545d6833",
+        "scrollbarSlider.activeBackground": "#76839047",
+        "scrollbarSlider.background": "#76839033",
+        "scrollbarSlider.hoverBackground": "#7683903d",
+        "settings.headerForeground": "#adbac7",
+        "settings.modifiedItemIndicator": "#ae7c1466",
+        "sideBar.background": "#1c2128",
+        "sideBar.border": "#444c56",
+        "sideBar.foreground": "#adbac7",
+        "sideBarSectionHeader.background": "#1c2128",
+        "sideBarSectionHeader.border": "#444c56",
+        "sideBarSectionHeader.foreground": "#adbac7",
+        "sideBarTitle.foreground": "#adbac7",
+        "statusBar.background": "#22272e",
+        "statusBar.border": "#444c56",
+        "statusBar.debuggingBackground": "#c93c37",
+        "statusBar.debuggingForeground": "#cdd9e5",
+        "statusBar.focusBorder": "#316dca80",
+        "statusBar.foreground": "#768390",
+        "statusBar.noFolderBackground": "#22272e",
+        "statusBarItem.activeBackground": "#adbac71f",
+        "statusBarItem.focusBorder": "#316dca",
+        "statusBarItem.hoverBackground": "#adbac714",
+        "statusBarItem.prominentBackground": "#636e7b66",
+        "statusBarItem.remoteBackground": "#444c56",
+        "statusBarItem.remoteForeground": "#adbac7",
+        "symbolIcon.arrayForeground": "#e0823d",
+        "symbolIcon.booleanForeground": "#539bf5",
+        "symbolIcon.classForeground": "#e0823d",
+        "symbolIcon.colorForeground": "#6cb6ff",
+        "symbolIcon.constructorForeground": "#dcbdfb",
+        "symbolIcon.enumeratorForeground": "#e0823d",
+        "symbolIcon.enumeratorMemberForeground": "#539bf5",
+        "symbolIcon.eventForeground": "#636e7b",
+        "symbolIcon.fieldForeground": "#e0823d",
+        "symbolIcon.fileForeground": "#c69026",
+        "symbolIcon.folderForeground": "#c69026",
+        "symbolIcon.functionForeground": "#b083f0",
+        "symbolIcon.interfaceForeground": "#e0823d",
+        "symbolIcon.keyForeground": "#539bf5",
+        "symbolIcon.keywordForeground": "#f47067",
+        "symbolIcon.methodForeground": "#b083f0",
+        "symbolIcon.moduleForeground": "#f47067",
+        "symbolIcon.namespaceForeground": "#f47067",
+        "symbolIcon.nullForeground": "#539bf5",
+        "symbolIcon.numberForeground": "#57ab5a",
+        "symbolIcon.objectForeground": "#e0823d",
+        "symbolIcon.operatorForeground": "#6cb6ff",
+        "symbolIcon.packageForeground": "#e0823d",
+        "symbolIcon.propertyForeground": "#e0823d",
+        "symbolIcon.referenceForeground": "#539bf5",
+        "symbolIcon.snippetForeground": "#539bf5",
+        "symbolIcon.stringForeground": "#6cb6ff",
+        "symbolIcon.structForeground": "#e0823d",
+        "symbolIcon.textForeground": "#6cb6ff",
+        "symbolIcon.typeParameterForeground": "#6cb6ff",
+        "symbolIcon.unitForeground": "#539bf5",
+        "symbolIcon.variableForeground": "#e0823d",
+        "tab.activeBackground": "#22272e",
+        "tab.activeBorder": "#22272e",
+        "tab.activeBorderTop": "#ec775c",
+        "tab.activeForeground": "#adbac7",
+        "tab.border": "#444c56",
+        "tab.hoverBackground": "#22272e",
+        "tab.inactiveBackground": "#1c2128",
+        "tab.inactiveForeground": "#768390",
+        "tab.unfocusedActiveBorder": "#22272e",
+        "tab.unfocusedActiveBorderTop": "#444c56",
+        "tab.unfocusedHoverBackground": "#636e7b1a",
+        "terminal.ansiBlack": "#545d68",
+        "terminal.ansiBlue": "#539bf5",
+        "terminal.ansiBrightBlack": "#636e7b",
+        "terminal.ansiBrightBlue": "#6cb6ff",
+        "terminal.ansiBrightCyan": "#56d4dd",
+        "terminal.ansiBrightGreen": "#6bc46d",
+        "terminal.ansiBrightMagenta": "#dcbdfb",
+        "terminal.ansiBrightRed": "#ff938a",
+        "terminal.ansiBrightWhite": "#cdd9e5",
+        "terminal.ansiBrightYellow": "#daaa3f",
+        "terminal.ansiCyan": "#39c5cf",
+        "terminal.ansiGreen": "#57ab5a",
+        "terminal.ansiMagenta": "#b083f0",
+        "terminal.ansiRed": "#f47067",
+        "terminal.ansiWhite": "#909dab",
+        "terminal.ansiYellow": "#c69026",
+        "terminal.foreground": "#adbac7",
+        "textBlockQuote.background": "#1c2128",
+        "textBlockQuote.border": "#444c56",
+        "textCodeBlock.background": "#636e7b66",
+        "textLink.activeForeground": "#539bf5",
+        "textLink.foreground": "#539bf5",
+        "textPreformat.foreground": "#768390",
+        "textSeparator.foreground": "#373e47",
+        "titleBar.activeBackground": "#22272e",
+        "titleBar.activeForeground": "#768390",
+        "titleBar.border": "#444c56",
+        "titleBar.inactiveBackground": "#1c2128",
+        "titleBar.inactiveForeground": "#768390",
+        "tree.indentGuidesStroke": "#373e47"
+    },
+    "rules": [
+        {
+            "foreground": "#768390",
+            "token": "comment"
+        },
+        {
+            "foreground": "#768390",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#768390",
+            "token": "string.comment"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "constant"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "entity.name.constant"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "entity"
+        },
+        {
+            "foreground": "#F69D50",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#F69D50",
+            "token": "meta.export.default"
+        },
+        {
+            "foreground": "#F69D50",
+            "token": "meta.definition.variable"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "variable.parameter.function"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "meta.block"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "meta.tag.attributes"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "entity.name.constant"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "meta.object.member"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "meta.embedded.expression"
+        },
+        {
+            "foreground": "#DCBDFB",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "token": "support.class.component"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "storage"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "storage.modifier.package"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "storage.modifier.import"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string punctuation.section.embedded source"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "support"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "meta.property-name"
+        },
+        {
+            "foreground": "#F69D50",
+            "token": "variable"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#FF938A",
+            "fontStyle": "italic",
+            "token": "invalid.broken"
+        },
+        {
+            "foreground": "#FF938A",
+            "fontStyle": "italic",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#FF938A",
+            "fontStyle": "italic",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#FF938A",
+            "fontStyle": "italic",
+            "token": "invalid.unimplemented"
+        },
+        {
+            "foreground": "#CDD9E5",
+            "background": "#F47067",
+            "fontStyle": "italic underline",
+            "token": "carriage-return"
+        },
+        {
+            "foreground": "#FF938A",
+            "token": "message.error"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "string variable"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "source.regexp"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.regexp.character-class"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.regexp source.ruby.embedded"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.regexp string.regexp.arbitrary-repitition"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "fontStyle": "bold",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "token": "support.type.property-name.json"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "meta.module-reference"
+        },
+        {
+            "foreground": "#F69D50",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "fontStyle": "bold",
+            "token": "markup.heading entity.name"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#ADBAC7",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#FF938A",
+            "background": "#5D0F12",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#FF938A",
+            "background": "#5D0F12",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#FF938A",
+            "background": "#5D0F12",
+            "token": "punctuation.definition.deleted"
+        },
+        {
+            "foreground": "#F47067",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "background": "#113417",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "background": "#113417",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#8DDB8C",
+            "background": "#113417",
+            "token": "punctuation.definition.inserted"
+        },
+        {
+            "foreground": "#F69D50",
+            "background": "#682D0F",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#F69D50",
+            "background": "#682D0F",
+            "token": "punctuation.definition.changed"
+        },
+        {
+            "foreground": "#2D333B",
+            "background": "#6CB6FF",
+            "token": "markup.ignored"
+        },
+        {
+            "foreground": "#2D333B",
+            "background": "#6CB6FF",
+            "token": "markup.untracked"
+        },
+        {
+            "foreground": "#DCBDFB",
+            "fontStyle": "bold",
+            "token": "meta.diff.range"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#6CB6FF",
+            "token": "meta.output"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.tag"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.curly"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.round"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.square"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.angle"
+        },
+        {
+            "foreground": "#768390",
+            "token": "brackethighlighter.quote"
+        },
+        {
+            "foreground": "#FF938A",
+            "token": "brackethighlighter.unmatched"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "constant.other.reference.link"
+        },
+        {
+            "foreground": "#96D0FF",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/github-dark/github-dark-monaco.json
+++ b/themes/github-dark/github-dark-monaco.json
@@ -1,531 +1,527 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.activeBorder": "#f9826c",
-                "activityBar.background": "#24292e",
-                "activityBar.border": "#1b1f23",
-                "activityBar.foreground": "#e1e4e8",
-                "activityBar.inactiveForeground": "#6a737d",
-                "activityBarBadge.background": "#0366d6",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#044289",
-                "badge.foreground": "#c8e1ff",
-                "breadcrumb.activeSelectionForeground": "#d1d5da",
-                "breadcrumb.focusForeground": "#e1e4e8",
-                "breadcrumb.foreground": "#959da5",
-                "breadcrumbPicker.background": "#2b3036",
-                "button.background": "#176f2c",
-                "button.foreground": "#dcffe4",
-                "button.hoverBackground": "#22863a",
-                "button.secondaryBackground": "#444d56",
-                "button.secondaryForeground": "#ffffff",
-                "button.secondaryHoverBackground": "#586069",
-                "checkbox.background": "#444d56",
-                "checkbox.border": "#1b1f23",
-                "debugToolBar.background": "#2b3036",
-                "descriptionForeground": "#959da5",
-                "diffEditor.insertedTextBackground": "#28a74530",
-                "diffEditor.removedTextBackground": "#d73a4930",
-                "dropdown.background": "#2f363d",
-                "dropdown.border": "#1b1f23",
-                "dropdown.foreground": "#e1e4e8",
-                "dropdown.listBackground": "#24292e",
-                "editor.background": "#24292e",
-                "editor.findMatchBackground": "#ffd33d44",
-                "editor.findMatchHighlightBackground": "#ffd33d22",
-                "editor.focusedStackFrameHighlightBackground": "#2b6a3033",
-                "editor.foldBackground": "#58606915",
-                "editor.foreground": "#e1e4e8",
-                "editor.inactiveSelectionBackground": "#3392ff22",
-                "editor.lineHighlightBackground": "#2b3036",
-                "editor.linkedEditingBackground": "#3392ff22",
-                "editor.selectionBackground": "#3392ff44",
-                "editor.selectionHighlightBackground": "#17e5e633",
-                "editor.selectionHighlightBorder": "#17e5e600",
-                "editor.stackFrameHighlightBackground": "#c6902625",
-                "editor.wordHighlightBackground": "#17e5e600",
-                "editor.wordHighlightBorder": "#17e5e699",
-                "editor.wordHighlightStrongBackground": "#17e5e600",
-                "editor.wordHighlightStrongBorder": "#17e5e666",
-                "editorBracketHighlight.foreground1": "#79b8ff",
-                "editorBracketHighlight.foreground2": "#ffab70",
-                "editorBracketHighlight.foreground3": "#b392f0",
-                "editorBracketHighlight.foreground4": "#79b8ff",
-                "editorBracketHighlight.foreground5": "#ffab70",
-                "editorBracketHighlight.foreground6": "#b392f0",
-                "editorBracketMatch.background": "#17e5e650",
-                "editorBracketMatch.border": "#17e5e600",
-                "editorCursor.foreground": "#c8e1ff",
-                "editorError.foreground": "#f97583",
-                "editorGroup.border": "#1b1f23",
-                "editorGroupHeader.tabsBackground": "#1f2428",
-                "editorGroupHeader.tabsBorder": "#1b1f23",
-                "editorGutter.addedBackground": "#28a745",
-                "editorGutter.deletedBackground": "#ea4a5a",
-                "editorGutter.modifiedBackground": "#2188ff",
-                "editorIndentGuide.activeBackground": "#444d56",
-                "editorIndentGuide.background": "#2f363d",
-                "editorLineNumber.activeForeground": "#e1e4e8",
-                "editorLineNumber.foreground": "#444d56",
-                "editorOverviewRuler.border": "#1b1f23",
-                "editorWarning.foreground": "#ffea7f",
-                "editorWhitespace.foreground": "#444d56",
-                "editorWidget.background": "#1f2428",
-                "errorForeground": "#f97583",
-                "focusBorder": "#005cc5",
-                "foreground": "#d1d5da",
-                "gitDecoration.addedResourceForeground": "#34d058",
-                "gitDecoration.conflictingResourceForeground": "#ffab70",
-                "gitDecoration.deletedResourceForeground": "#ea4a5a",
-                "gitDecoration.ignoredResourceForeground": "#6a737d",
-                "gitDecoration.modifiedResourceForeground": "#79b8ff",
-                "gitDecoration.submoduleResourceForeground": "#6a737d",
-                "gitDecoration.untrackedResourceForeground": "#34d058",
-                "input.background": "#2f363d",
-                "input.border": "#1b1f23",
-                "input.foreground": "#e1e4e8",
-                "input.placeholderForeground": "#959da5",
-                "list.activeSelectionBackground": "#39414a",
-                "list.activeSelectionForeground": "#e1e4e8",
-                "list.focusBackground": "#044289",
-                "list.hoverBackground": "#282e34",
-                "list.hoverForeground": "#e1e4e8",
-                "list.inactiveFocusBackground": "#1d2d3e",
-                "list.inactiveSelectionBackground": "#282e34",
-                "list.inactiveSelectionForeground": "#e1e4e8",
-                "notificationCenterHeader.background": "#24292e",
-                "notificationCenterHeader.foreground": "#959da5",
-                "notifications.background": "#2f363d",
-                "notifications.border": "#1b1f23",
-                "notifications.foreground": "#e1e4e8",
-                "notificationsErrorIcon.foreground": "#ea4a5a",
-                "notificationsInfoIcon.foreground": "#79b8ff",
-                "notificationsWarningIcon.foreground": "#ffab70",
-                "panel.background": "#1f2428",
-                "panel.border": "#1b1f23",
-                "panelInput.border": "#2f363d",
-                "panelTitle.activeBorder": "#f9826c",
-                "panelTitle.activeForeground": "#e1e4e8",
-                "panelTitle.inactiveForeground": "#959da5",
-                "peekViewEditor.background": "#1f242888",
-                "peekViewEditor.matchHighlightBackground": "#ffd33d33",
-                "peekViewResult.background": "#1f2428",
-                "peekViewResult.matchHighlightBackground": "#ffd33d33",
-                "pickerGroup.border": "#444d56",
-                "pickerGroup.foreground": "#e1e4e8",
-                "progressBar.background": "#0366d6",
-                "quickInput.background": "#24292e",
-                "quickInput.foreground": "#e1e4e8",
-                "scrollbar.shadow": "#00000088",
-                "scrollbarSlider.activeBackground": "#6a737d88",
-                "scrollbarSlider.background": "#6a737d33",
-                "scrollbarSlider.hoverBackground": "#6a737d44",
-                "settings.headerForeground": "#e1e4e8",
-                "settings.modifiedItemIndicator": "#0366d6",
-                "sideBar.background": "#1f2428",
-                "sideBar.border": "#1b1f23",
-                "sideBar.foreground": "#d1d5da",
-                "sideBarSectionHeader.background": "#1f2428",
-                "sideBarSectionHeader.border": "#1b1f23",
-                "sideBarSectionHeader.foreground": "#e1e4e8",
-                "sideBarTitle.foreground": "#e1e4e8",
-                "statusBar.background": "#24292e",
-                "statusBar.border": "#1b1f23",
-                "statusBar.debuggingBackground": "#931c06",
-                "statusBar.debuggingForeground": "#ffffff",
-                "statusBar.foreground": "#d1d5da",
-                "statusBar.noFolderBackground": "#24292e",
-                "statusBarItem.prominentBackground": "#282e34",
-                "statusBarItem.remoteBackground": "#24292e",
-                "statusBarItem.remoteForeground": "#d1d5da",
-                "tab.activeBackground": "#24292e",
-                "tab.activeBorder": "#24292e",
-                "tab.activeBorderTop": "#f9826c",
-                "tab.activeForeground": "#e1e4e8",
-                "tab.border": "#1b1f23",
-                "tab.hoverBackground": "#24292e",
-                "tab.inactiveBackground": "#1f2428",
-                "tab.inactiveForeground": "#959da5",
-                "tab.unfocusedActiveBorder": "#24292e",
-                "tab.unfocusedActiveBorderTop": "#1b1f23",
-                "tab.unfocusedHoverBackground": "#24292e",
-                "terminal.ansiBlack": "#586069",
-                "terminal.ansiBlue": "#2188ff",
-                "terminal.ansiBrightBlack": "#959da5",
-                "terminal.ansiBrightBlue": "#79b8ff",
-                "terminal.ansiBrightCyan": "#56d4dd",
-                "terminal.ansiBrightGreen": "#85e89d",
-                "terminal.ansiBrightMagenta": "#b392f0",
-                "terminal.ansiBrightRed": "#f97583",
-                "terminal.ansiBrightWhite": "#fafbfc",
-                "terminal.ansiBrightYellow": "#ffea7f",
-                "terminal.ansiCyan": "#39c5cf",
-                "terminal.ansiGreen": "#34d058",
-                "terminal.ansiMagenta": "#b392f0",
-                "terminal.ansiRed": "#ea4a5a",
-                "terminal.ansiWhite": "#d1d5da",
-                "terminal.ansiYellow": "#ffea7f",
-                "terminal.foreground": "#d1d5da",
-                "terminal.tab.activeBorder": "#f9826c",
-                "terminalCursor.background": "#586069",
-                "terminalCursor.foreground": "#79b8ff",
-                "textBlockQuote.background": "#24292e",
-                "textBlockQuote.border": "#444d56",
-                "textCodeBlock.background": "#2f363d",
-                "textLink.activeForeground": "#c8e1ff",
-                "textLink.foreground": "#79b8ff",
-                "textPreformat.foreground": "#d1d5da",
-                "textSeparator.foreground": "#586069",
-                "titleBar.activeBackground": "#24292e",
-                "titleBar.activeForeground": "#e1e4e8",
-                "titleBar.border": "#1b1f23",
-                "titleBar.inactiveBackground": "#1f2428",
-                "titleBar.inactiveForeground": "#959da5",
-                "tree.indentGuidesStroke": "#2f363d"
-            },
-            "rules": [
-                {
-                    "foreground": "#6A737D",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#6A737D",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#6A737D",
-                    "token": "string.comment"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "entity.name.constant"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#B392F0",
-                    "token": "entity"
-                },
-                {
-                    "foreground": "#B392F0",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "token": "variable.parameter.function"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#F97583",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#F97583",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#F97583",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "token": "storage.modifier.package"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#9ECBFF",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#9ECBFF",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#9ECBFF",
-                    "token": "string punctuation.section.embedded source"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "meta.property-name"
-                },
-                {
-                    "foreground": "#FFAB70",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "fontStyle": "italic",
-                    "token": "invalid.broken"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "fontStyle": "italic",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "fontStyle": "italic",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "fontStyle": "italic",
-                    "token": "invalid.unimplemented"
-                },
-                {
-                    "foreground": "#24292E",
-                    "background": "#F97583",
-                    "fontStyle": "italic underline",
-                    "token": "carriage-return"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "token": "message.error"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "string variable"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "source.regexp"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "string.regexp.character-class"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "string.regexp source.ruby.embedded"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "token": "string.regexp string.regexp.arbitrary-repitition"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "fontStyle": "bold",
-                    "token": "string.regexp constant.character.escape"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "meta.module-reference"
-                },
-                {
-                    "foreground": "#FFAB70",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "fontStyle": "bold",
-                    "token": "markup.heading entity.name"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#E1E4E8",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "background": "#86181D",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "background": "#86181D",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "background": "#86181D",
-                    "token": "punctuation.definition.deleted"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "background": "#144620",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "background": "#144620",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#85E89D",
-                    "background": "#144620",
-                    "token": "punctuation.definition.inserted"
-                },
-                {
-                    "foreground": "#FFAB70",
-                    "background": "#C24E00",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#FFAB70",
-                    "background": "#C24E00",
-                    "token": "punctuation.definition.changed"
-                },
-                {
-                    "foreground": "#2F363D",
-                    "background": "#79B8FF",
-                    "token": "markup.ignored"
-                },
-                {
-                    "foreground": "#2F363D",
-                    "background": "#79B8FF",
-                    "token": "markup.untracked"
-                },
-                {
-                    "foreground": "#B392F0",
-                    "fontStyle": "bold",
-                    "token": "meta.diff.range"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#79B8FF",
-                    "token": "meta.output"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.tag"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.curly"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.round"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.square"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.angle"
-                },
-                {
-                    "foreground": "#D1D5DA",
-                    "token": "brackethighlighter.quote"
-                },
-                {
-                    "foreground": "#FDAEB7",
-                    "token": "brackethighlighter.unmatched"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "fontStyle": "underline",
-                    "token": "constant.other.reference.link"
-                },
-                {
-                    "foreground": "#DBEDFF",
-                    "fontStyle": "underline",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.activeBorder": "#f9826c",
+        "activityBar.background": "#24292e",
+        "activityBar.border": "#1b1f23",
+        "activityBar.foreground": "#e1e4e8",
+        "activityBar.inactiveForeground": "#6a737d",
+        "activityBarBadge.background": "#0366d6",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#044289",
+        "badge.foreground": "#c8e1ff",
+        "breadcrumb.activeSelectionForeground": "#d1d5da",
+        "breadcrumb.focusForeground": "#e1e4e8",
+        "breadcrumb.foreground": "#959da5",
+        "breadcrumbPicker.background": "#2b3036",
+        "button.background": "#176f2c",
+        "button.foreground": "#dcffe4",
+        "button.hoverBackground": "#22863a",
+        "button.secondaryBackground": "#444d56",
+        "button.secondaryForeground": "#ffffff",
+        "button.secondaryHoverBackground": "#586069",
+        "checkbox.background": "#444d56",
+        "checkbox.border": "#1b1f23",
+        "debugToolBar.background": "#2b3036",
+        "descriptionForeground": "#959da5",
+        "diffEditor.insertedTextBackground": "#28a74530",
+        "diffEditor.removedTextBackground": "#d73a4930",
+        "dropdown.background": "#2f363d",
+        "dropdown.border": "#1b1f23",
+        "dropdown.foreground": "#e1e4e8",
+        "dropdown.listBackground": "#24292e",
+        "editor.background": "#24292e",
+        "editor.findMatchBackground": "#ffd33d44",
+        "editor.findMatchHighlightBackground": "#ffd33d22",
+        "editor.focusedStackFrameHighlightBackground": "#2b6a3033",
+        "editor.foldBackground": "#58606915",
+        "editor.foreground": "#e1e4e8",
+        "editor.inactiveSelectionBackground": "#3392ff22",
+        "editor.lineHighlightBackground": "#2b3036",
+        "editor.linkedEditingBackground": "#3392ff22",
+        "editor.selectionBackground": "#3392ff44",
+        "editor.selectionHighlightBackground": "#17e5e633",
+        "editor.selectionHighlightBorder": "#17e5e600",
+        "editor.stackFrameHighlightBackground": "#c6902625",
+        "editor.wordHighlightBackground": "#17e5e600",
+        "editor.wordHighlightBorder": "#17e5e699",
+        "editor.wordHighlightStrongBackground": "#17e5e600",
+        "editor.wordHighlightStrongBorder": "#17e5e666",
+        "editorBracketHighlight.foreground1": "#79b8ff",
+        "editorBracketHighlight.foreground2": "#ffab70",
+        "editorBracketHighlight.foreground3": "#b392f0",
+        "editorBracketHighlight.foreground4": "#79b8ff",
+        "editorBracketHighlight.foreground5": "#ffab70",
+        "editorBracketHighlight.foreground6": "#b392f0",
+        "editorBracketMatch.background": "#17e5e650",
+        "editorBracketMatch.border": "#17e5e600",
+        "editorCursor.foreground": "#c8e1ff",
+        "editorError.foreground": "#f97583",
+        "editorGroup.border": "#1b1f23",
+        "editorGroupHeader.tabsBackground": "#1f2428",
+        "editorGroupHeader.tabsBorder": "#1b1f23",
+        "editorGutter.addedBackground": "#28a745",
+        "editorGutter.deletedBackground": "#ea4a5a",
+        "editorGutter.modifiedBackground": "#2188ff",
+        "editorIndentGuide.activeBackground": "#444d56",
+        "editorIndentGuide.background": "#2f363d",
+        "editorLineNumber.activeForeground": "#e1e4e8",
+        "editorLineNumber.foreground": "#444d56",
+        "editorOverviewRuler.border": "#1b1f23",
+        "editorWarning.foreground": "#ffea7f",
+        "editorWhitespace.foreground": "#444d56",
+        "editorWidget.background": "#1f2428",
+        "errorForeground": "#f97583",
+        "focusBorder": "#005cc5",
+        "foreground": "#d1d5da",
+        "gitDecoration.addedResourceForeground": "#34d058",
+        "gitDecoration.conflictingResourceForeground": "#ffab70",
+        "gitDecoration.deletedResourceForeground": "#ea4a5a",
+        "gitDecoration.ignoredResourceForeground": "#6a737d",
+        "gitDecoration.modifiedResourceForeground": "#79b8ff",
+        "gitDecoration.submoduleResourceForeground": "#6a737d",
+        "gitDecoration.untrackedResourceForeground": "#34d058",
+        "input.background": "#2f363d",
+        "input.border": "#1b1f23",
+        "input.foreground": "#e1e4e8",
+        "input.placeholderForeground": "#959da5",
+        "list.activeSelectionBackground": "#39414a",
+        "list.activeSelectionForeground": "#e1e4e8",
+        "list.focusBackground": "#044289",
+        "list.hoverBackground": "#282e34",
+        "list.hoverForeground": "#e1e4e8",
+        "list.inactiveFocusBackground": "#1d2d3e",
+        "list.inactiveSelectionBackground": "#282e34",
+        "list.inactiveSelectionForeground": "#e1e4e8",
+        "notificationCenterHeader.background": "#24292e",
+        "notificationCenterHeader.foreground": "#959da5",
+        "notifications.background": "#2f363d",
+        "notifications.border": "#1b1f23",
+        "notifications.foreground": "#e1e4e8",
+        "notificationsErrorIcon.foreground": "#ea4a5a",
+        "notificationsInfoIcon.foreground": "#79b8ff",
+        "notificationsWarningIcon.foreground": "#ffab70",
+        "panel.background": "#1f2428",
+        "panel.border": "#1b1f23",
+        "panelInput.border": "#2f363d",
+        "panelTitle.activeBorder": "#f9826c",
+        "panelTitle.activeForeground": "#e1e4e8",
+        "panelTitle.inactiveForeground": "#959da5",
+        "peekViewEditor.background": "#1f242888",
+        "peekViewEditor.matchHighlightBackground": "#ffd33d33",
+        "peekViewResult.background": "#1f2428",
+        "peekViewResult.matchHighlightBackground": "#ffd33d33",
+        "pickerGroup.border": "#444d56",
+        "pickerGroup.foreground": "#e1e4e8",
+        "progressBar.background": "#0366d6",
+        "quickInput.background": "#24292e",
+        "quickInput.foreground": "#e1e4e8",
+        "scrollbar.shadow": "#00000088",
+        "scrollbarSlider.activeBackground": "#6a737d88",
+        "scrollbarSlider.background": "#6a737d33",
+        "scrollbarSlider.hoverBackground": "#6a737d44",
+        "settings.headerForeground": "#e1e4e8",
+        "settings.modifiedItemIndicator": "#0366d6",
+        "sideBar.background": "#1f2428",
+        "sideBar.border": "#1b1f23",
+        "sideBar.foreground": "#d1d5da",
+        "sideBarSectionHeader.background": "#1f2428",
+        "sideBarSectionHeader.border": "#1b1f23",
+        "sideBarSectionHeader.foreground": "#e1e4e8",
+        "sideBarTitle.foreground": "#e1e4e8",
+        "statusBar.background": "#24292e",
+        "statusBar.border": "#1b1f23",
+        "statusBar.debuggingBackground": "#931c06",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.foreground": "#d1d5da",
+        "statusBar.noFolderBackground": "#24292e",
+        "statusBarItem.prominentBackground": "#282e34",
+        "statusBarItem.remoteBackground": "#24292e",
+        "statusBarItem.remoteForeground": "#d1d5da",
+        "tab.activeBackground": "#24292e",
+        "tab.activeBorder": "#24292e",
+        "tab.activeBorderTop": "#f9826c",
+        "tab.activeForeground": "#e1e4e8",
+        "tab.border": "#1b1f23",
+        "tab.hoverBackground": "#24292e",
+        "tab.inactiveBackground": "#1f2428",
+        "tab.inactiveForeground": "#959da5",
+        "tab.unfocusedActiveBorder": "#24292e",
+        "tab.unfocusedActiveBorderTop": "#1b1f23",
+        "tab.unfocusedHoverBackground": "#24292e",
+        "terminal.ansiBlack": "#586069",
+        "terminal.ansiBlue": "#2188ff",
+        "terminal.ansiBrightBlack": "#959da5",
+        "terminal.ansiBrightBlue": "#79b8ff",
+        "terminal.ansiBrightCyan": "#56d4dd",
+        "terminal.ansiBrightGreen": "#85e89d",
+        "terminal.ansiBrightMagenta": "#b392f0",
+        "terminal.ansiBrightRed": "#f97583",
+        "terminal.ansiBrightWhite": "#fafbfc",
+        "terminal.ansiBrightYellow": "#ffea7f",
+        "terminal.ansiCyan": "#39c5cf",
+        "terminal.ansiGreen": "#34d058",
+        "terminal.ansiMagenta": "#b392f0",
+        "terminal.ansiRed": "#ea4a5a",
+        "terminal.ansiWhite": "#d1d5da",
+        "terminal.ansiYellow": "#ffea7f",
+        "terminal.foreground": "#d1d5da",
+        "terminal.tab.activeBorder": "#f9826c",
+        "terminalCursor.background": "#586069",
+        "terminalCursor.foreground": "#79b8ff",
+        "textBlockQuote.background": "#24292e",
+        "textBlockQuote.border": "#444d56",
+        "textCodeBlock.background": "#2f363d",
+        "textLink.activeForeground": "#c8e1ff",
+        "textLink.foreground": "#79b8ff",
+        "textPreformat.foreground": "#d1d5da",
+        "textSeparator.foreground": "#586069",
+        "titleBar.activeBackground": "#24292e",
+        "titleBar.activeForeground": "#e1e4e8",
+        "titleBar.border": "#1b1f23",
+        "titleBar.inactiveBackground": "#1f2428",
+        "titleBar.inactiveForeground": "#959da5",
+        "tree.indentGuidesStroke": "#2f363d"
+    },
+    "rules": [
+        {
+            "foreground": "#6A737D",
+            "token": "comment"
+        },
+        {
+            "foreground": "#6A737D",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#6A737D",
+            "token": "string.comment"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "constant"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "entity.name.constant"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#B392F0",
+            "token": "entity"
+        },
+        {
+            "foreground": "#B392F0",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "token": "variable.parameter.function"
+        },
+        {
+            "foreground": "#85E89D",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#F97583",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#F97583",
+            "token": "storage"
+        },
+        {
+            "foreground": "#F97583",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "token": "storage.modifier.package"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "token": "storage.modifier.import"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#9ECBFF",
+            "token": "string"
+        },
+        {
+            "foreground": "#9ECBFF",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#9ECBFF",
+            "token": "string punctuation.section.embedded source"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "support"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "meta.property-name"
+        },
+        {
+            "foreground": "#FFAB70",
+            "token": "variable"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "fontStyle": "italic",
+            "token": "invalid.broken"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "fontStyle": "italic",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "fontStyle": "italic",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "fontStyle": "italic",
+            "token": "invalid.unimplemented"
+        },
+        {
+            "foreground": "#24292E",
+            "background": "#F97583",
+            "fontStyle": "italic underline",
+            "token": "carriage-return"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "token": "message.error"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "string variable"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "source.regexp"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "string.regexp.character-class"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "string.regexp source.ruby.embedded"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "token": "string.regexp string.regexp.arbitrary-repitition"
+        },
+        {
+            "foreground": "#85E89D",
+            "fontStyle": "bold",
+            "token": "string.regexp constant.character.escape"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "meta.module-reference"
+        },
+        {
+            "foreground": "#FFAB70",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#79B8FF",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#79B8FF",
+            "fontStyle": "bold",
+            "token": "markup.heading entity.name"
+        },
+        {
+            "foreground": "#85E89D",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#E1E4E8",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "background": "#86181D",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "background": "#86181D",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "background": "#86181D",
+            "token": "punctuation.definition.deleted"
+        },
+        {
+            "foreground": "#85E89D",
+            "background": "#144620",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#85E89D",
+            "background": "#144620",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#85E89D",
+            "background": "#144620",
+            "token": "punctuation.definition.inserted"
+        },
+        {
+            "foreground": "#FFAB70",
+            "background": "#C24E00",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#FFAB70",
+            "background": "#C24E00",
+            "token": "punctuation.definition.changed"
+        },
+        {
+            "foreground": "#2F363D",
+            "background": "#79B8FF",
+            "token": "markup.ignored"
+        },
+        {
+            "foreground": "#2F363D",
+            "background": "#79B8FF",
+            "token": "markup.untracked"
+        },
+        {
+            "foreground": "#B392F0",
+            "fontStyle": "bold",
+            "token": "meta.diff.range"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#79B8FF",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#79B8FF",
+            "token": "meta.output"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.tag"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.curly"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.round"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.square"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.angle"
+        },
+        {
+            "foreground": "#D1D5DA",
+            "token": "brackethighlighter.quote"
+        },
+        {
+            "foreground": "#FDAEB7",
+            "token": "brackethighlighter.unmatched"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "fontStyle": "underline",
+            "token": "constant.other.reference.link"
+        },
+        {
+            "foreground": "#DBEDFF",
+            "fontStyle": "underline",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/midnight-red/midnight-red-monaco.json
+++ b/themes/midnight-red/midnight-red-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "tomorrow-night-bright"
-    }
-}
+"tomorrow-night-bright"

--- a/themes/monoindustrial/monoindustrial-monaco.json
+++ b/themes/monoindustrial/monoindustrial-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "monoindustrial"
-    }
-}
+"monoindustrial"

--- a/themes/monokai-dimmed/monokai-dimmed-monaco.json
+++ b/themes/monokai-dimmed/monokai-dimmed-monaco.json
@@ -1,617 +1,613 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#353535",
-                "activityBar.foreground": "#ffffff",
-                "activityBarBadge.background": "#3655b5",
-                "button.background": "#565656",
-                "dropdown.background": "#525252",
-                "editor.background": "#1e1e1e",
-                "editor.foreground": "#c5c8c6",
-                "editor.lineHighlightBackground": "#303030",
-                "editor.selectionBackground": "#676b7180",
-                "editor.selectionHighlightBackground": "#575b6180",
-                "editor.wordHighlightBackground": "#4747a180",
-                "editor.wordHighlightStrongBackground": "#6767ce80",
-                "editorCursor.foreground": "#c07020",
-                "editorGroupHeader.tabsBackground": "#282828",
-                "editorIndentGuide.activeBackground": "#707057",
-                "editorIndentGuide.background": "#505037",
-                "editorLineNumber.activeForeground": "#949494",
-                "editorWhitespace.foreground": "#505037",
-                "focusBorder": "#3655b5",
-                "inputOption.activeBorder": "#3655b5",
-                "list.activeSelectionBackground": "#707070",
-                "list.highlightForeground": "#e58520",
-                "list.hoverBackground": "#444444",
-                "list.inactiveSelectionBackground": "#4e4e4e",
-                "menu.background": "#272727",
-                "menu.foreground": "#cccccc",
-                "minimap.selectionHighlight": "#676b7180",
-                "panelTitle.activeForeground": "#ffffff",
-                "peekView.border": "#3655b5",
-                "pickerGroup.foreground": "#b0b0b0",
-                "ports.iconRunningProcessForeground": "#cccccc",
-                "quickInputList.focusBackground": "#707070",
-                "sideBar.background": "#272727",
-                "sideBarSectionHeader.background": "#505050",
-                "statusBar.background": "#505050",
-                "statusBar.debuggingBackground": "#505050",
-                "statusBar.noFolderBackground": "#505050",
-                "statusBarItem.remoteBackground": "#3655b5",
-                "tab.border": "#303030",
-                "tab.inactiveBackground": "#404040",
-                "tab.inactiveForeground": "#d8d8d8",
-                "tab.lastPinnedBorder": "#505050",
-                "terminal.ansiBlack": "#1e1e1e",
-                "terminal.ansiBlue": "#6a7ec8",
-                "terminal.ansiBrightBlack": "#666666",
-                "terminal.ansiBrightBlue": "#819aff",
-                "terminal.ansiBrightCyan": "#66d9ef",
-                "terminal.ansiBrightGreen": "#a6e22e",
-                "terminal.ansiBrightMagenta": "#ae81ff",
-                "terminal.ansiBrightRed": "#f92672",
-                "terminal.ansiBrightWhite": "#f8f8f2",
-                "terminal.ansiBrightYellow": "#e2e22e",
-                "terminal.ansiCyan": "#56adbc",
-                "terminal.ansiGreen": "#86b42b",
-                "terminal.ansiMagenta": "#8c6bc8",
-                "terminal.ansiRed": "#c4265e",
-                "terminal.ansiWhite": "#e3e3dd",
-                "terminal.ansiYellow": "#b3b42b",
-                "terminal.inactiveSelectionBackground": "#676b7140",
-                "titleBar.activeBackground": "#505050"
-            },
-            "rules": [
-                {
-                    "foreground": "#C5C8C6",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#C5C8C6",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#C5C8C6",
-                    "token": "variable.legacy.builtin.python"
-                },
-                {
-                    "foreground": "#9A9B99",
-                    "fontStyle": "",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#D08442",
-                    "fontStyle": "",
-                    "token": "string source"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#408080",
-                    "fontStyle": "",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#8080FF",
-                    "fontStyle": "",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#8080FF",
-                    "fontStyle": "",
-                    "token": " constant.other"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#C7444A",
-                    "fontStyle": "",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#9B0000",
-                    "fontStyle": "",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#9B0000",
-                    "fontStyle": "",
-                    "token": " entity.name.type"
-                },
-                {
-                    "foreground": "#9B0000",
-                    "fontStyle": "",
-                    "token": " entity.name.namespace"
-                },
-                {
-                    "foreground": "#9B0000",
-                    "fontStyle": "",
-                    "token": " entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#C7444A",
-                    "fontStyle": "",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#CE6700",
-                    "fontStyle": "",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#676867",
-                    "fontStyle": "",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " variable.js"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " punctuation.separator.variable"
-                },
-                {
-                    "foreground": "#008200",
-                    "fontStyle": "",
-                    "token": "punctuation.section.embedded -(source string source punctuation.section.embedded)"
-                },
-                {
-                    "foreground": "#008200",
-                    "fontStyle": "",
-                    "token": " meta.brace.erb.html"
-                },
-                {
-                    "foreground": "#FF0B00",
-                    "fontStyle": "",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "variable.other.php"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " variable.other.normal"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "meta.function-call.object"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "variable.other.property"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.operator.new.cpp"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.operator.delete.cpp"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.other.using"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.other.directive.using"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "keyword.other.operator"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": "meta.doctype"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " meta.tag.sgml-declaration.doctype"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " meta.tag.sgml.doctype"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": "meta.tag.inline source"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " text.html.php.source"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "meta.tag.other"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": " entity.name.tag.style"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": " entity.name.tag.script"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": " meta.tag.block.script"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": " source.js.embedded punctuation.definition.tag.html"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": " source.css.embedded punctuation.definition.tag.html"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": " meta.tag punctuation.definition.string"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "meta.tag string -source -punctuation"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " text source text meta.tag string -punctuation"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "punctuation.section.embedded -(source string source punctuation.section.embedded)"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": " meta.brace.erb.html"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "token": "meta.toc-list.id"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": "string.quoted.double.html"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " punctuation.definition.string.begin.html"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " punctuation.definition.string.end.html"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " punctuation.definition.string.end.html source"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": " string.quoted.double.html source"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": "punctuation.definition.tag.html"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " punctuation.definition.tag.begin"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "fontStyle": "",
-                    "token": " punctuation.definition.tag.end"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "fontStyle": "",
-                    "token": "meta.selector.css entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#676867",
-                    "fontStyle": "",
-                    "token": "support.type.property-name.css"
-                },
-                {
-                    "foreground": "#C7444A",
-                    "fontStyle": "",
-                    "token": "meta.property-group support.constant.property-value.css"
-                },
-                {
-                    "foreground": "#C7444A",
-                    "fontStyle": "",
-                    "token": " meta.property-value support.constant.property-value.css"
-                },
-                {
-                    "foreground": "#CC555A",
-                    "token": "variable.language.js"
-                },
-                {
-                    "foreground": "#D08442",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#D08442",
-                    "token": "punctuation.section.embedded.coffee"
-                },
-                {
-                    "foreground": "#C5C8C6",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "meta.function-call.object.php"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "token": "punctuation.definition.string.end.php"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "token": " punctuation.definition.string.begin.php"
-                },
-                {
-                    "foreground": "#676867",
-                    "token": "source.php.embedded.line.html"
-                },
-                {
-                    "foreground": "#D08442",
-                    "fontStyle": "",
-                    "token": "punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#D08442",
-                    "fontStyle": "",
-                    "token": " punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "fontStyle": "",
-                    "token": "constant.other.symbol.ruby"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "variable.language.ruby"
-                },
-                {
-                    "foreground": "#D9B700",
-                    "fontStyle": "",
-                    "token": "keyword.other.special-method.ruby"
-                },
-                {
-                    "foreground": "#D08442",
-                    "token": "punctuation.section.embedded.begin.ruby"
-                },
-                {
-                    "foreground": "#D08442",
-                    "token": "punctuation.section.embedded.end.ruby"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "keyword.other.DML.sql"
-                },
-                {
-                    "foreground": "#E0EDDD",
-                    "fontStyle": "italic",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#E0EDDD",
-                    "fontStyle": "italic",
-                    "token": " meta.diff.header"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "fontStyle": "",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#219186",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#9872A2",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#9AA83A",
-                    "token": "markup.list"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#6089B4",
-                    "token": " markup.italic"
-                },
-                {
-                    "foreground": "#FF0080",
-                    "fontStyle": "",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#D0B344",
-                    "fontStyle": "",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.heading.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.quote.markdown"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold.markdown"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "token": "markup.underline.link.image.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic.markdown"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "token": "markup.list.unnumbered.markdown"
-                },
-                {
-                    "token": " markup.list.numbered.markdown"
-                },
-                {
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#C7444A",
-                    "token": "variable.language"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#353535",
+        "activityBar.foreground": "#ffffff",
+        "activityBarBadge.background": "#3655b5",
+        "button.background": "#565656",
+        "dropdown.background": "#525252",
+        "editor.background": "#1e1e1e",
+        "editor.foreground": "#c5c8c6",
+        "editor.lineHighlightBackground": "#303030",
+        "editor.selectionBackground": "#676b7180",
+        "editor.selectionHighlightBackground": "#575b6180",
+        "editor.wordHighlightBackground": "#4747a180",
+        "editor.wordHighlightStrongBackground": "#6767ce80",
+        "editorCursor.foreground": "#c07020",
+        "editorGroupHeader.tabsBackground": "#282828",
+        "editorIndentGuide.activeBackground": "#707057",
+        "editorIndentGuide.background": "#505037",
+        "editorLineNumber.activeForeground": "#949494",
+        "editorWhitespace.foreground": "#505037",
+        "focusBorder": "#3655b5",
+        "inputOption.activeBorder": "#3655b5",
+        "list.activeSelectionBackground": "#707070",
+        "list.highlightForeground": "#e58520",
+        "list.hoverBackground": "#444444",
+        "list.inactiveSelectionBackground": "#4e4e4e",
+        "menu.background": "#272727",
+        "menu.foreground": "#cccccc",
+        "minimap.selectionHighlight": "#676b7180",
+        "panelTitle.activeForeground": "#ffffff",
+        "peekView.border": "#3655b5",
+        "pickerGroup.foreground": "#b0b0b0",
+        "ports.iconRunningProcessForeground": "#cccccc",
+        "quickInputList.focusBackground": "#707070",
+        "sideBar.background": "#272727",
+        "sideBarSectionHeader.background": "#505050",
+        "statusBar.background": "#505050",
+        "statusBar.debuggingBackground": "#505050",
+        "statusBar.noFolderBackground": "#505050",
+        "statusBarItem.remoteBackground": "#3655b5",
+        "tab.border": "#303030",
+        "tab.inactiveBackground": "#404040",
+        "tab.inactiveForeground": "#d8d8d8",
+        "tab.lastPinnedBorder": "#505050",
+        "terminal.ansiBlack": "#1e1e1e",
+        "terminal.ansiBlue": "#6a7ec8",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#819aff",
+        "terminal.ansiBrightCyan": "#66d9ef",
+        "terminal.ansiBrightGreen": "#a6e22e",
+        "terminal.ansiBrightMagenta": "#ae81ff",
+        "terminal.ansiBrightRed": "#f92672",
+        "terminal.ansiBrightWhite": "#f8f8f2",
+        "terminal.ansiBrightYellow": "#e2e22e",
+        "terminal.ansiCyan": "#56adbc",
+        "terminal.ansiGreen": "#86b42b",
+        "terminal.ansiMagenta": "#8c6bc8",
+        "terminal.ansiRed": "#c4265e",
+        "terminal.ansiWhite": "#e3e3dd",
+        "terminal.ansiYellow": "#b3b42b",
+        "terminal.inactiveSelectionBackground": "#676b7140",
+        "titleBar.activeBackground": "#505050"
+    },
+    "rules": [
+        {
+            "foreground": "#C5C8C6",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#C5C8C6",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#C5C8C6",
+            "token": "variable.legacy.builtin.python"
+        },
+        {
+            "foreground": "#9A9B99",
+            "fontStyle": "",
+            "token": "comment"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": "string"
+        },
+        {
+            "foreground": "#D08442",
+            "fontStyle": "",
+            "token": "string source"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#408080",
+            "fontStyle": "",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#8080FF",
+            "fontStyle": "",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#8080FF",
+            "fontStyle": "",
+            "token": " constant.other"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#C7444A",
+            "fontStyle": "",
+            "token": "support"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "storage"
+        },
+        {
+            "foreground": "#9B0000",
+            "fontStyle": "",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#9B0000",
+            "fontStyle": "",
+            "token": " entity.name.type"
+        },
+        {
+            "foreground": "#9B0000",
+            "fontStyle": "",
+            "token": " entity.name.namespace"
+        },
+        {
+            "foreground": "#9B0000",
+            "fontStyle": "",
+            "token": " entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#C7444A",
+            "fontStyle": "",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#CE6700",
+            "fontStyle": "",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#676867",
+            "fontStyle": "",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " variable.js"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " punctuation.separator.variable"
+        },
+        {
+            "foreground": "#008200",
+            "fontStyle": "",
+            "token": "punctuation.section.embedded -(source string source punctuation.section.embedded)"
+        },
+        {
+            "foreground": "#008200",
+            "fontStyle": "",
+            "token": " meta.brace.erb.html"
+        },
+        {
+            "foreground": "#FF0B00",
+            "fontStyle": "",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "variable.other.php"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " variable.other.normal"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "meta.function-call.object"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "variable.other.property"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.operator.new.cpp"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.operator.delete.cpp"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.other.using"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.other.directive.using"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "keyword.other.operator"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": "meta.doctype"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " meta.tag.sgml-declaration.doctype"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " meta.tag.sgml.doctype"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": "meta.tag.inline source"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " text.html.php.source"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "meta.tag.other"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": " entity.name.tag.style"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": " entity.name.tag.script"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": " meta.tag.block.script"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": " source.js.embedded punctuation.definition.tag.html"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": " source.css.embedded punctuation.definition.tag.html"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": " meta.tag punctuation.definition.string"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "meta.tag string -source -punctuation"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " text source text meta.tag string -punctuation"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "punctuation.section.embedded -(source string source punctuation.section.embedded)"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": " meta.brace.erb.html"
+        },
+        {
+            "foreground": "#9AA83A",
+            "token": "meta.toc-list.id"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": "string.quoted.double.html"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " punctuation.definition.string.begin.html"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " punctuation.definition.string.end.html"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " punctuation.definition.string.end.html source"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": " string.quoted.double.html source"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": "punctuation.definition.tag.html"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " punctuation.definition.tag.begin"
+        },
+        {
+            "foreground": "#6089B4",
+            "fontStyle": "",
+            "token": " punctuation.definition.tag.end"
+        },
+        {
+            "foreground": "#9872A2",
+            "fontStyle": "",
+            "token": "meta.selector.css entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#676867",
+            "fontStyle": "",
+            "token": "support.type.property-name.css"
+        },
+        {
+            "foreground": "#C7444A",
+            "fontStyle": "",
+            "token": "meta.property-group support.constant.property-value.css"
+        },
+        {
+            "foreground": "#C7444A",
+            "fontStyle": "",
+            "token": " meta.property-value support.constant.property-value.css"
+        },
+        {
+            "foreground": "#CC555A",
+            "token": "variable.language.js"
+        },
+        {
+            "foreground": "#D08442",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#D08442",
+            "token": "punctuation.section.embedded.coffee"
+        },
+        {
+            "foreground": "#C5C8C6",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "meta.function-call.object.php"
+        },
+        {
+            "foreground": "#9AA83A",
+            "token": "punctuation.definition.string.end.php"
+        },
+        {
+            "foreground": "#9AA83A",
+            "token": " punctuation.definition.string.begin.php"
+        },
+        {
+            "foreground": "#676867",
+            "token": "source.php.embedded.line.html"
+        },
+        {
+            "foreground": "#D08442",
+            "fontStyle": "",
+            "token": "punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#D08442",
+            "fontStyle": "",
+            "token": " punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#9AA83A",
+            "fontStyle": "",
+            "token": "constant.other.symbol.ruby"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "variable.language.ruby"
+        },
+        {
+            "foreground": "#D9B700",
+            "fontStyle": "",
+            "token": "keyword.other.special-method.ruby"
+        },
+        {
+            "foreground": "#D08442",
+            "token": "punctuation.section.embedded.begin.ruby"
+        },
+        {
+            "foreground": "#D08442",
+            "token": "punctuation.section.embedded.end.ruby"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "keyword.other.DML.sql"
+        },
+        {
+            "foreground": "#E0EDDD",
+            "fontStyle": "italic",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#E0EDDD",
+            "fontStyle": "italic",
+            "token": " meta.diff.header"
+        },
+        {
+            "foreground": "#DC322F",
+            "fontStyle": "",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#219186",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#9872A2",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#9AA83A",
+            "token": "markup.list"
+        },
+        {
+            "foreground": "#6089B4",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#6089B4",
+            "token": " markup.italic"
+        },
+        {
+            "foreground": "#FF0080",
+            "fontStyle": "",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#D0B344",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#D0B344",
+            "fontStyle": "",
+            "token": "markup.heading.setext"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.heading.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.quote.markdown"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold.markdown"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "token": "markup.underline.link.image.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic.markdown"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "token": "markup.list.unnumbered.markdown"
+        },
+        {
+            "token": " markup.list.numbered.markdown"
+        },
+        {
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#C7444A",
+            "token": "variable.language"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/monokai/monokai-monaco.json
+++ b/themes/monokai/monokai-monaco.json
@@ -1,386 +1,382 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#272822",
-                "activityBar.foreground": "#f8f8f2",
-                "badge.background": "#75715e",
-                "badge.foreground": "#f8f8f2",
-                "button.background": "#75715e",
-                "debugToolBar.background": "#1e1f1c",
-                "diffEditor.insertedTextBackground": "#4b661680",
-                "diffEditor.removedTextBackground": "#90274a70",
-                "dropdown.background": "#414339",
-                "dropdown.listBackground": "#1e1f1c",
-                "editor.background": "#272822",
-                "editor.foreground": "#f8f8f2",
-                "editor.lineHighlightBackground": "#3e3d32",
-                "editor.selectionBackground": "#878b9180",
-                "editor.selectionHighlightBackground": "#575b6180",
-                "editor.wordHighlightBackground": "#4a4a7680",
-                "editor.wordHighlightStrongBackground": "#6a6a9680",
-                "editorCursor.foreground": "#f8f8f0",
-                "editorGroup.border": "#34352f",
-                "editorGroup.dropBackground": "#41433980",
-                "editorGroupHeader.tabsBackground": "#1e1f1c",
-                "editorHoverWidget.background": "#414339",
-                "editorHoverWidget.border": "#75715e",
-                "editorIndentGuide.activeBackground": "#767771",
-                "editorIndentGuide.background": "#464741",
-                "editorLineNumber.activeForeground": "#c2c2bf",
-                "editorLineNumber.foreground": "#90908a",
-                "editorSuggestWidget.background": "#272822",
-                "editorSuggestWidget.border": "#75715e",
-                "editorWhitespace.foreground": "#464741",
-                "editorWidget.background": "#1e1f1c",
-                "focusBorder": "#99947c",
-                "input.background": "#414339",
-                "inputOption.activeBorder": "#75715e",
-                "inputValidation.errorBackground": "#90274a",
-                "inputValidation.errorBorder": "#f92672",
-                "inputValidation.infoBackground": "#546190",
-                "inputValidation.infoBorder": "#819aff",
-                "inputValidation.warningBackground": "#848528",
-                "inputValidation.warningBorder": "#e2e22e",
-                "list.activeSelectionBackground": "#75715e",
-                "list.dropBackground": "#414339",
-                "list.highlightForeground": "#f8f8f2",
-                "list.hoverBackground": "#3e3d32",
-                "list.inactiveSelectionBackground": "#414339",
-                "menu.background": "#1e1f1c",
-                "menu.foreground": "#cccccc",
-                "minimap.selectionHighlight": "#878b9180",
-                "panel.border": "#414339",
-                "panelTitle.activeBorder": "#75715e",
-                "panelTitle.activeForeground": "#f8f8f2",
-                "panelTitle.inactiveForeground": "#75715e",
-                "peekView.border": "#75715e",
-                "peekViewEditor.background": "#272822",
-                "peekViewEditor.matchHighlightBackground": "#75715e",
-                "peekViewResult.background": "#1e1f1c",
-                "peekViewResult.matchHighlightBackground": "#75715e",
-                "peekViewResult.selectionBackground": "#414339",
-                "peekViewTitle.background": "#1e1f1c",
-                "pickerGroup.foreground": "#75715e",
-                "ports.iconRunningProcessForeground": "#ccccc7",
-                "progressBar.background": "#75715e",
-                "quickInputList.focusBackground": "#414339",
-                "selection.background": "#878b9180",
-                "settings.focusedRowBackground": "#4143395a",
-                "sideBar.background": "#1e1f1c",
-                "sideBarSectionHeader.background": "#272822",
-                "statusBar.background": "#414339",
-                "statusBar.debuggingBackground": "#75715e",
-                "statusBar.noFolderBackground": "#414339",
-                "statusBarItem.remoteBackground": "#ac6218",
-                "tab.border": "#1e1f1c",
-                "tab.inactiveBackground": "#34352f",
-                "tab.inactiveForeground": "#ccccc7",
-                "tab.lastPinnedBorder": "#414339",
-                "terminal.ansiBlack": "#333333",
-                "terminal.ansiBlue": "#6a7ec8",
-                "terminal.ansiBrightBlack": "#666666",
-                "terminal.ansiBrightBlue": "#819aff",
-                "terminal.ansiBrightCyan": "#66d9ef",
-                "terminal.ansiBrightGreen": "#a6e22e",
-                "terminal.ansiBrightMagenta": "#ae81ff",
-                "terminal.ansiBrightRed": "#f92672",
-                "terminal.ansiBrightWhite": "#f8f8f2",
-                "terminal.ansiBrightYellow": "#e2e22e",
-                "terminal.ansiCyan": "#56adbc",
-                "terminal.ansiGreen": "#86b42b",
-                "terminal.ansiMagenta": "#8c6bc8",
-                "terminal.ansiRed": "#c4265e",
-                "terminal.ansiWhite": "#e3e3dd",
-                "terminal.ansiYellow": "#b3b42b",
-                "titleBar.activeBackground": "#1e1f1c",
-                "widget.shadow": "#00000098"
-            },
-            "rules": [
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "string meta.image.inline.markdown"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "variable.legacy.builtin.python"
-                },
-                {
-                    "foreground": "#88846F",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#F92672",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#F92672",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": " constant.other"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "fontStyle": "",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#F92672",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#F92672",
-                    "fontStyle": "",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "fontStyle": "italic",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "underline",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "underline",
-                    "token": " entity.name.class"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "underline",
-                    "token": " entity.name.namespace"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "underline",
-                    "token": " entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "italic underline",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#FD971F",
-                    "fontStyle": "italic",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#F92672",
-                    "fontStyle": "",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "fontStyle": "",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "fontStyle": "",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "fontStyle": "italic",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "fontStyle": "italic",
-                    "token": " support.class"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#F44747",
-                    "fontStyle": "",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#CFCFC2",
-                    "token": "meta.structure.dictionary.json string.quoted.double.json"
-                },
-                {
-                    "foreground": "#75715E",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#75715E",
-                    "token": " meta.diff.header"
-                },
-                {
-                    "foreground": "#F92672",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#AE81FFA0",
-                    "token": "constant.numeric.line-number.find-in-files - match"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "entity.name.filename.find-in-files"
-                },
-                {
-                    "foreground": "#F92672",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "markup.list"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#66D9EF",
-                    "token": " markup.italic"
-                },
-                {
-                    "foreground": "#FD971F",
-                    "fontStyle": "",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "fontStyle": "bold",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.heading.markdown"
-                },
-                {
-                    "foreground": "#75715E",
-                    "fontStyle": "italic",
-                    "token": "markup.quote.markdown"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold.markdown"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#AE81FF",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "#E6DB74",
-                    "token": "markup.underline.link.image.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic.markdown"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": "markup.list.unnumbered.markdown"
-                },
-                {
-                    "foreground": "#F8F8F2",
-                    "token": " markup.list.numbered.markdown"
-                },
-                {
-                    "foreground": "#A6E22E",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#FD971F",
-                    "token": "variable.language"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#272822",
+        "activityBar.foreground": "#f8f8f2",
+        "badge.background": "#75715e",
+        "badge.foreground": "#f8f8f2",
+        "button.background": "#75715e",
+        "debugToolBar.background": "#1e1f1c",
+        "diffEditor.insertedTextBackground": "#4b661680",
+        "diffEditor.removedTextBackground": "#90274a70",
+        "dropdown.background": "#414339",
+        "dropdown.listBackground": "#1e1f1c",
+        "editor.background": "#272822",
+        "editor.foreground": "#f8f8f2",
+        "editor.lineHighlightBackground": "#3e3d32",
+        "editor.selectionBackground": "#878b9180",
+        "editor.selectionHighlightBackground": "#575b6180",
+        "editor.wordHighlightBackground": "#4a4a7680",
+        "editor.wordHighlightStrongBackground": "#6a6a9680",
+        "editorCursor.foreground": "#f8f8f0",
+        "editorGroup.border": "#34352f",
+        "editorGroup.dropBackground": "#41433980",
+        "editorGroupHeader.tabsBackground": "#1e1f1c",
+        "editorHoverWidget.background": "#414339",
+        "editorHoverWidget.border": "#75715e",
+        "editorIndentGuide.activeBackground": "#767771",
+        "editorIndentGuide.background": "#464741",
+        "editorLineNumber.activeForeground": "#c2c2bf",
+        "editorLineNumber.foreground": "#90908a",
+        "editorSuggestWidget.background": "#272822",
+        "editorSuggestWidget.border": "#75715e",
+        "editorWhitespace.foreground": "#464741",
+        "editorWidget.background": "#1e1f1c",
+        "focusBorder": "#99947c",
+        "input.background": "#414339",
+        "inputOption.activeBorder": "#75715e",
+        "inputValidation.errorBackground": "#90274a",
+        "inputValidation.errorBorder": "#f92672",
+        "inputValidation.infoBackground": "#546190",
+        "inputValidation.infoBorder": "#819aff",
+        "inputValidation.warningBackground": "#848528",
+        "inputValidation.warningBorder": "#e2e22e",
+        "list.activeSelectionBackground": "#75715e",
+        "list.dropBackground": "#414339",
+        "list.highlightForeground": "#f8f8f2",
+        "list.hoverBackground": "#3e3d32",
+        "list.inactiveSelectionBackground": "#414339",
+        "menu.background": "#1e1f1c",
+        "menu.foreground": "#cccccc",
+        "minimap.selectionHighlight": "#878b9180",
+        "panel.border": "#414339",
+        "panelTitle.activeBorder": "#75715e",
+        "panelTitle.activeForeground": "#f8f8f2",
+        "panelTitle.inactiveForeground": "#75715e",
+        "peekView.border": "#75715e",
+        "peekViewEditor.background": "#272822",
+        "peekViewEditor.matchHighlightBackground": "#75715e",
+        "peekViewResult.background": "#1e1f1c",
+        "peekViewResult.matchHighlightBackground": "#75715e",
+        "peekViewResult.selectionBackground": "#414339",
+        "peekViewTitle.background": "#1e1f1c",
+        "pickerGroup.foreground": "#75715e",
+        "ports.iconRunningProcessForeground": "#ccccc7",
+        "progressBar.background": "#75715e",
+        "quickInputList.focusBackground": "#414339",
+        "selection.background": "#878b9180",
+        "settings.focusedRowBackground": "#4143395a",
+        "sideBar.background": "#1e1f1c",
+        "sideBarSectionHeader.background": "#272822",
+        "statusBar.background": "#414339",
+        "statusBar.debuggingBackground": "#75715e",
+        "statusBar.noFolderBackground": "#414339",
+        "statusBarItem.remoteBackground": "#ac6218",
+        "tab.border": "#1e1f1c",
+        "tab.inactiveBackground": "#34352f",
+        "tab.inactiveForeground": "#ccccc7",
+        "tab.lastPinnedBorder": "#414339",
+        "terminal.ansiBlack": "#333333",
+        "terminal.ansiBlue": "#6a7ec8",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#819aff",
+        "terminal.ansiBrightCyan": "#66d9ef",
+        "terminal.ansiBrightGreen": "#a6e22e",
+        "terminal.ansiBrightMagenta": "#ae81ff",
+        "terminal.ansiBrightRed": "#f92672",
+        "terminal.ansiBrightWhite": "#f8f8f2",
+        "terminal.ansiBrightYellow": "#e2e22e",
+        "terminal.ansiCyan": "#56adbc",
+        "terminal.ansiGreen": "#86b42b",
+        "terminal.ansiMagenta": "#8c6bc8",
+        "terminal.ansiRed": "#c4265e",
+        "terminal.ansiWhite": "#e3e3dd",
+        "terminal.ansiYellow": "#b3b42b",
+        "titleBar.activeBackground": "#1e1f1c",
+        "widget.shadow": "#00000098"
+    },
+    "rules": [
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "string meta.image.inline.markdown"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "variable.legacy.builtin.python"
+        },
+        {
+            "foreground": "#88846F",
+            "token": "comment"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "string"
+        },
+        {
+            "foreground": "#F92672",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#F92672",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": " constant.other"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "fontStyle": "",
+            "token": "variable"
+        },
+        {
+            "foreground": "#F92672",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#F92672",
+            "fontStyle": "",
+            "token": "storage"
+        },
+        {
+            "foreground": "#66D9EF",
+            "fontStyle": "italic",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "underline",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "underline",
+            "token": " entity.name.class"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "underline",
+            "token": " entity.name.namespace"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "underline",
+            "token": " entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "italic underline",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#FD971F",
+            "fontStyle": "italic",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#F92672",
+            "fontStyle": "",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#66D9EF",
+            "fontStyle": "",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#66D9EF",
+            "fontStyle": "",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#66D9EF",
+            "fontStyle": "italic",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#66D9EF",
+            "fontStyle": "italic",
+            "token": " support.class"
+        },
+        {
+            "fontStyle": "",
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#F44747",
+            "fontStyle": "",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#CFCFC2",
+            "token": "meta.structure.dictionary.json string.quoted.double.json"
+        },
+        {
+            "foreground": "#75715E",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#75715E",
+            "token": " meta.diff.header"
+        },
+        {
+            "foreground": "#F92672",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#A6E22E",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#AE81FFA0",
+            "token": "constant.numeric.line-number.find-in-files - match"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "entity.name.filename.find-in-files"
+        },
+        {
+            "foreground": "#F92672",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "markup.list"
+        },
+        {
+            "foreground": "#66D9EF",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#66D9EF",
+            "token": " markup.italic"
+        },
+        {
+            "foreground": "#FD971F",
+            "fontStyle": "",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#A6E22E",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#A6E22E",
+            "fontStyle": "bold",
+            "token": "markup.heading.setext"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.heading.markdown"
+        },
+        {
+            "foreground": "#75715E",
+            "fontStyle": "italic",
+            "token": "markup.quote.markdown"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold.markdown"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#AE81FF",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "foreground": "#E6DB74",
+            "token": "markup.underline.link.image.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic.markdown"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": "markup.list.unnumbered.markdown"
+        },
+        {
+            "foreground": "#F8F8F2",
+            "token": " markup.list.numbered.markdown"
+        },
+        {
+            "foreground": "#A6E22E",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#FD971F",
+            "token": "variable.language"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/noctis/noctis-monaco.json
+++ b/themes/noctis/noctis-monaco.json
@@ -1,3010 +1,3006 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.activeBackground": "#40d4e733",
-                "activityBar.activeBorder": "#40d4e7",
-                "activityBar.background": "#052529",
-                "activityBar.border": "#0f1415",
-                "activityBar.foreground": "#169fb1",
-                "activityBar.inactiveForeground": "#169fb177",
-                "activityBarBadge.background": "#40d4e7",
-                "activityBarBadge.foreground": "#0f1415",
-                "badge.background": "#40d4e7",
-                "badge.foreground": "#0f1415",
-                "breadcrumb.activeSelectionForeground": "#ebfdff",
-                "breadcrumb.background": "#052529",
-                "breadcrumb.focusForeground": "#40d4e7",
-                "breadcrumb.foreground": "#87a7ab",
-                "breadcrumbPicker.background": "#073940",
-                "button.background": "#009999",
-                "button.foreground": "#ebfdff",
-                "button.hoverBackground": "#00cccc",
-                "debugExceptionWidget.background": "#041d20",
-                "debugExceptionWidget.border": "#16a3b6",
-                "debugToolBar.background": "#041d20",
-                "descriptionForeground": "#929ea0",
-                "diffEditor.insertedTextBackground": "#16b67327",
-                "diffEditor.removedTextBackground": "#e6653341",
-                "dropdown.background": "#073940",
-                "dropdown.border": "#073940",
-                "dropdown.foreground": "#87a7ab",
-                "editor.background": "#052529",
-                "editor.findMatchBackground": "#40bf6a11",
-                "editor.findMatchHighlightBackground": "#0e667179",
-                "editor.findRangeHighlightBackground": "#49e9a633",
-                "editor.foreground": "#b2cacd",
-                "editor.hoverHighlightBackground": "#169fb13f",
-                "editor.inactiveSelectionBackground": "#0e657155",
-                "editor.lineHighlightBackground": "#083d44ee",
-                "editor.lineHighlightBorder": "#083d44",
-                "editor.rangeHighlightBackground": "#083d44a1",
-                "editor.selectionBackground": "#169fb144",
-                "editor.selectionHighlightBackground": "#49ace944",
-                "editor.snippetFinalTabstopHighlightBackground": "#03181b",
-                "editor.snippetFinalTabstopHighlightBorder": "#042124",
-                "editor.snippetTabstopHighlightBackground": "#03181b",
-                "editor.snippetTabstopHighlightBorder": "#042124",
-                "editor.wordHighlightBackground": "#e4b78133",
-                "editor.wordHighlightStrongBackground": "#cc990033",
-                "editorBracketMatch.background": "#169fb122",
-                "editorBracketMatch.border": "#169fb1",
-                "editorCodeLens.foreground": "#507b95",
-                "editorCursor.foreground": "#85efff",
-                "editorError.border": "#052529",
-                "editorError.foreground": "#e34e1c",
-                "editorGroup.border": "#0f1415",
-                "editorGroup.dropBackground": "#5f6b6d33",
-                "editorGroup.emptyBackground": "#5f6b6d33",
-                "editorGroupHeader.noTabsBackground": "#062e32",
-                "editorGroupHeader.tabsBackground": "#062e32",
-                "editorGroupHeader.tabsBorder": "#062e32",
-                "editorGutter.addedBackground": "#8ce99a",
-                "editorGutter.background": "#052529",
-                "editorGutter.deletedBackground": "#e34e1c",
-                "editorGutter.modifiedBackground": "#e0c184",
-                "editorHint.border": "#49e9a600",
-                "editorHint.foreground": "#49e9a6",
-                "editorHoverWidget.background": "#073940",
-                "editorHoverWidget.border": "#0f1415",
-                "editorIndentGuide.activeBackground": "#3e6f74",
-                "editorIndentGuide.background": "#223b3f",
-                "editorInfo.border": "#052529",
-                "editorInfo.foreground": "#40d4e7",
-                "editorLineNumber.activeForeground": "#169fb1",
-                "editorLineNumber.foreground": "#4e6b6e",
-                "editorLink.activeForeground": "#14a5ff",
-                "editorMarkerNavigation.background": "#3a3a5e29",
-                "editorMarkerNavigationError.background": "#e34e1c",
-                "editorMarkerNavigationWarning.background": "#e69533",
-                "editorOverviewRuler.border": "#052529",
-                "editorOverviewRuler.commonContentForeground": "#ffc18044",
-                "editorOverviewRuler.currentContentForeground": "#85f1ff44",
-                "editorOverviewRuler.incomingContentForeground": "#9d92f244",
-                "editorRuler.foreground": "#29484c",
-                "editorSuggestWidget.background": "#073940",
-                "editorSuggestWidget.border": "#0f1415",
-                "editorSuggestWidget.foreground": "#87a7ab",
-                "editorSuggestWidget.highlightForeground": "#40d4e7",
-                "editorSuggestWidget.selectedBackground": "#0e6671",
-                "editorWarning.border": "#052529",
-                "editorWarning.foreground": "#e69533",
-                "editorWhitespace.foreground": "#ffffff21",
-                "editorWidget.background": "#073940",
-                "editorWidget.border": "#0f1415",
-                "errorForeground": "#e34e1c",
-                "extensionButton.prominentBackground": "#009999",
-                "extensionButton.prominentForeground": "#e5f5f5",
-                "extensionButton.prominentHoverBackground": "#00cccc",
-                "focusBorder": "#073940",
-                "foreground": "#b2cacd",
-                "gitDecoration.addedResourceForeground": "#16b673",
-                "gitDecoration.conflictingResourceForeground": "#e4b781",
-                "gitDecoration.deletedResourceForeground": "#e34e1c",
-                "gitDecoration.ignoredResourceForeground": "#5b858b",
-                "gitDecoration.modifiedResourceForeground": "#49e9a6",
-                "gitDecoration.untrackedResourceForeground": "#40d4e7",
-                "input.background": "#052529",
-                "input.border": "#073940",
-                "input.foreground": "#cdd3de",
-                "input.placeholderForeground": "#87a7ab",
-                "inputOption.activeBorder": "#169fb1",
-                "inputValidation.errorBackground": "#501502ee",
-                "inputValidation.errorBorder": "#691c02",
-                "inputValidation.errorForeground": "#ff4000",
-                "inputValidation.infoBackground": "#0f6e7bee",
-                "inputValidation.infoBorder": "#148f9f",
-                "inputValidation.infoForeground": "#40d4e7",
-                "inputValidation.warningBackground": "#82694acc",
-                "inputValidation.warningBorder": "#a88457",
-                "inputValidation.warningForeground": "#e69533",
-                "list.activeSelectionBackground": "#0e6671",
-                "list.activeSelectionForeground": "#ebfdff",
-                "list.dropBackground": "#00404d",
-                "list.errorForeground": "#e34e1c",
-                "list.focusBackground": "#00404d",
-                "list.focusForeground": "#ebfdff",
-                "list.highlightForeground": "#40d4e7",
-                "list.hoverBackground": "#0b515b",
-                "list.hoverForeground": "#ebfdff",
-                "list.inactiveFocusBackground": "#062d32",
-                "list.inactiveSelectionBackground": "#07353b",
-                "list.inactiveSelectionForeground": "#b2cacd",
-                "list.warningForeground": "#ffa487",
-                "listFilterWidget.background": "#00404d",
-                "listFilterWidget.noMatchesOutline": "#e34e1c",
-                "listFilterWidget.outline": "#49e9a6",
-                "menu.background": "#073940",
-                "menu.foreground": "#87a7ab",
-                "menu.selectionBackground": "#0b515b",
-                "menu.selectionBorder": "#0b515b",
-                "menu.selectionForeground": "#40d4e7",
-                "menu.separatorBackground": "#40d4e7",
-                "menubar.selectionBackground": "#0b515b",
-                "menubar.selectionBorder": "#0b515b",
-                "menubar.selectionForeground": "#40d4e7",
-                "merge.border": "#05252900",
-                "merge.commonContentBackground": "#ffc18022",
-                "merge.commonHeaderBackground": "#ffc18044",
-                "merge.currentContentBackground": "#85f1ff22",
-                "merge.currentHeaderBackground": "#85f1ff44",
-                "merge.incomingContentBackground": "#9d92f222",
-                "merge.incomingHeaderBackground": "#9d92f244",
-                "minimap.background": "#05252999",
-                "minimap.errorHighlight": "#e34e1cee",
-                "minimap.findMatchHighlight": "#49d6e9ee",
-                "minimap.warningHighlight": "#e69533ee",
-                "minimapGutter.addedBackground": "#16b673",
-                "minimapGutter.deletedBackground": "#e34e1c",
-                "minimapGutter.modifiedBackground": "#49e9a6",
-                "notificationCenter.border": "#073940",
-                "notificationCenterHeader.background": "#073940",
-                "notificationCenterHeader.foreground": "#87a7ab",
-                "notificationLink.foreground": "#87a7ab",
-                "notificationToast.border": "#073940",
-                "notifications.background": "#073940",
-                "notifications.border": "#073940",
-                "notifications.foreground": "#cdd3de",
-                "panel.background": "#03191b",
-                "panel.border": "#0e6671",
-                "panelTitle.activeBorder": "#0e6671",
-                "panelTitle.activeForeground": "#40d4e7",
-                "panelTitle.inactiveForeground": "#87a7ab",
-                "peekView.border": "#169fb1",
-                "peekViewEditor.background": "#002124",
-                "peekViewEditor.matchHighlightBackground": "#00718079",
-                "peekViewEditor.matchHighlightBorder": "#007180cc",
-                "peekViewEditorGutter.background": "#002124",
-                "peekViewResult.background": "#041d20",
-                "peekViewResult.fileForeground": "#e4b781",
-                "peekViewResult.lineForeground": "#87a7ab",
-                "peekViewResult.matchHighlightBackground": "#073940",
-                "peekViewResult.selectionBackground": "#073940",
-                "peekViewResult.selectionForeground": "#87a7ab",
-                "peekViewTitle.background": "#041d20",
-                "peekViewTitleDescription.foreground": "#87a7ab",
-                "peekViewTitleLabel.foreground": "#e4b781",
-                "pickerGroup.border": "#0e6671",
-                "pickerGroup.foreground": "#169fb1",
-                "progressBar.background": "#40d4e7",
-                "scrollbar.shadow": "#00000044",
-                "scrollbarSlider.activeBackground": "#169fb1ad",
-                "scrollbarSlider.background": "#6a90955b",
-                "scrollbarSlider.hoverBackground": "#169fb162",
-                "selection.background": "#107684",
-                "settings.checkboxBackground": "#073940",
-                "settings.checkboxBorder": "#073940",
-                "settings.checkboxForeground": "#00cccc",
-                "settings.dropdownBackground": "#073940",
-                "settings.dropdownBorder": "#073940",
-                "settings.dropdownForeground": "#00cccc",
-                "settings.dropdownListBorder": "#0e657188",
-                "settings.headerForeground": "#b2cacd",
-                "settings.modifiedItemIndicator": "#15ac31",
-                "settings.numberInputBackground": "#041d20",
-                "settings.numberInputBorder": "#041d20",
-                "settings.numberInputForeground": "#7060eb",
-                "settings.textInputBackground": "#073940",
-                "settings.textInputBorder": "#073940",
-                "settings.textInputForeground": "#00cccc",
-                "sideBar.background": "#041d20",
-                "sideBar.border": "#0f1415",
-                "sideBar.dropBackground": "#041d20",
-                "sideBar.foreground": "#a5b5b5",
-                "sideBarSectionHeader.background": "#083d44",
-                "sideBarSectionHeader.border": "#0f1415",
-                "sideBarSectionHeader.foreground": "#a5b5b5",
-                "sideBarTitle.foreground": "#a5b5b5",
-                "statusBar.background": "#041d20",
-                "statusBar.border": "#0f1415",
-                "statusBar.debuggingBackground": "#041d20",
-                "statusBar.debuggingBorder": "#df769baf",
-                "statusBar.debuggingForeground": "#df769b50",
-                "statusBar.foreground": "#169fb1",
-                "statusBar.noFolderBackground": "#041d20",
-                "statusBar.noFolderBorder": "#041d20",
-                "statusBar.noFolderForeground": "#87a7ab",
-                "statusBarItem.activeBackground": "#19bacc45",
-                "statusBarItem.hoverBackground": "#062e32",
-                "statusBarItem.prominentBackground": "#020c0e",
-                "statusBarItem.prominentHoverBackground": "#00292e",
-                "tab.activeBackground": "#052529",
-                "tab.activeBorder": "#052529",
-                "tab.activeBorderTop": "#40d4e7",
-                "tab.activeForeground": "#40d4e7",
-                "tab.activeModifiedBorder": "#49e9a6",
-                "tab.border": "#0f1415",
-                "tab.inactiveBackground": "#062e32",
-                "tab.inactiveForeground": "#87a7ab",
-                "tab.unfocusedActiveBackground": "#0e1e20",
-                "tab.unfocusedActiveBorder": "#052529",
-                "tab.unfocusedActiveForeground": "#87a7ab",
-                "tab.unfocusedHoverBackground": "#169fb121",
-                "tab.unfocusedInactiveForeground": "#87a7ab",
-                "terminal.ansiBlack": "#324a4d",
-                "terminal.ansiBlue": "#49ace9",
-                "terminal.ansiBrightBlack": "#47686c",
-                "terminal.ansiBrightBlue": "#60b6eb",
-                "terminal.ansiBrightCyan": "#60dbeb",
-                "terminal.ansiBrightGreen": "#60ebb1",
-                "terminal.ansiBrightMagenta": "#e798b3",
-                "terminal.ansiBrightRed": "#e97749",
-                "terminal.ansiBrightWhite": "#c1d4d7",
-                "terminal.ansiBrightYellow": "#e69533",
-                "terminal.ansiCyan": "#49d6e9",
-                "terminal.ansiGreen": "#49e9a6",
-                "terminal.ansiMagenta": "#df769b",
-                "terminal.ansiRed": "#e66533",
-                "terminal.ansiWhite": "#b2cacd",
-                "terminal.ansiYellow": "#e4b781",
-                "terminal.background": "#03191b",
-                "terminal.foreground": "#b2cacd",
-                "terminalCursor.background": "#03191b",
-                "terminalCursor.foreground": "#b2cacd",
-                "textBlockQuote.background": "#041d20",
-                "textBlockQuote.border": "#16a3b6",
-                "textCodeBlock.background": "#041d20",
-                "textLink.activeForeground": "#40d4e7",
-                "textLink.foreground": "#40d4e7",
-                "textPreformat.foreground": "#e4b781",
-                "textSeparator.foreground": "#041d20",
-                "titleBar.activeBackground": "#041d20",
-                "titleBar.activeForeground": "#b2cacd",
-                "titleBar.inactiveBackground": "#041d20",
-                "titleBar.inactiveForeground": "#87a7ab",
-                "tree.indentGuidesStroke": "#3e6f74",
-                "walkThrough.embeddedEditorBackground": "#041d20",
-                "widget.shadow": "#00000044"
-            },
-            "rules": [
-                {
-                    "foreground": "#5B858B",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "comment.block.documentation punctuation.definition.bracket"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "source.ocaml comment constant.regexp meta.separator"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "markup.other.anchor support.constant"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "markup.fenced_code"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "markup.fenced_code punctuation.definition"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.heading"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.bold.markdown"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.italic.markdown"
-                },
-                {
-                    "foreground": "#5B858B",
-                    "token": "punctuation.definition.strikethrough.markdown"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "constant.escape"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "text.html.markdown"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "punctuation.definition.list_item"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "keyword.begin.tag.ejs"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "constant.name.attribute.tag.pug"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.clojure meta.symbol"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "constant.other.description.jsdoc"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "keyword.other.array.phpdoc.php"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "keyword.operator.other.powershell"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "meta.link.inline punctuation.definition.string"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.sql"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source meta.brace"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source punctuation"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "text.html punctuation"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "markup meta punctuation.definition"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "meta.bracket.julia"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "meta.array.julia"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "entity.name.footnote"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.ocaml punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.ocaml entity.name.filename"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.reason entity.name.filename"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "entity.other.attribute-name strong"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "binding.fsharp keyword.symbol.fsharp"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "entity.name.record.field.elm"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "entity.name.record.field.accessor.elm"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "storage.modifier.array.bracket"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "source.css entity.other"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "meta.attribute-selector punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "markup.other.anchor string"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "punctuation.separator"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "punctuation.section"
-                },
-                {
-                    "foreground": "#B2CACD",
-                    "token": "punctuation.terminator"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.other.template"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.other.substitution"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "meta.tag.sgml"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.accessor"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "constant.other.color"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "entity.name.section"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "markup.heading punctuation.definition"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "storage.type.function.pug"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "text.pug storage.type"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "text.pug meta.tag.other"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.clojure storage.control"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "meta.expression.clojure"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.slice.python"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.question-mark.cs"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.definition.parameters.varargs"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.go keyword.operator"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.pointer-access"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.other.ruby"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.package"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.import"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.hash.cs"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "entity.other.attribute-name.pseudo-class.css punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "entity.other.attribute-name.pseudo-element.css punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.kotlin storage.type.import"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.kotlin storage.type.package"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "constant.string.documentation.powershell"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.section.directive"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "storage.type.rust"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.definition.attribute"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.definition.preprocessor"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.namespace"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.separator.method"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.control punctuation.definition.function"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.ocaml variable.interpolation string"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.reason variable.interpolation"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "punctuation.definition.directive"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "storage.type.modifier"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.other.class.fileds"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.toml entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "source.css entity.name.tag.custom"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "sharing.modifier"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.control.class.ruby"
-                },
-                {
-                    "foreground": "#DF769B",
-                    "token": "keyword.control.def.ruby"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.object"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "support"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "entity.name.module"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.import.parameter"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.other.class"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "meta.toc-list.id.html"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "meta.var.clojure"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "entity.name.variable"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.java meta.class.body.java"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "entity.name.package.go"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.c"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.cpp"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.go"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.python"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "meta.function-call.arguments.python"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.ruby"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.coffee.embedded.source"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.coffee"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "storage.modifier.package"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "storage.type.annotation"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "punctuation.definition.annotation"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.groovy.embedded.source"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.powershell"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "string.quoted.interpolated.vala constant.character.escape.vala"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.apacheconf"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.objc"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.crystal"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "string.quoted.double.kotlin entity.string.template.element.kotlin"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "entity.name.package.kotlin"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "meta.template.expression.kotlin"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "parameter.variable.function"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.other.constant.elixir"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.elixir.embedded.source"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.sql.embedded"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "punctuation.definition.placeholder"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.swift"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.julia"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.shell"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "variable.other.normal punctuation.definition.variable.shell"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.reason variable.language"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.reason variable.language string.other.link"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.elm meta.value"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.elm meta.declaration.module"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "meta.embedded.block variable punctuation.definition.variable.php"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "string.quoted.double.class.other"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.toml keyword"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "support.type.nim"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.tf meta.template.expression"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "source.scala entity.name.import"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "markup.code"
-                },
-                {
-                    "foreground": "#E4B781",
-                    "token": "markup.fenced_code.block"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "constant.other.symbol.hashkey.ruby"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.other.attribute-name.id punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.type.annotation.kotlin"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.type.primitive"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "meta.type.parameters entity.name.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "meta.type.annotation entity.name.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "punctuation.definition.typeparameters"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.python support.type.python"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "comment.block.documentation.phpdoc.php keyword.other.type.php"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "keyword.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.c"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.objc"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "punctuation.definition.storage.type.objc"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "markup punctuation.definition"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.powershell"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "comment.block.documentation entity.name.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.java storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.primitive"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.groovy storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.r"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.haskell storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "punctuation.separator.clause-head-body"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.go storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.core.rust"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.class.std.rust"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.modifier.lifetime.rust"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.lifetime.rust"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.type.vb"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.type.kotlin"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.type.julia"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "constant.other.reference"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.graphql support.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.reason support.type string"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.type.fsharp"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.elm storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.user-defined"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.built-in"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.type.builtin"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.swift support.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.class.crystal"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "storage.type.integral"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.cpp storage.type.cpp"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.vala storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.hlsl storage.type.basic"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.hlsl support.type.other"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.apex storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.nim storage.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.cpp entity.name.type"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "support.class.builtin"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.tf meta.keyword.string"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.tf meta.keyword.number"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "source.scala entity.name.class"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "markup.raw.monospace"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "markup.mark"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.type.primitive"
-                },
-                {
-                    "foreground": "#D67E5C",
-                    "token": "entity.name.type.numeric"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "constant.character.entity"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "support.variable.magic"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "entity.name.type.type-parameter.cs"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "punctuation.bracket.angle"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "entity.name.function.preprocessor.c"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "storage.type.scala"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "entity.helper.apacheconf"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "variable.language.crystal"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "support.constant punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "constant.character.math"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "support.class.math"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.graphql constant.character"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.reason constant.language.list"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.cpp variable.other.enummember"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "support.variable.class.hideshow"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "entity.other.attribute-name.class"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "meta.attribute.id entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "text.html entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "meta.tag.attributes entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "text.xml entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.cs entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "constant.character.format.placeholder"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.vue entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "entity.other.attribute-name.mjml"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "source.vue meta.directive punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#D5971A",
-                    "token": "meta.definition.attribute-entry punctuation.separator"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "punctuation.definition.italic"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "punctuation.definition.bold"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "variable.language punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.control.clojure"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "support.type.exception.python"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.this.cs"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.base.cs"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.var.cs"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "storage.modifier.super"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.go keyword"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.function.go"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.fn.rust"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "storage.modifier.static.rust"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.r meta.function.r keyword.control.r"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "storage.type.def"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "meta.class.identifier storage.modifier"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.scala keyword.declaration"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "comment.block.documentation punctuation.definition.block.tag"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "comment.block.documentation punctuation.definition.inline.tag"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "entity.tag.apacheconf"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.julia"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.julia storage.modifier"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "constant.language.empty-list.haskell"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "meta.function.powershell storage.type.powershell"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.control.fun"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "punctuation.terminator.function"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.rust"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.declaration-specifier.swift"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.control.class"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.control.def"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.ocaml keyword markup.underline"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.ocaml storage.type markup.underline"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "binding.fsharp keyword"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "function.anonymous keyword"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "function.anonymous keyword.symbol.fsharp"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "meta.embedded.block variable.language punctuation.definition.variable.php"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.declaration.dart"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.wsd keyword.other.class"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.wsd keyword.other.linebegin"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.skinparam.keyword"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "keyword.other.nim"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "markup.deleted.diff"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.tf support.class.variable"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "meta.function.lua keyword.control.lua"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "markup.block entity.name.tag"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "markup.meta.attribute-list"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.zig keyword.default"
-                },
-                {
-                    "foreground": "#E66533",
-                    "token": "source.zig keyword.structure"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "source.css support.constant"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "entity.name.import.go"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "markup.raw.texttt"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "markup.inserted.diff"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "source.scala punctuation.definition.character"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "constant.character.literal.scala"
-                },
-                {
-                    "foreground": "#49E9A6",
-                    "token": "source.tf entity.name"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.template"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "punctuation.definition.string.template"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.interpolated.python string.quoted.single.python"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.quoted.double.heredoc"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.quoted.interpolated.vala"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.quoted.interpolated.vala punctuation.definition.string"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.regexp.apacheconf"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "markup.inline.raw.string"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "markup.inline.raw punctuation.definition.raw"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.quoted.double.interpolated.crystal"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "string.quoted.double.interpolated.crystal punctuation.definition.string"
-                },
-                {
-                    "foreground": "#16B673",
-                    "token": "text.tex markup.raw"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "punctuation.separator.decimal.period.php"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "keyword.operator.null-conditional.cs"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "punctuation.separator.question-mark.cs"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "constant.integer.apacheconf"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "keyword.operator.nullable-type"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "constant.language punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "constant.others.fsharp"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "string.quoted.double.skinparam.value"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "source.toml constant"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "source.zig keyword.constant.bool"
-                },
-                {
-                    "foreground": "#7060EB",
-                    "token": "source.zig keyword.constant.default"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "markup.link"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "support.type.vendored"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "meta.function-call.generic.python"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "meta.method-call.groovy meta.method.groovy"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "meta.class.body.groovy meta.method.body.java storage.type.groovy"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "punctuation.definition.decorator"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "support.function.any-method"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "text.tex support.function"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "text.tex punctuation.definition.function"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "entity.name.section.fsharp entity.name.section.fsharp"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "support.variable.class.function"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "keyword.control.cucumber.table"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "punctuation.decorator"
-                },
-                {
-                    "foreground": "#16A3B6",
-                    "token": "source.tf support.class"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.other"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.orther.namespace.use.php"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "meta.use.php"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "support.function.construct"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "markup.changed.git_gutter"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "markup.underline.link"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "markup.underline.link.image"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "meta.symbol.namespace.clojure"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.mime-type.apacheconf"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "keyword.operator.function.infix"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.name.function.infix"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.name.function.call.kotlin"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "text.tex support.function.verb"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "text.tex support.function.texttt"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "source.reason constant.language.unit"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "source.ocaml constant.language constant.numeric entity.other.attribute-name.id.css"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "source.reason entity.other.attribute-name constant.language constant.numeric"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "constant.language.unit.fsharp"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "source.wsd support.class.preprocessings"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "keyword.language.gherkin.feature.scenario"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "source.nim keyword.other.common.function"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.name.type.namespace"
-                },
-                {
-                    "foreground": "#49D6E9",
-                    "token": "entity.name.scope-resolution.function.call"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.js constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.js punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "storage.type.string.python"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "string.interpolated.pug"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.clojure punctuation.section.set"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.clojure punctuation.section.metadata"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "entity.global.clojure"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.python meta.function-call.python support.type.python"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "entity.other.inherited-class.python"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.definition.interpolation"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.section.embedded.begin.ruby"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.section.embedded.end.ruby source.ruby"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "entity.namespace.r"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "meta.method-call.groovy storage.type.groovy"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.scala entity.name.class.declaration"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.function.macro.julia"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "string.replacement.apacheconf"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "storage.modifier.using.vala"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "constant.other.haskell"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.objc entity.name.tag"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "string.quoted.other.literal.upper.crystal punctuation.definition.string"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "meta.embedded.line.crystal punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "meta.embedded.line.crystal punctuation.section.embedded source.crystal"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.section.tag"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "punctuation.section.embedded source.swift"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "variable.other.bracket punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "string.interpolated.dollar punctuation.definition.string"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "constant.character.escape punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.ocaml entity.name.class constant.numeric"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.reason entity.name.class"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "keyword.format.specifier.fsharp"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.module.elm"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "meta.embedded.block.php punctuation.definition.variable.php"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.vala storage.type"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "support.variable.class.group"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "entity.name.type.class"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.tf meta.keyword.list"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "source.tf meta.keyword.map"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "entity.name.class.lua"
-                },
-                {
-                    "foreground": "#49ACE9",
-                    "token": "markup.substitution"
-                },
-                {
-                    "foreground": "#E3541C",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#E3541C",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.modifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.language"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.type.vendored"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.constant.vendored"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.quote"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.clojure"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.clojure meta.symbol.dynamic"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.other.this.cs"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.other.base.cs"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.other.member.c"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.type.core.rust"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.other.object.property"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.other.property"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.r meta.function.r keyword.control.r"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.line.roxygen.r keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.line.roxygen.r variable.parameter.r"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.inheritance.coffee"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation.phpdoc.php keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.other.array.phpdoc.php"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.modifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.javadoc.java keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.javadoc.java variable.parameter.java"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.operator.documentation.powershell"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.scala"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation.scala keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation.scala variable.parameter"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.function.builtin.go"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.symbol.hashkey.ruby"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.symbol.ruby"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.vala storage.type.generic"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.table-name"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.other.field"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.alias.import.go"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.swift keyword.other.declaration-specifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.variable.swift"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.other.capture-specifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "text.tex support.function.emph"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "constant.other.math"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.function.textit"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.footnote"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.function.directive.graphql"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.graphql support.type.enum"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.ocaml entity.name.filename"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.reason entity.name.filename"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "abstract.definition.fsharp keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "abstract.definition.fsharp entity"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "function.anonymous keyword"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.record.field.accessor.elm"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.type.primitive"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.type.builtin"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.type.cs"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.built-in"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.primitive"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.python support.type.python"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.core.rust"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.swift support.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.go storage.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.php"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.function.kotlin"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.type.kotlin"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.type.julia"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.other.member"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.other.import"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.package"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.import"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.wsd keyword.control.diagram"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.language.gherkin.feature.step"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.hlsl storage.type.basic"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.apex keyword.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "sharing.modifier"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.nim storage.type.concrete"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.preprocessor.pragma.nim"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.type.integral"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.scope-resolution.function.call"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "support.class.builtin"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation storage.type.class"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.tf meta.keyword.string"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.tf meta.keyword.number"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.scala entity.name.class"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.import keyword.control"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.export"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.vue meta.directive punctuation.separator.key-value"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.local.lua"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.mark.constrained markup.mark"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.block.open"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.type.primitive"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.name.type.numeric"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.zig keyword.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.zig keyword.storage"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "source.zig keyword.structure"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.control"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.operator"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.other.template"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.other.substitution"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.function.arrow"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "constant.other.color"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.accessor"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "entity.name.section"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markdown.heading"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.inline.raw punctuation.definition.raw"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.function.pug"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.function.python"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.annotation"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.bracket.angle"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.other.new"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.generic.wildcard"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.go keyword.operator"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "constant.other.symbol.ruby punctuation.definition.constant.ruby"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "variable.parameter"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "support.function.builtin.rust"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.function.coffee"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "entity.name.variable.parameter"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.separator.hash.cs"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "constant.other.symbol.ruby punctuation.definition.constant.ruby"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "meta.function.parameters variable.other"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "entity.name.type.annotation.kotlin"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "storage.type.objc"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "parameter.variable.function"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup punctuation.definition"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.section.directive"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.definition.preprocessor"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.ruby punctuation.definition.variable"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "support.function.textbf"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.graphql support.type.builtin"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.ocaml variable.interpolation string"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "entity.name.function.definition.special.constructor"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "entity.name.function.definition.special.member.destructor."
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "meta.function.parameters variable punctuation.definition.variable.php"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.wsd keyword.other.activity"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.control.class.ruby"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.control.def.ruby"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.function.go"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.other.fn.rust"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.other.anchor"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.list.bullet"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.list punctuation.definition"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "keyword.control.default"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.section"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.separator"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "punctuation.terminator"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold.markdown"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "source.zig storage.type.function"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "markup.quote markup.bold"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "text.html punctuation.section.embedded"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "variable.other.c"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "storage.modifier.lifetime.rust"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "entity.name.lifetime.rust"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "source.rust meta.attribute.rust"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "meta.attribute.id entity.other.attribute-name"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "source.ocaml punctuation.definition.tag emphasis"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "source.tf entity.name"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "markup.quote punctuation.definition"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "markup.fenced_code punctuation.definition"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "fenced_code.block.language"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.begin.tag.ejs"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.python meta.function.decorator.python support.type.python"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.cs keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.var.cs"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.go keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.modifier.static.rust"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "variable.parameter.r"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "variable.parameter.handlebars"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.modifier.import"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.modifier.package"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "meta.class.identifier storage.modifier"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.operator.other.powershell"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.css variable.parameter"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "string.interpolated variable.parameter"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.apacheconf keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.julia"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.modifier.using.vala"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.objc keyword.other.property.attribute"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.sql keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.using.vala"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.operator.function.infix"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.directive"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.rust"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.declaration-specifier.swift"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "entity.name.function.swift"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.class"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.def"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "punctuation.definition.variable"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "entity.name.section.latex"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.ocaml keyword markup.underline"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.ocaml constant.language constant.numeric entity.other.attribute-name.id.css"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.reason entity.other.attribute-name constant.language constant.numeric"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.format.specifier.fsharp"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "entity.name.section.fsharp"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "binding.fsharp keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "binding.fsharp keyword.symbol"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "record.fsharp keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.symbol.fsharp"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "entity.name.section.fsharp keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "namespace.open.fsharp keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "namespace.open.fsharp entity"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.type"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.cpp keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.c keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "storage.modifier.array.bracket"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "meta.import.haskell keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.declaration.dart"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.wsd keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.skinparam"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.css keyword.control"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.css keyword.operator"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.language.gherkin.feature.scenario"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.cucumber.table"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.toml entity.other.attribute-name"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.toml keyword"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.other.nim"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.nim keyword.other.common.function"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.nim keyword.other"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.scala keyword.declaration"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.scala entity.name.class.declaration"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.lua"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.css punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.c punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.cpp punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.java punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.php punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.powershell punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.r punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.ruby punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.swift punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.objc punctuation.section"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.zig keyword.constant.bool"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.zig keyword.default"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.zig keyword.statement"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "source.zig keyword.constant.default"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.activeBackground": "#40d4e733",
+        "activityBar.activeBorder": "#40d4e7",
+        "activityBar.background": "#052529",
+        "activityBar.border": "#0f1415",
+        "activityBar.foreground": "#169fb1",
+        "activityBar.inactiveForeground": "#169fb177",
+        "activityBarBadge.background": "#40d4e7",
+        "activityBarBadge.foreground": "#0f1415",
+        "badge.background": "#40d4e7",
+        "badge.foreground": "#0f1415",
+        "breadcrumb.activeSelectionForeground": "#ebfdff",
+        "breadcrumb.background": "#052529",
+        "breadcrumb.focusForeground": "#40d4e7",
+        "breadcrumb.foreground": "#87a7ab",
+        "breadcrumbPicker.background": "#073940",
+        "button.background": "#009999",
+        "button.foreground": "#ebfdff",
+        "button.hoverBackground": "#00cccc",
+        "debugExceptionWidget.background": "#041d20",
+        "debugExceptionWidget.border": "#16a3b6",
+        "debugToolBar.background": "#041d20",
+        "descriptionForeground": "#929ea0",
+        "diffEditor.insertedTextBackground": "#16b67327",
+        "diffEditor.removedTextBackground": "#e6653341",
+        "dropdown.background": "#073940",
+        "dropdown.border": "#073940",
+        "dropdown.foreground": "#87a7ab",
+        "editor.background": "#052529",
+        "editor.findMatchBackground": "#40bf6a11",
+        "editor.findMatchHighlightBackground": "#0e667179",
+        "editor.findRangeHighlightBackground": "#49e9a633",
+        "editor.foreground": "#b2cacd",
+        "editor.hoverHighlightBackground": "#169fb13f",
+        "editor.inactiveSelectionBackground": "#0e657155",
+        "editor.lineHighlightBackground": "#083d44ee",
+        "editor.lineHighlightBorder": "#083d44",
+        "editor.rangeHighlightBackground": "#083d44a1",
+        "editor.selectionBackground": "#169fb144",
+        "editor.selectionHighlightBackground": "#49ace944",
+        "editor.snippetFinalTabstopHighlightBackground": "#03181b",
+        "editor.snippetFinalTabstopHighlightBorder": "#042124",
+        "editor.snippetTabstopHighlightBackground": "#03181b",
+        "editor.snippetTabstopHighlightBorder": "#042124",
+        "editor.wordHighlightBackground": "#e4b78133",
+        "editor.wordHighlightStrongBackground": "#cc990033",
+        "editorBracketMatch.background": "#169fb122",
+        "editorBracketMatch.border": "#169fb1",
+        "editorCodeLens.foreground": "#507b95",
+        "editorCursor.foreground": "#85efff",
+        "editorError.border": "#052529",
+        "editorError.foreground": "#e34e1c",
+        "editorGroup.border": "#0f1415",
+        "editorGroup.dropBackground": "#5f6b6d33",
+        "editorGroup.emptyBackground": "#5f6b6d33",
+        "editorGroupHeader.noTabsBackground": "#062e32",
+        "editorGroupHeader.tabsBackground": "#062e32",
+        "editorGroupHeader.tabsBorder": "#062e32",
+        "editorGutter.addedBackground": "#8ce99a",
+        "editorGutter.background": "#052529",
+        "editorGutter.deletedBackground": "#e34e1c",
+        "editorGutter.modifiedBackground": "#e0c184",
+        "editorHint.border": "#49e9a600",
+        "editorHint.foreground": "#49e9a6",
+        "editorHoverWidget.background": "#073940",
+        "editorHoverWidget.border": "#0f1415",
+        "editorIndentGuide.activeBackground": "#3e6f74",
+        "editorIndentGuide.background": "#223b3f",
+        "editorInfo.border": "#052529",
+        "editorInfo.foreground": "#40d4e7",
+        "editorLineNumber.activeForeground": "#169fb1",
+        "editorLineNumber.foreground": "#4e6b6e",
+        "editorLink.activeForeground": "#14a5ff",
+        "editorMarkerNavigation.background": "#3a3a5e29",
+        "editorMarkerNavigationError.background": "#e34e1c",
+        "editorMarkerNavigationWarning.background": "#e69533",
+        "editorOverviewRuler.border": "#052529",
+        "editorOverviewRuler.commonContentForeground": "#ffc18044",
+        "editorOverviewRuler.currentContentForeground": "#85f1ff44",
+        "editorOverviewRuler.incomingContentForeground": "#9d92f244",
+        "editorRuler.foreground": "#29484c",
+        "editorSuggestWidget.background": "#073940",
+        "editorSuggestWidget.border": "#0f1415",
+        "editorSuggestWidget.foreground": "#87a7ab",
+        "editorSuggestWidget.highlightForeground": "#40d4e7",
+        "editorSuggestWidget.selectedBackground": "#0e6671",
+        "editorWarning.border": "#052529",
+        "editorWarning.foreground": "#e69533",
+        "editorWhitespace.foreground": "#ffffff21",
+        "editorWidget.background": "#073940",
+        "editorWidget.border": "#0f1415",
+        "errorForeground": "#e34e1c",
+        "extensionButton.prominentBackground": "#009999",
+        "extensionButton.prominentForeground": "#e5f5f5",
+        "extensionButton.prominentHoverBackground": "#00cccc",
+        "focusBorder": "#073940",
+        "foreground": "#b2cacd",
+        "gitDecoration.addedResourceForeground": "#16b673",
+        "gitDecoration.conflictingResourceForeground": "#e4b781",
+        "gitDecoration.deletedResourceForeground": "#e34e1c",
+        "gitDecoration.ignoredResourceForeground": "#5b858b",
+        "gitDecoration.modifiedResourceForeground": "#49e9a6",
+        "gitDecoration.untrackedResourceForeground": "#40d4e7",
+        "input.background": "#052529",
+        "input.border": "#073940",
+        "input.foreground": "#cdd3de",
+        "input.placeholderForeground": "#87a7ab",
+        "inputOption.activeBorder": "#169fb1",
+        "inputValidation.errorBackground": "#501502ee",
+        "inputValidation.errorBorder": "#691c02",
+        "inputValidation.errorForeground": "#ff4000",
+        "inputValidation.infoBackground": "#0f6e7bee",
+        "inputValidation.infoBorder": "#148f9f",
+        "inputValidation.infoForeground": "#40d4e7",
+        "inputValidation.warningBackground": "#82694acc",
+        "inputValidation.warningBorder": "#a88457",
+        "inputValidation.warningForeground": "#e69533",
+        "list.activeSelectionBackground": "#0e6671",
+        "list.activeSelectionForeground": "#ebfdff",
+        "list.dropBackground": "#00404d",
+        "list.errorForeground": "#e34e1c",
+        "list.focusBackground": "#00404d",
+        "list.focusForeground": "#ebfdff",
+        "list.highlightForeground": "#40d4e7",
+        "list.hoverBackground": "#0b515b",
+        "list.hoverForeground": "#ebfdff",
+        "list.inactiveFocusBackground": "#062d32",
+        "list.inactiveSelectionBackground": "#07353b",
+        "list.inactiveSelectionForeground": "#b2cacd",
+        "list.warningForeground": "#ffa487",
+        "listFilterWidget.background": "#00404d",
+        "listFilterWidget.noMatchesOutline": "#e34e1c",
+        "listFilterWidget.outline": "#49e9a6",
+        "menu.background": "#073940",
+        "menu.foreground": "#87a7ab",
+        "menu.selectionBackground": "#0b515b",
+        "menu.selectionBorder": "#0b515b",
+        "menu.selectionForeground": "#40d4e7",
+        "menu.separatorBackground": "#40d4e7",
+        "menubar.selectionBackground": "#0b515b",
+        "menubar.selectionBorder": "#0b515b",
+        "menubar.selectionForeground": "#40d4e7",
+        "merge.border": "#05252900",
+        "merge.commonContentBackground": "#ffc18022",
+        "merge.commonHeaderBackground": "#ffc18044",
+        "merge.currentContentBackground": "#85f1ff22",
+        "merge.currentHeaderBackground": "#85f1ff44",
+        "merge.incomingContentBackground": "#9d92f222",
+        "merge.incomingHeaderBackground": "#9d92f244",
+        "minimap.background": "#05252999",
+        "minimap.errorHighlight": "#e34e1cee",
+        "minimap.findMatchHighlight": "#49d6e9ee",
+        "minimap.warningHighlight": "#e69533ee",
+        "minimapGutter.addedBackground": "#16b673",
+        "minimapGutter.deletedBackground": "#e34e1c",
+        "minimapGutter.modifiedBackground": "#49e9a6",
+        "notificationCenter.border": "#073940",
+        "notificationCenterHeader.background": "#073940",
+        "notificationCenterHeader.foreground": "#87a7ab",
+        "notificationLink.foreground": "#87a7ab",
+        "notificationToast.border": "#073940",
+        "notifications.background": "#073940",
+        "notifications.border": "#073940",
+        "notifications.foreground": "#cdd3de",
+        "panel.background": "#03191b",
+        "panel.border": "#0e6671",
+        "panelTitle.activeBorder": "#0e6671",
+        "panelTitle.activeForeground": "#40d4e7",
+        "panelTitle.inactiveForeground": "#87a7ab",
+        "peekView.border": "#169fb1",
+        "peekViewEditor.background": "#002124",
+        "peekViewEditor.matchHighlightBackground": "#00718079",
+        "peekViewEditor.matchHighlightBorder": "#007180cc",
+        "peekViewEditorGutter.background": "#002124",
+        "peekViewResult.background": "#041d20",
+        "peekViewResult.fileForeground": "#e4b781",
+        "peekViewResult.lineForeground": "#87a7ab",
+        "peekViewResult.matchHighlightBackground": "#073940",
+        "peekViewResult.selectionBackground": "#073940",
+        "peekViewResult.selectionForeground": "#87a7ab",
+        "peekViewTitle.background": "#041d20",
+        "peekViewTitleDescription.foreground": "#87a7ab",
+        "peekViewTitleLabel.foreground": "#e4b781",
+        "pickerGroup.border": "#0e6671",
+        "pickerGroup.foreground": "#169fb1",
+        "progressBar.background": "#40d4e7",
+        "scrollbar.shadow": "#00000044",
+        "scrollbarSlider.activeBackground": "#169fb1ad",
+        "scrollbarSlider.background": "#6a90955b",
+        "scrollbarSlider.hoverBackground": "#169fb162",
+        "selection.background": "#107684",
+        "settings.checkboxBackground": "#073940",
+        "settings.checkboxBorder": "#073940",
+        "settings.checkboxForeground": "#00cccc",
+        "settings.dropdownBackground": "#073940",
+        "settings.dropdownBorder": "#073940",
+        "settings.dropdownForeground": "#00cccc",
+        "settings.dropdownListBorder": "#0e657188",
+        "settings.headerForeground": "#b2cacd",
+        "settings.modifiedItemIndicator": "#15ac31",
+        "settings.numberInputBackground": "#041d20",
+        "settings.numberInputBorder": "#041d20",
+        "settings.numberInputForeground": "#7060eb",
+        "settings.textInputBackground": "#073940",
+        "settings.textInputBorder": "#073940",
+        "settings.textInputForeground": "#00cccc",
+        "sideBar.background": "#041d20",
+        "sideBar.border": "#0f1415",
+        "sideBar.dropBackground": "#041d20",
+        "sideBar.foreground": "#a5b5b5",
+        "sideBarSectionHeader.background": "#083d44",
+        "sideBarSectionHeader.border": "#0f1415",
+        "sideBarSectionHeader.foreground": "#a5b5b5",
+        "sideBarTitle.foreground": "#a5b5b5",
+        "statusBar.background": "#041d20",
+        "statusBar.border": "#0f1415",
+        "statusBar.debuggingBackground": "#041d20",
+        "statusBar.debuggingBorder": "#df769baf",
+        "statusBar.debuggingForeground": "#df769b50",
+        "statusBar.foreground": "#169fb1",
+        "statusBar.noFolderBackground": "#041d20",
+        "statusBar.noFolderBorder": "#041d20",
+        "statusBar.noFolderForeground": "#87a7ab",
+        "statusBarItem.activeBackground": "#19bacc45",
+        "statusBarItem.hoverBackground": "#062e32",
+        "statusBarItem.prominentBackground": "#020c0e",
+        "statusBarItem.prominentHoverBackground": "#00292e",
+        "tab.activeBackground": "#052529",
+        "tab.activeBorder": "#052529",
+        "tab.activeBorderTop": "#40d4e7",
+        "tab.activeForeground": "#40d4e7",
+        "tab.activeModifiedBorder": "#49e9a6",
+        "tab.border": "#0f1415",
+        "tab.inactiveBackground": "#062e32",
+        "tab.inactiveForeground": "#87a7ab",
+        "tab.unfocusedActiveBackground": "#0e1e20",
+        "tab.unfocusedActiveBorder": "#052529",
+        "tab.unfocusedActiveForeground": "#87a7ab",
+        "tab.unfocusedHoverBackground": "#169fb121",
+        "tab.unfocusedInactiveForeground": "#87a7ab",
+        "terminal.ansiBlack": "#324a4d",
+        "terminal.ansiBlue": "#49ace9",
+        "terminal.ansiBrightBlack": "#47686c",
+        "terminal.ansiBrightBlue": "#60b6eb",
+        "terminal.ansiBrightCyan": "#60dbeb",
+        "terminal.ansiBrightGreen": "#60ebb1",
+        "terminal.ansiBrightMagenta": "#e798b3",
+        "terminal.ansiBrightRed": "#e97749",
+        "terminal.ansiBrightWhite": "#c1d4d7",
+        "terminal.ansiBrightYellow": "#e69533",
+        "terminal.ansiCyan": "#49d6e9",
+        "terminal.ansiGreen": "#49e9a6",
+        "terminal.ansiMagenta": "#df769b",
+        "terminal.ansiRed": "#e66533",
+        "terminal.ansiWhite": "#b2cacd",
+        "terminal.ansiYellow": "#e4b781",
+        "terminal.background": "#03191b",
+        "terminal.foreground": "#b2cacd",
+        "terminalCursor.background": "#03191b",
+        "terminalCursor.foreground": "#b2cacd",
+        "textBlockQuote.background": "#041d20",
+        "textBlockQuote.border": "#16a3b6",
+        "textCodeBlock.background": "#041d20",
+        "textLink.activeForeground": "#40d4e7",
+        "textLink.foreground": "#40d4e7",
+        "textPreformat.foreground": "#e4b781",
+        "textSeparator.foreground": "#041d20",
+        "titleBar.activeBackground": "#041d20",
+        "titleBar.activeForeground": "#b2cacd",
+        "titleBar.inactiveBackground": "#041d20",
+        "titleBar.inactiveForeground": "#87a7ab",
+        "tree.indentGuidesStroke": "#3e6f74",
+        "walkThrough.embeddedEditorBackground": "#041d20",
+        "widget.shadow": "#00000044"
+    },
+    "rules": [
+        {
+            "foreground": "#5B858B",
+            "token": "comment"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "comment.block.documentation punctuation.definition.bracket"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "source.ocaml comment constant.regexp meta.separator"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "markup.other.anchor support.constant"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "markup.fenced_code"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "markup.fenced_code punctuation.definition"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.heading"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.bold.markdown"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.italic.markdown"
+        },
+        {
+            "foreground": "#5B858B",
+            "token": "punctuation.definition.strikethrough.markdown"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "constant.escape"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "text.html.markdown"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "punctuation.definition.list_item"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "keyword.begin.tag.ejs"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "constant.name.attribute.tag.pug"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.clojure meta.symbol"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "constant.other.description.jsdoc"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "keyword.other.array.phpdoc.php"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "keyword.operator.other.powershell"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "meta.link.inline punctuation.definition.string"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.sql"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source meta.brace"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source punctuation"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "text.html punctuation"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "markup meta punctuation.definition"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "meta.bracket.julia"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "meta.array.julia"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "entity.name.footnote"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.ocaml punctuation.definition.tag"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.ocaml entity.name.filename"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.reason entity.name.filename"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "entity.other.attribute-name strong"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "binding.fsharp keyword.symbol.fsharp"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "entity.name.record.field.elm"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "entity.name.record.field.accessor.elm"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "storage.modifier.array.bracket"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "source.css entity.other"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "meta.attribute-selector punctuation.definition.entity"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "markup.other.anchor string"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "punctuation.separator"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "punctuation.section"
+        },
+        {
+            "foreground": "#B2CACD",
+            "token": "punctuation.terminator"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.other.template"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.other.substitution"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "meta.tag.sgml"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.accessor"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "constant.other.color"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "entity.name.section"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "markup.heading punctuation.definition"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "storage.type.function.pug"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "text.pug storage.type"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "text.pug meta.tag.other"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.clojure storage.control"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "meta.expression.clojure"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.slice.python"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.question-mark.cs"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.definition.parameters.varargs"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.go keyword.operator"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.pointer-access"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.other.ruby"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.package"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.import"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.hash.cs"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "entity.other.attribute-name.pseudo-class.css punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "entity.other.attribute-name.pseudo-element.css punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.kotlin storage.type.import"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.kotlin storage.type.package"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "constant.string.documentation.powershell"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.section.directive"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "storage.type.rust"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.definition.attribute"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.definition.preprocessor"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.namespace"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.separator.method"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.control punctuation.definition.function"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.ocaml variable.interpolation string"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.reason variable.interpolation"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "punctuation.definition.directive"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "storage.type.modifier"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.other.class.fileds"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.toml entity.other.attribute-name"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "source.css entity.name.tag.custom"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "sharing.modifier"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.control.class.ruby"
+        },
+        {
+            "foreground": "#DF769B",
+            "token": "keyword.control.def.ruby"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.object"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "support"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "entity.name.module"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.import.parameter"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.other.class"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "meta.toc-list.id.html"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "meta.var.clojure"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "entity.name.variable"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.java meta.class.body.java"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "entity.name.package.go"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.c"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.cpp"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.go"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.python"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "meta.function-call.arguments.python"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.ruby"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.coffee.embedded.source"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.coffee"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "storage.modifier.import"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "storage.modifier.package"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "storage.type.annotation"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "punctuation.definition.annotation"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.groovy.embedded.source"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.powershell"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "string.quoted.interpolated.vala constant.character.escape.vala"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.apacheconf"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.objc"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.crystal"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "string.quoted.double.kotlin entity.string.template.element.kotlin"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "entity.name.package.kotlin"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "meta.template.expression.kotlin"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "parameter.variable.function"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.other.constant.elixir"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.elixir.embedded.source"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.sql.embedded"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "punctuation.definition.placeholder"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.swift"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.julia"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.shell"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "variable.other.normal punctuation.definition.variable.shell"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.reason variable.language"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.reason variable.language string.other.link"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.elm meta.value"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.elm meta.declaration.module"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "meta.embedded.block variable punctuation.definition.variable.php"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "string.quoted.double.class.other"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.toml keyword"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "support.type.nim"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.tf meta.template.expression"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "source.scala entity.name.import"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "markup.code"
+        },
+        {
+            "foreground": "#E4B781",
+            "token": "markup.fenced_code.block"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "constant.other.symbol.hashkey.ruby"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.other.attribute-name.id punctuation.definition.entity"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.type.annotation.kotlin"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.type.primitive"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "meta.type.parameters entity.name.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "meta.type.annotation entity.name.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "punctuation.definition.typeparameters"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.python support.type.python"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "comment.block.documentation.phpdoc.php keyword.other.type.php"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "keyword.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.c"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.objc"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "punctuation.definition.storage.type.objc"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "markup punctuation.definition"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.powershell"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "comment.block.documentation entity.name.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.java storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.primitive"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.groovy storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.r"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.haskell storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "punctuation.separator.clause-head-body"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.go storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.core.rust"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.class.std.rust"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.modifier.lifetime.rust"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.lifetime.rust"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.type.vb"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.type.kotlin"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.type.julia"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "constant.other.reference"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.graphql support.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.reason support.type string"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.type.fsharp"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.elm storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.user-defined"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.built-in"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.type.builtin"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.swift support.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.class.crystal"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "storage.type.integral"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.cpp storage.type.cpp"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.vala storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.hlsl storage.type.basic"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.hlsl support.type.other"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.apex storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.nim storage.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.cpp entity.name.type"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "support.class.builtin"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.tf meta.keyword.string"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.tf meta.keyword.number"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "source.scala entity.name.class"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "markup.raw.monospace"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "markup.mark"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.type.primitive"
+        },
+        {
+            "foreground": "#D67E5C",
+            "token": "entity.name.type.numeric"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "constant"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "punctuation.definition.entity"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "constant.character.entity"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "support.variable.magic"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "entity.name.type.type-parameter.cs"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "punctuation.bracket.angle"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "entity.name.function.preprocessor.c"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "storage.type.scala"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "entity.helper.apacheconf"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "variable.language.crystal"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "support.constant punctuation.definition.variable"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "constant.character.math"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "support.class.math"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.graphql constant.character"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.reason constant.language.list"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.cpp variable.other.enummember"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "support.variable.class.hideshow"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "entity.other.attribute-name.class"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "meta.attribute.id entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "text.html entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "meta.tag.attributes entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "text.xml entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.cs entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "constant.character.format.placeholder"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.vue entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "entity.other.attribute-name.mjml"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "source.vue meta.directive punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#D5971A",
+            "token": "meta.definition.attribute-entry punctuation.separator"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "punctuation.definition.italic"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "punctuation.definition.bold"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "variable.language punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.control.clojure"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "support.type.exception.python"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.this.cs"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.base.cs"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.var.cs"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "storage.modifier.super"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.go keyword"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.function.go"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.fn.rust"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "storage.modifier.static.rust"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.r meta.function.r keyword.control.r"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "storage.type.def"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "meta.class.identifier storage.modifier"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.scala keyword.declaration"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "comment.block.documentation punctuation.definition.block.tag"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "comment.block.documentation punctuation.definition.inline.tag"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "entity.tag.apacheconf"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.julia"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.julia storage.modifier"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "constant.language.empty-list.haskell"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "meta.function.powershell storage.type.powershell"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.control.fun"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "punctuation.terminator.function"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.rust"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.declaration-specifier.swift"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.control.class"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.control.def"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.ocaml keyword markup.underline"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.ocaml storage.type markup.underline"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "binding.fsharp keyword"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "function.anonymous keyword"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "function.anonymous keyword.symbol.fsharp"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "meta.embedded.block variable.language punctuation.definition.variable.php"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.declaration.dart"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.wsd keyword.other.class"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.wsd keyword.other.linebegin"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.skinparam.keyword"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "keyword.other.nim"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "markup.deleted.diff"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.tf support.class.variable"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "meta.function.lua keyword.control.lua"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "markup.block entity.name.tag"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "markup.meta.attribute-list"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.zig keyword.default"
+        },
+        {
+            "foreground": "#E66533",
+            "token": "source.zig keyword.structure"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "string"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "source.css support.constant"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "entity.name.import.go"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "markup.raw.texttt"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "markup.inserted.diff"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "source.scala punctuation.definition.character"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "constant.character.literal.scala"
+        },
+        {
+            "foreground": "#49E9A6",
+            "token": "source.tf entity.name"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.template"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "punctuation.definition.string.template"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.interpolated.python string.quoted.single.python"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.quoted.double.heredoc"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.quoted.interpolated.vala"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.quoted.interpolated.vala punctuation.definition.string"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.regexp.apacheconf"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "markup.inline.raw.string"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "markup.inline.raw punctuation.definition.raw"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.quoted.double.interpolated.crystal"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "string.quoted.double.interpolated.crystal punctuation.definition.string"
+        },
+        {
+            "foreground": "#16B673",
+            "token": "text.tex markup.raw"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "punctuation.separator.decimal.period.php"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "keyword.operator.null-conditional.cs"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "punctuation.separator.question-mark.cs"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "constant.integer.apacheconf"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "keyword.operator.nullable-type"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "constant.language punctuation.definition.variable"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "constant.others.fsharp"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "string.quoted.double.skinparam.value"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "source.toml constant"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "source.zig keyword.constant.bool"
+        },
+        {
+            "foreground": "#7060EB",
+            "token": "source.zig keyword.constant.default"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "markup.link"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "support.type.vendored"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "meta.function-call.generic.python"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "meta.method-call.groovy meta.method.groovy"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "meta.class.body.groovy meta.method.body.java storage.type.groovy"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "punctuation.definition.decorator"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "support.function.any-method"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "text.tex support.function"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "text.tex punctuation.definition.function"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "entity.name.section.fsharp entity.name.section.fsharp"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "support.variable.class.function"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "keyword.control.cucumber.table"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "punctuation.decorator"
+        },
+        {
+            "foreground": "#16A3B6",
+            "token": "source.tf support.class"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.other"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.orther.namespace.use.php"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "meta.use.php"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "support.function.construct"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "markup.changed.git_gutter"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "markup.underline.link"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "markup.underline.link.image"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "meta.symbol.namespace.clojure"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.mime-type.apacheconf"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "keyword.operator.function.infix"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.name.function.infix"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.name.function.call.kotlin"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "text.tex support.function.verb"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "text.tex support.function.texttt"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "source.reason constant.language.unit"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "source.ocaml constant.language constant.numeric entity.other.attribute-name.id.css"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "source.reason entity.other.attribute-name constant.language constant.numeric"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "constant.language.unit.fsharp"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "source.wsd support.class.preprocessings"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "keyword.language.gherkin.feature.scenario"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "source.nim keyword.other.common.function"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.name.type.namespace"
+        },
+        {
+            "foreground": "#49D6E9",
+            "token": "entity.name.scope-resolution.function.call"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.js constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.js punctuation.section.embedded"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "storage.type.string.python"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "string.interpolated.pug"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.clojure punctuation.section.set"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.clojure punctuation.section.metadata"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "entity.global.clojure"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.python meta.function-call.python support.type.python"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "entity.other.inherited-class.python"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.definition.interpolation"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.section.embedded.begin.ruby"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.section.embedded.end.ruby source.ruby"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "entity.namespace.r"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "meta.method-call.groovy storage.type.groovy"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.scala entity.name.class.declaration"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.function.macro.julia"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "string.replacement.apacheconf"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "storage.modifier.using.vala"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "constant.other.haskell"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.objc entity.name.tag"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "string.quoted.other.literal.upper.crystal punctuation.definition.string"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "meta.embedded.line.crystal punctuation.section.embedded"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "meta.embedded.line.crystal punctuation.section.embedded source.crystal"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.section.tag"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "punctuation.section.embedded source.swift"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "variable.other.bracket punctuation.definition.variable"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "string.interpolated.dollar punctuation.definition.string"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "constant.character.escape punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.ocaml entity.name.class constant.numeric"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.reason entity.name.class"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "keyword.format.specifier.fsharp"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.module.elm"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "meta.embedded.block.php punctuation.definition.variable.php"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.vala storage.type"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "support.variable.class.group"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "entity.name.type.class"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.tf meta.keyword.list"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "source.tf meta.keyword.map"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "entity.name.class.lua"
+        },
+        {
+            "foreground": "#49ACE9",
+            "token": "markup.substitution"
+        },
+        {
+            "foreground": "#E3541C",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#E3541C",
+            "token": "invalid.illegal"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.modifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.language"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.type.vendored"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.constant.vendored"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.quote"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.clojure"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.clojure meta.symbol.dynamic"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.other.this.cs"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.other.base.cs"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.other.member.c"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.type.core.rust"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.other.object.property"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.other.property"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.r meta.function.r keyword.control.r"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.line.roxygen.r keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.line.roxygen.r variable.parameter.r"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.inheritance.coffee"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.documentation.phpdoc.php keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.other.array.phpdoc.php"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.modifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.javadoc.java keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.javadoc.java variable.parameter.java"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.operator.documentation.powershell"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.scala"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.documentation.scala keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.documentation.scala variable.parameter"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.function.builtin.go"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.symbol.hashkey.ruby"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.symbol.ruby"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.vala storage.type.generic"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.table-name"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.other.field"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.alias.import.go"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.swift keyword.other.declaration-specifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.variable.swift"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.other.capture-specifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "text.tex support.function.emph"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "constant.other.math"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.function.textit"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.footnote"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.function.directive.graphql"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.graphql support.type.enum"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.ocaml entity.name.filename"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.reason entity.name.filename"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "abstract.definition.fsharp keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "abstract.definition.fsharp entity"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "function.anonymous keyword"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.record.field.accessor.elm"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.type.primitive"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.type.builtin"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.type.cs"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.built-in"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.primitive"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.python support.type.python"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.core.rust"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.swift support.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.go storage.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.php"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.function.kotlin"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.type.kotlin"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.type.julia"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.other.member"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.other.import"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.package"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.import"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.wsd keyword.control.diagram"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.language.gherkin.feature.step"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.hlsl storage.type.basic"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.apex keyword.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "sharing.modifier"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.nim storage.type.concrete"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.preprocessor.pragma.nim"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.type.integral"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.scope-resolution.function.call"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "support.class.builtin"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.documentation storage.type.class"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.tf meta.keyword.string"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.tf meta.keyword.number"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.scala entity.name.class"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.import keyword.control"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.export"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.vue meta.directive punctuation.separator.key-value"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.local.lua"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.mark.constrained markup.mark"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.block.open"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.type.primitive"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.name.type.numeric"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.zig keyword.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.zig keyword.storage"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "source.zig keyword.structure"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.control"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.operator"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.other.template"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.other.substitution"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.function.arrow"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "constant.other.color"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.accessor"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "entity.name.section"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markdown.heading"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.inline.raw punctuation.definition.raw"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.function.pug"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.function.python"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.annotation"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.bracket.angle"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.other.new"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.generic.wildcard"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.go keyword.operator"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "constant.other.symbol.ruby punctuation.definition.constant.ruby"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "variable.parameter"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "support.function.builtin.rust"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.function.coffee"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "entity.name.variable.parameter"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.separator.hash.cs"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "constant.other.symbol.ruby punctuation.definition.constant.ruby"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "constant.other.symbol.hashkey.ruby punctuation.definition.constant.ruby"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "meta.function.parameters variable.other"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "entity.name.type.annotation.kotlin"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "storage.type.objc"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "parameter.variable.function"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup punctuation.definition"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.section.directive"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.definition.preprocessor"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.ruby punctuation.definition.variable"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "support.function.textbf"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.graphql support.type.builtin"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.ocaml variable.interpolation string"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "entity.name.function.definition.special.constructor"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "entity.name.function.definition.special.member.destructor."
+        },
+        {
+            "fontStyle": "bold",
+            "token": "meta.function.parameters variable punctuation.definition.variable.php"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.wsd keyword.other.activity"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.control.class.ruby"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.control.def.ruby"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.function.go"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.other.fn.rust"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.other.anchor"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.list.bullet"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.list punctuation.definition"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "keyword.control.default"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.section"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.separator"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "punctuation.terminator"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold.markdown"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "source.zig storage.type.function"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "markup.quote markup.bold"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "text.html punctuation.section.embedded"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "variable.other.c"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "storage.modifier.lifetime.rust"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "entity.name.lifetime.rust"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "source.rust meta.attribute.rust"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "meta.attribute.id entity.other.attribute-name"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "source.ocaml punctuation.definition.tag emphasis"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "source.tf entity.name"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "markup.quote punctuation.definition"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "markup.fenced_code punctuation.definition"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "fenced_code.block.language"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.begin.tag.ejs"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.python meta.function.decorator.python support.type.python"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.cs keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.var.cs"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.go keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.modifier.static.rust"
+        },
+        {
+            "fontStyle": "",
+            "token": "variable.parameter.r"
+        },
+        {
+            "fontStyle": "",
+            "token": "variable.parameter.handlebars"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.modifier.import"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.modifier.package"
+        },
+        {
+            "fontStyle": "",
+            "token": "meta.class.identifier storage.modifier"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.operator.other.powershell"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.css variable.parameter"
+        },
+        {
+            "fontStyle": "",
+            "token": "string.interpolated variable.parameter"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.apacheconf keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.julia"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.modifier.using.vala"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.objc keyword.other.property.attribute"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.sql keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.using.vala"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.operator.function.infix"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.directive"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.rust"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.declaration-specifier.swift"
+        },
+        {
+            "fontStyle": "",
+            "token": "entity.name.function.swift"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.class"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.def"
+        },
+        {
+            "fontStyle": "",
+            "token": "punctuation.definition.variable"
+        },
+        {
+            "fontStyle": "",
+            "token": "entity.name.section.latex"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.ocaml keyword markup.underline"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.ocaml constant.language constant.numeric entity.other.attribute-name.id.css"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.reason entity.other.attribute-name constant.language constant.numeric"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.format.specifier.fsharp"
+        },
+        {
+            "fontStyle": "",
+            "token": "entity.name.section.fsharp"
+        },
+        {
+            "fontStyle": "",
+            "token": "binding.fsharp keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "binding.fsharp keyword.symbol"
+        },
+        {
+            "fontStyle": "",
+            "token": "record.fsharp keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.symbol.fsharp"
+        },
+        {
+            "fontStyle": "",
+            "token": "entity.name.section.fsharp keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "namespace.open.fsharp keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "namespace.open.fsharp entity"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.type"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.cpp keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.c keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.unit"
+        },
+        {
+            "fontStyle": "",
+            "token": "storage.modifier.array.bracket"
+        },
+        {
+            "fontStyle": "",
+            "token": "meta.import.haskell keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.declaration.dart"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.wsd keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.skinparam"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.css keyword.control"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.css keyword.operator"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.language.gherkin.feature.scenario"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.cucumber.table"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.toml entity.other.attribute-name"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.toml keyword"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.other.nim"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.nim keyword.other.common.function"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.nim keyword.other"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.scala keyword.declaration"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.scala entity.name.class.declaration"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.lua"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.css punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.c punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.cpp punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.java punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.php punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.powershell punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.r punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.ruby punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.swift punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.objc punctuation.section"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.zig keyword.constant.bool"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.zig keyword.default"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.zig keyword.statement"
+        },
+        {
+            "fontStyle": "",
+            "token": "source.zig keyword.constant.default"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/oceanic-next/oceanic-next-monaco.json
+++ b/themes/oceanic-next/oceanic-next-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "oceanic-next"
-    }
-}
+"oceanic-next"

--- a/themes/oled/oled-monaco.json
+++ b/themes/oled/oled-monaco.json
@@ -1,5 +1,1 @@
-{
-    "monacoOptions": {
-        "theme": "tomorrow-night-bright"
-    }
-}
+"tomorrow-night-bright"

--- a/themes/one-dark-pro-darker/one-dark-pro-darker-monaco.json
+++ b/themes/one-dark-pro-darker/one-dark-pro-darker-monaco.json
@@ -1,1933 +1,1929 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#23272e",
-                "activityBar.foreground": "#d7dae0",
-                "activityBarBadge.background": "#4d78cc",
-                "activityBarBadge.foreground": "#f8fafd",
-                "badge.background": "#23272e",
-                "button.background": "#404754",
-                "button.secondaryBackground": "#30333d",
-                "button.secondaryForeground": "#c0bdbd",
-                "checkbox.border": "#404754",
-                "debugToolBar.background": "#1e2227",
-                "descriptionForeground": "#abb2bf",
-                "diffEditor.insertedTextBackground": "#00809b33",
-                "dropdown.background": "#1e2227",
-                "dropdown.border": "#1e2227",
-                "editor.background": "#23272e",
-                "editor.findMatchBackground": "#42557b",
-                "editor.findMatchBorder": "#457dff",
-                "editor.findMatchHighlightBackground": "#6199ff2f",
-                "editor.foreground": "#abb2bf",
-                "editor.lineHighlightBackground": "#2c313c",
-                "editor.selectionBackground": "#67769660",
-                "editor.selectionHighlightBackground": "#ffffff10",
-                "editor.selectionHighlightBorder": "#dddddd",
-                "editor.wordHighlightBackground": "#d2e0ff2f",
-                "editor.wordHighlightBorder": "#7f848e",
-                "editor.wordHighlightStrongBackground": "#abb2bf26",
-                "editor.wordHighlightStrongBorder": "#7f848e",
-                "editorBracketHighlight.foreground1": "#d19a66",
-                "editorBracketHighlight.foreground2": "#c678dd",
-                "editorBracketHighlight.foreground3": "#56b6c2",
-                "editorBracketMatch.background": "#515a6b",
-                "editorBracketMatch.border": "#515a6b",
-                "editorCursor.background": "#ffffffc9",
-                "editorCursor.foreground": "#528bff",
-                "editorError.foreground": "#c24038",
-                "editorGroup.border": "#181a1f",
-                "editorGroupHeader.tabsBackground": "#1e2227",
-                "editorGutter.addedBackground": "#109868",
-                "editorGutter.deletedBackground": "#9a353d",
-                "editorGutter.modifiedBackground": "#948b60",
-                "editorHoverWidget.background": "#1e2227",
-                "editorHoverWidget.border": "#181a1f",
-                "editorHoverWidget.highlightForeground": "#61afef",
-                "editorIndentGuide.activeBackground": "#c8c8c859",
-                "editorIndentGuide.background": "#3b4048",
-                "editorInlayHint.background": "#2c313c",
-                "editorInlayHint.foreground": "#abb2bf",
-                "editorLineNumber.activeForeground": "#abb2bf",
-                "editorLineNumber.foreground": "#495162",
-                "editorMarkerNavigation.background": "#1e2227",
-                "editorRuler.foreground": "#abb2bf26",
-                "editorSuggestWidget.background": "#1e2227",
-                "editorSuggestWidget.border": "#181a1f",
-                "editorSuggestWidget.selectedBackground": "#2c313a",
-                "editorWarning.foreground": "#d19a66",
-                "editorWhitespace.foreground": "#ffffff1d",
-                "editorWidget.background": "#1e2227",
-                "focusBorder": "#3e4452",
-                "gitDecoration.ignoredResourceForeground": "#636b78",
-                "input.background": "#1d1f23",
-                "input.foreground": "#abb2bf",
-                "list.activeSelectionBackground": "#2c313a",
-                "list.activeSelectionForeground": "#d7dae0",
-                "list.focusBackground": "#323842",
-                "list.focusForeground": "#f0f0f0",
-                "list.highlightForeground": "#ecebeb",
-                "list.hoverBackground": "#2c313a",
-                "list.hoverForeground": "#abb2bf",
-                "list.inactiveSelectionBackground": "#323842",
-                "list.inactiveSelectionForeground": "#d7dae0",
-                "list.warningForeground": "#d19a66",
-                "menu.foreground": "#abb2bf",
-                "menu.separatorBackground": "#343a45",
-                "minimapGutter.addedBackground": "#109868",
-                "minimapGutter.deletedBackground": "#9a353d",
-                "minimapGutter.modifiedBackground": "#948b60",
-                "panel.border": "#3e4452",
-                "panelSectionHeader.background": "#1e2227",
-                "peekViewEditor.background": "#1b1d23",
-                "peekViewEditor.matchHighlightBackground": "#29244b",
-                "peekViewResult.background": "#22262b",
-                "scrollbar.shadow": "#23252c",
-                "scrollbarSlider.activeBackground": "#747d9180",
-                "scrollbarSlider.background": "#4e566660",
-                "scrollbarSlider.hoverBackground": "#5a637580",
-                "settings.focusedRowBackground": "#23272e",
-                "settings.headerForeground": "#ffffff",
-                "sideBar.background": "#1e2227",
-                "sideBar.foreground": "#abb2bf",
-                "sideBarSectionHeader.background": "#23272e",
-                "sideBarSectionHeader.foreground": "#abb2bf",
-                "statusBar.background": "#1e2227",
-                "statusBar.debuggingBackground": "#cc6633",
-                "statusBar.debuggingBorder": "#ff000000",
-                "statusBar.debuggingForeground": "#ffffff",
-                "statusBar.foreground": "#9da5b4",
-                "statusBar.noFolderBackground": "#1e2227",
-                "statusBarItem.remoteBackground": "#4d78cc",
-                "statusBarItem.remoteForeground": "#f8fafd",
-                "tab.activeBackground": "#23272e",
-                "tab.activeBorder": "#b4b4b4",
-                "tab.activeForeground": "#dcdcdc",
-                "tab.border": "#181a1f",
-                "tab.hoverBackground": "#323842",
-                "tab.inactiveBackground": "#1e2227",
-                "tab.unfocusedHoverBackground": "#323842",
-                "terminal.ansiBlack": "#3f4451",
-                "terminal.ansiBlue": "#4aa5f0",
-                "terminal.ansiBrightBlack": "#4f5666",
-                "terminal.ansiBrightBlue": "#4dc4ff",
-                "terminal.ansiBrightCyan": "#4cd1e0",
-                "terminal.ansiBrightGreen": "#a5e075",
-                "terminal.ansiBrightMagenta": "#de73ff",
-                "terminal.ansiBrightRed": "#ff616e",
-                "terminal.ansiBrightWhite": "#e6e6e6",
-                "terminal.ansiBrightYellow": "#f0a45d",
-                "terminal.ansiCyan": "#42b3c2",
-                "terminal.ansiGreen": "#8cc265",
-                "terminal.ansiMagenta": "#c162de",
-                "terminal.ansiRed": "#e05561",
-                "terminal.ansiWhite": "#d7dae0",
-                "terminal.ansiYellow": "#d18f52",
-                "terminal.background": "#23272e",
-                "terminal.border": "#3e4452",
-                "terminal.foreground": "#abb2bf",
-                "terminal.selectionBackground": "#abb2bf30",
-                "textBlockQuote.background": "#2e3440",
-                "textBlockQuote.border": "#4b5362",
-                "textLink.foreground": "#61afef",
-                "textPreformat.foreground": "#d19a66",
-                "titleBar.activeBackground": "#23272e",
-                "titleBar.activeForeground": "#9da5b4",
-                "titleBar.inactiveBackground": "#23272e",
-                "titleBar.inactiveForeground": "#6b717d",
-                "tree.indentGuidesStroke": "#ffffff1d",
-                "walkThrough.embeddedEditorBackground": "#2e3440"
-            },
-            "rules": [
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.delayed.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.list.begin.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.list.end.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.ability.begin.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.ability.end.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.operator.assignment.as.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.separator.pipe.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.separator.delimiter.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.hash.unison"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "variable.other.generic-type.haskell"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "storage.type.haskell"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.magic.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.period.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.element.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.parenthesis.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.parenthesis.end.python"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.parameter.function.language.special.self.python"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.parameter.function.language.special.cls.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "storage.modifier.lifetime.rust"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.std.rust"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.lifetime.rust"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.language.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.constant.edge"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.word"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "variable.parameter.function"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "comment markup.link"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "markup.changed.diff"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "punctuation.definition.from-file.diff"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "punctuation.definition.to-file.diff"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inserted.diff"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.deleted.diff"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.function.c"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.function.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.bracket.curly.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.bracket.curly.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.statement.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.bracket.curly.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.bracket.curly.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parens.begin.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parens.end.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parameters.begin.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parameters.end.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "keyword.operator.expression.import"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property.math"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.annotation.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.object.array.java"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.method-parameters.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.method-parameters.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method.identifier.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.inner-class.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.inner-class.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method-call.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.begin.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.end.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.begin.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.end.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.period.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.bracket.angle.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.annotation.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method.body.java"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.method.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.modifier.import.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.generic.java"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.instanceof.java"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.definition.variable.name.java"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.bitwise"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.channel"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property-value.scss"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property-value.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.scss"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.less"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.css"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.scss"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.list.comma.css"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.vendored.property-name.css"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.module.node"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.object.module"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.module.node"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type.module"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.readwrite"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.object.process"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.object.node"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.instanceof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.ternary"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.optional"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.keyof"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.object.console"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.variable.property.process"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.console"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "keyword.operator.misc.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sigil.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.delete"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.object.dom"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.dom"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.arithmetic"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.comparison"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.decrement"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.increment"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.relational"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.comparison.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.increment.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.decrement.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.bitwise.shift.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.comparison.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.increment.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.decrement.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.bitwise.shift.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.delimiter"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.separator.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.separator.cpp"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.posix-reserved.c"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.posix-reserved.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sizeof.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sizeof.cpp"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "variable.parameter.function.language.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.python"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.logical.python"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "variable.parameter.function.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.end.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.arguments.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.list.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.list.end.python"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.generic.python"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant.character.format.placeholder.other.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.compound"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment.compound.js"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment.compound.ts"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "variable.c"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "token.variable.parameter.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "import.storage.java"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.package.keyword"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "token.package"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.require"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.any-method"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type.namespace"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": " entity.name.type.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.class.identifier.namespace.type"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.class.js"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.class.ts"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.class.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "control.elements"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": " keyword.operator.less"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "keyword.other.special-method"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.storage"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.delete"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.in"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.of"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.instanceof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.typeof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.void"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "token.storage.type.java"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.toml"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " support.type.property-name.table.toml"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " support.type.property-name.array.toml"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.other.symbol"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "entity.other.attribute-name.class.css"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "meta.selector"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "markup.heading punctuation.definition.heading"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": " entity.name.section"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "todo.bold"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.bold"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": " punctuation.definition.italic"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "todo.emphasis"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "emphasis md"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.section.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "punctuation.definition.bold.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.string.begin.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.string.end.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "beginning.punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.underline.link.image.markdown"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.raw.monospace.asciidoc"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.asciidoc"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "markup.list.asciidoc"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.link.asciidoc"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.other.url.asciidoc"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.unquoted.asciidoc"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "markup.other.url.asciidoc"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " variable.interpolation"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded.begin"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded.end"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "invalid.illegal.bad-ampersand.html"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "invalid.illegal.unrecognized-tag.html"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.broken"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "invalid.deprecated.entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.unimplemented"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.json meta.structure.dictionary.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.array.json > value.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "source.json meta.structure.dictionary.json > constant.language.json"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "source.json meta.structure.array.json > constant.language.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.json punctuation"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.other.namespace.use.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.other.namespace.use-as.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.other.alias.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "meta.interface.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.error-control.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.type.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.array.begin.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.array.end.php"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "invalid.illegal.non-null-typehinted.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "meta.other.type.phpdoc.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.other.type.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.other.array.phpdoc.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.object.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.static.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.parameters.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.parameters.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.delimiter.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.scope.begin.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.scope.end.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.expression.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.storage-type.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.storage-type.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.array.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.array.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.begin.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.start.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.begin.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.core.rust"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.ext.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.std.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.core.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.parser-token.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.goto-label.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.other.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.logical.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.bitwise.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.arithmetic.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.regexp.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.comparison.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.heredoc.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.nowdoc.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function.decorator.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.token.decorator.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "meta.function.decorator.identifier.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.parameter"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.brace"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.parameter.ruby"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": " function.parameter.cs"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.ruby"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.hashkey.ruby"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "rgb-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "inline-color-decoration rgb-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "less rgb-value"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "selector.sass"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive.ts"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.builtin.ts"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive.tsx"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.builtin.tsx"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "block.scope.end"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "block.scope.begin"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.variable.local.cs"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.definition.template-expression.begin"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.definition.template-expression.end"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.module"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.type.type.flowtype"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.property.object"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.js"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.template.begin"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.template.end"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.substitution.begin"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.substitution.end"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.operator.assignment.go"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.arithmetic.go"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.address.go"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.package.go"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.prelude.elm"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.elm"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.quasi.element"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.character.entity"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.global.clojure"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.symbol.clojure"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.keyword.clojure"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.arguments.coffee"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.coffee"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.ini"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.scope.prerequisites.makefile"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "source.makefile"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.modifier.import.groovy"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.method.groovy"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.definition.variable.name.groovy"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "meta.definition.class.inherited.classes.groovy"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.variable.semantic.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.texture.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.sampler.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.rw.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.fx.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.hlsl"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "text.variable"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "text.bracketed"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.swift"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.vb.asp"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.function.xi"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.name.class.xi"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.character.character-class.regexp.xi"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "constant.regexp.xi"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.control.xi"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "invalid.xi"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "beginning.punctuation.definition.quote.markdown.xi"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "token": "beginning.punctuation.definition.list.markdown.xi"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "constant.character.xi"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "accent.xi"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "wikiword.xi"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "constant.other.color.rgb-value.xi"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "punctuation.definition.tag.xi"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.label.cs"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.scope-resolution.function.call"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.scope-resolution.function.definition"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.label.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading.setext.1.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading.setext.2.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": " meta.brace.square"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "token": " punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "markup.quote.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.block.sequence.item.yaml"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.elixir"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.double-quoted.elixir"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.variable.parameter.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.variable.field.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inserted"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#BE5046",
-                    "token": "punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#BE5046",
-                    "token": "punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.latex"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.object"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.constant.property"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.readwrite.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "entity.name.variable.parameter.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.colon.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "constant.other.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "constant.numeric.decimal.asm.x86_64"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.other.parenthesis.regexp"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "log.info"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "log.warning"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "log.error"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.is"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.label"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#23272e",
+        "activityBar.foreground": "#d7dae0",
+        "activityBarBadge.background": "#4d78cc",
+        "activityBarBadge.foreground": "#f8fafd",
+        "badge.background": "#23272e",
+        "button.background": "#404754",
+        "button.secondaryBackground": "#30333d",
+        "button.secondaryForeground": "#c0bdbd",
+        "checkbox.border": "#404754",
+        "debugToolBar.background": "#1e2227",
+        "descriptionForeground": "#abb2bf",
+        "diffEditor.insertedTextBackground": "#00809b33",
+        "dropdown.background": "#1e2227",
+        "dropdown.border": "#1e2227",
+        "editor.background": "#23272e",
+        "editor.findMatchBackground": "#42557b",
+        "editor.findMatchBorder": "#457dff",
+        "editor.findMatchHighlightBackground": "#6199ff2f",
+        "editor.foreground": "#abb2bf",
+        "editor.lineHighlightBackground": "#2c313c",
+        "editor.selectionBackground": "#67769660",
+        "editor.selectionHighlightBackground": "#ffffff10",
+        "editor.selectionHighlightBorder": "#dddddd",
+        "editor.wordHighlightBackground": "#d2e0ff2f",
+        "editor.wordHighlightBorder": "#7f848e",
+        "editor.wordHighlightStrongBackground": "#abb2bf26",
+        "editor.wordHighlightStrongBorder": "#7f848e",
+        "editorBracketHighlight.foreground1": "#d19a66",
+        "editorBracketHighlight.foreground2": "#c678dd",
+        "editorBracketHighlight.foreground3": "#56b6c2",
+        "editorBracketMatch.background": "#515a6b",
+        "editorBracketMatch.border": "#515a6b",
+        "editorCursor.background": "#ffffffc9",
+        "editorCursor.foreground": "#528bff",
+        "editorError.foreground": "#c24038",
+        "editorGroup.border": "#181a1f",
+        "editorGroupHeader.tabsBackground": "#1e2227",
+        "editorGutter.addedBackground": "#109868",
+        "editorGutter.deletedBackground": "#9a353d",
+        "editorGutter.modifiedBackground": "#948b60",
+        "editorHoverWidget.background": "#1e2227",
+        "editorHoverWidget.border": "#181a1f",
+        "editorHoverWidget.highlightForeground": "#61afef",
+        "editorIndentGuide.activeBackground": "#c8c8c859",
+        "editorIndentGuide.background": "#3b4048",
+        "editorInlayHint.background": "#2c313c",
+        "editorInlayHint.foreground": "#abb2bf",
+        "editorLineNumber.activeForeground": "#abb2bf",
+        "editorLineNumber.foreground": "#495162",
+        "editorMarkerNavigation.background": "#1e2227",
+        "editorRuler.foreground": "#abb2bf26",
+        "editorSuggestWidget.background": "#1e2227",
+        "editorSuggestWidget.border": "#181a1f",
+        "editorSuggestWidget.selectedBackground": "#2c313a",
+        "editorWarning.foreground": "#d19a66",
+        "editorWhitespace.foreground": "#ffffff1d",
+        "editorWidget.background": "#1e2227",
+        "focusBorder": "#3e4452",
+        "gitDecoration.ignoredResourceForeground": "#636b78",
+        "input.background": "#1d1f23",
+        "input.foreground": "#abb2bf",
+        "list.activeSelectionBackground": "#2c313a",
+        "list.activeSelectionForeground": "#d7dae0",
+        "list.focusBackground": "#323842",
+        "list.focusForeground": "#f0f0f0",
+        "list.highlightForeground": "#ecebeb",
+        "list.hoverBackground": "#2c313a",
+        "list.hoverForeground": "#abb2bf",
+        "list.inactiveSelectionBackground": "#323842",
+        "list.inactiveSelectionForeground": "#d7dae0",
+        "list.warningForeground": "#d19a66",
+        "menu.foreground": "#abb2bf",
+        "menu.separatorBackground": "#343a45",
+        "minimapGutter.addedBackground": "#109868",
+        "minimapGutter.deletedBackground": "#9a353d",
+        "minimapGutter.modifiedBackground": "#948b60",
+        "panel.border": "#3e4452",
+        "panelSectionHeader.background": "#1e2227",
+        "peekViewEditor.background": "#1b1d23",
+        "peekViewEditor.matchHighlightBackground": "#29244b",
+        "peekViewResult.background": "#22262b",
+        "scrollbar.shadow": "#23252c",
+        "scrollbarSlider.activeBackground": "#747d9180",
+        "scrollbarSlider.background": "#4e566660",
+        "scrollbarSlider.hoverBackground": "#5a637580",
+        "settings.focusedRowBackground": "#23272e",
+        "settings.headerForeground": "#ffffff",
+        "sideBar.background": "#1e2227",
+        "sideBar.foreground": "#abb2bf",
+        "sideBarSectionHeader.background": "#23272e",
+        "sideBarSectionHeader.foreground": "#abb2bf",
+        "statusBar.background": "#1e2227",
+        "statusBar.debuggingBackground": "#cc6633",
+        "statusBar.debuggingBorder": "#ff000000",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.foreground": "#9da5b4",
+        "statusBar.noFolderBackground": "#1e2227",
+        "statusBarItem.remoteBackground": "#4d78cc",
+        "statusBarItem.remoteForeground": "#f8fafd",
+        "tab.activeBackground": "#23272e",
+        "tab.activeBorder": "#b4b4b4",
+        "tab.activeForeground": "#dcdcdc",
+        "tab.border": "#181a1f",
+        "tab.hoverBackground": "#323842",
+        "tab.inactiveBackground": "#1e2227",
+        "tab.unfocusedHoverBackground": "#323842",
+        "terminal.ansiBlack": "#3f4451",
+        "terminal.ansiBlue": "#4aa5f0",
+        "terminal.ansiBrightBlack": "#4f5666",
+        "terminal.ansiBrightBlue": "#4dc4ff",
+        "terminal.ansiBrightCyan": "#4cd1e0",
+        "terminal.ansiBrightGreen": "#a5e075",
+        "terminal.ansiBrightMagenta": "#de73ff",
+        "terminal.ansiBrightRed": "#ff616e",
+        "terminal.ansiBrightWhite": "#e6e6e6",
+        "terminal.ansiBrightYellow": "#f0a45d",
+        "terminal.ansiCyan": "#42b3c2",
+        "terminal.ansiGreen": "#8cc265",
+        "terminal.ansiMagenta": "#c162de",
+        "terminal.ansiRed": "#e05561",
+        "terminal.ansiWhite": "#d7dae0",
+        "terminal.ansiYellow": "#d18f52",
+        "terminal.background": "#23272e",
+        "terminal.border": "#3e4452",
+        "terminal.foreground": "#abb2bf",
+        "terminal.selectionBackground": "#abb2bf30",
+        "textBlockQuote.background": "#2e3440",
+        "textBlockQuote.border": "#4b5362",
+        "textLink.foreground": "#61afef",
+        "textPreformat.foreground": "#d19a66",
+        "titleBar.activeBackground": "#23272e",
+        "titleBar.activeForeground": "#9da5b4",
+        "titleBar.inactiveBackground": "#23272e",
+        "titleBar.inactiveForeground": "#6b717d",
+        "tree.indentGuidesStroke": "#ffffff1d",
+        "walkThrough.embeddedEditorBackground": "#2e3440"
+    },
+    "rules": [
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.delayed.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.list.begin.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.list.end.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.ability.begin.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.ability.end.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.operator.assignment.as.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.separator.pipe.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.separator.delimiter.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.hash.unison"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "variable.other.generic-type.haskell"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "storage.type.haskell"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.magic.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.period.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.element.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.parenthesis.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.parenthesis.end.python"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.parameter.function.language.special.self.python"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.parameter.function.language.special.cls.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "storage.modifier.lifetime.rust"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.std.rust"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.lifetime.rust"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.language.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.constant.edge"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.word"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "variable.parameter.function"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "comment markup.link"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "markup.changed.diff"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "punctuation.definition.from-file.diff"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "punctuation.definition.to-file.diff"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inserted.diff"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.deleted.diff"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.function.c"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.function.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.bracket.curly.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.bracket.curly.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.statement.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.bracket.curly.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.bracket.curly.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parens.begin.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parens.end.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parameters.begin.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parameters.end.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "keyword.operator.expression.import"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property.math"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.annotation.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.object.array.java"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.method-parameters.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.method-parameters.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method.identifier.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.inner-class.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.inner-class.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method-call.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.begin.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.end.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.begin.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.end.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.period.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.bracket.angle.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.annotation.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method.body.java"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.method.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.modifier.import.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.generic.java"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.instanceof.java"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.definition.variable.name.java"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.bitwise"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.channel"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property-value.scss"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property-value.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.scss"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.less"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.css"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.scss"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.list.comma.css"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.vendored.property-name.css"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.module.node"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.object.module"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.module.node"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type.module"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.readwrite"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.object.process"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.object.node"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.instanceof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.ternary"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.optional"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.keyof"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.object.console"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.variable.property.process"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.console"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "keyword.operator.misc.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sigil.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.delete"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.object.dom"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.dom"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.arithmetic"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.comparison"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.decrement"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.increment"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.relational"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.comparison.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.increment.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.decrement.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.bitwise.shift.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.comparison.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.increment.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.decrement.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.bitwise.shift.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.delimiter"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.separator.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.separator.cpp"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.posix-reserved.c"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.posix-reserved.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sizeof.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sizeof.cpp"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "variable.parameter.function.language.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.python"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.logical.python"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "variable.parameter.function.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.end.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.arguments.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.list.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.list.end.python"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.generic.python"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant.character.format.placeholder.other.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.compound"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment.compound.js"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment.compound.ts"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "variable.c"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "token.variable.parameter.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "import.storage.java"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.package.keyword"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "token.package"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.require"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.any-method"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type.namespace"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": " entity.name.type.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.class.identifier.namespace.type"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.class.js"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.class.ts"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.class.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "control.elements"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": " keyword.operator.less"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "keyword.other.special-method"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "storage"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.storage"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.delete"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.in"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.of"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.instanceof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.typeof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.void"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "token.storage.type.java"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.toml"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " support.type.property-name.table.toml"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " support.type.property-name.array.toml"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "string"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.other.symbol"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "entity.other.attribute-name.class.css"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "meta.selector"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "markup.heading punctuation.definition.heading"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": " entity.name.section"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "todo.bold"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.bold"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": " punctuation.definition.italic"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "todo.emphasis"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "emphasis md"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.section.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "markup.heading.setext"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "punctuation.definition.bold.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.string.begin.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.string.end.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "beginning.punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.underline.link.image.markdown"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.raw.monospace.asciidoc"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.asciidoc"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "markup.list.asciidoc"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.link.asciidoc"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.other.url.asciidoc"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.unquoted.asciidoc"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "markup.other.url.asciidoc"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " variable.interpolation"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded.begin"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded.end"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "invalid.illegal.bad-ampersand.html"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "invalid.illegal.unrecognized-tag.html"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.broken"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "invalid.deprecated.entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.unimplemented"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.json meta.structure.dictionary.json > string.quoted.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.array.json > value.json > string.quoted.json"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "source.json meta.structure.dictionary.json > constant.language.json"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "source.json meta.structure.array.json > constant.language.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.json punctuation"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.other.namespace.use.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.other.namespace.use-as.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.other.alias.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "meta.interface.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.error-control.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.type.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.array.begin.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.array.end.php"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "invalid.illegal.non-null-typehinted.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "meta.other.type.phpdoc.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.other.type.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.other.array.phpdoc.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.object.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.static.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.parameters.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.parameters.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.delimiter.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.scope.begin.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.scope.end.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.expression.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.storage-type.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.storage-type.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.array.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.array.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.begin.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.start.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.begin.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.core.rust"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.ext.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.std.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.core.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.parser-token.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.goto-label.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.other.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.logical.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.bitwise.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.arithmetic.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.regexp.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.comparison.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.heredoc.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.nowdoc.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function.decorator.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.token.decorator.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "meta.function.decorator.identifier.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.parameter"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.brace"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.parameter.ruby"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": " function.parameter.cs"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.ruby"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.hashkey.ruby"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "rgb-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "inline-color-decoration rgb-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "less rgb-value"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "selector.sass"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive.ts"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.builtin.ts"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive.tsx"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.builtin.tsx"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "block.scope.end"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "block.scope.begin"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.variable.local.cs"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.definition.template-expression.begin"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.definition.template-expression.end"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.module"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.type.type.flowtype"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.property.object"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.js"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.template.begin"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.template.end"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.substitution.begin"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.substitution.end"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.operator.assignment.go"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.arithmetic.go"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.address.go"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.package.go"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.prelude.elm"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.elm"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.quasi.element"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.character.entity"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.global.clojure"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.symbol.clojure"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.keyword.clojure"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.arguments.coffee"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.coffee"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.ini"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.scope.prerequisites.makefile"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "source.makefile"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.modifier.import.groovy"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.method.groovy"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.definition.variable.name.groovy"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "meta.definition.class.inherited.classes.groovy"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.variable.semantic.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.texture.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.sampler.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.rw.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.fx.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.hlsl"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "text.variable"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "text.bracketed"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.swift"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.vb.asp"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.function.xi"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.name.class.xi"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.character.character-class.regexp.xi"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "constant.regexp.xi"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.control.xi"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "invalid.xi"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "beginning.punctuation.definition.quote.markdown.xi"
+        },
+        {
+            "foreground": "#7F848E",
+            "token": "beginning.punctuation.definition.list.markdown.xi"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "constant.character.xi"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "accent.xi"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "wikiword.xi"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "constant.other.color.rgb-value.xi"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "punctuation.definition.tag.xi"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.label.cs"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.scope-resolution.function.call"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.scope-resolution.function.definition"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.label.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading.setext.1.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading.setext.2.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": " meta.brace.square"
+        },
+        {
+            "foreground": "#7F848E",
+            "token": "comment"
+        },
+        {
+            "foreground": "#7F848E",
+            "token": " punctuation.definition.comment"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "markup.quote.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.block.sequence.item.yaml"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.elixir"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.double-quoted.elixir"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.variable.parameter.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.variable.field.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inserted"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#BE5046",
+            "token": "punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#BE5046",
+            "token": "punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.latex"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.object"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.constant.property"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.readwrite.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "entity.name.variable.parameter.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.colon.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "constant.other.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "constant.numeric.decimal.asm.x86_64"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.other.parenthesis.regexp"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "log.info"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "log.warning"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "log.error"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.is"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.label"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/one-dark-pro/one-dark-pro-monaco.json
+++ b/themes/one-dark-pro/one-dark-pro-monaco.json
@@ -1,1971 +1,1967 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#282c34",
-                "activityBar.foreground": "#d7dae0",
-                "activityBarBadge.background": "#4d78cc",
-                "activityBarBadge.foreground": "#f8fafd",
-                "badge.background": "#282c34",
-                "button.background": "#404754",
-                "button.secondaryBackground": "#30333d",
-                "button.secondaryForeground": "#c0bdbd",
-                "checkbox.border": "#404754",
-                "debugToolBar.background": "#21252b",
-                "descriptionForeground": "#abb2bf",
-                "diffEditor.insertedTextBackground": "#00809b33",
-                "dropdown.background": "#21252b",
-                "dropdown.border": "#21252b",
-                "editor.background": "#282c34",
-                "editor.findMatchBackground": "#42557b",
-                "editor.findMatchBorder": "#457dff",
-                "editor.findMatchHighlightBackground": "#6199ff2f",
-                "editor.foreground": "#abb2bf",
-                "editor.lineHighlightBackground": "#2c313c",
-                "editor.selectionBackground": "#67769660",
-                "editor.selectionHighlightBackground": "#ffffff10",
-                "editor.selectionHighlightBorder": "#dddddd",
-                "editor.wordHighlightBackground": "#d2e0ff2f",
-                "editor.wordHighlightBorder": "#7f848e",
-                "editor.wordHighlightStrongBackground": "#abb2bf26",
-                "editor.wordHighlightStrongBorder": "#7f848e",
-                "editorBracketHighlight.foreground1": "#d19a66",
-                "editorBracketHighlight.foreground2": "#c678dd",
-                "editorBracketHighlight.foreground3": "#56b6c2",
-                "editorBracketMatch.background": "#515a6b",
-                "editorBracketMatch.border": "#515a6b",
-                "editorCursor.background": "#ffffffc9",
-                "editorCursor.foreground": "#528bff",
-                "editorError.foreground": "#c24038",
-                "editorGroup.border": "#181a1f",
-                "editorGroupHeader.tabsBackground": "#21252b",
-                "editorGutter.addedBackground": "#109868",
-                "editorGutter.deletedBackground": "#9a353d",
-                "editorGutter.modifiedBackground": "#948b60",
-                "editorHoverWidget.background": "#21252b",
-                "editorHoverWidget.border": "#181a1f",
-                "editorHoverWidget.highlightForeground": "#61afef",
-                "editorIndentGuide.activeBackground": "#c8c8c859",
-                "editorIndentGuide.background": "#3b4048",
-                "editorInlayHint.background": "#2c313c",
-                "editorInlayHint.foreground": "#abb2bf",
-                "editorLineNumber.activeForeground": "#abb2bf",
-                "editorLineNumber.foreground": "#495162",
-                "editorMarkerNavigation.background": "#21252b",
-                "editorRuler.foreground": "#abb2bf26",
-                "editorSuggestWidget.background": "#21252b",
-                "editorSuggestWidget.border": "#181a1f",
-                "editorSuggestWidget.selectedBackground": "#2c313a",
-                "editorWarning.foreground": "#d19a66",
-                "editorWhitespace.foreground": "#ffffff1d",
-                "editorWidget.background": "#21252b",
-                "focusBorder": "#3e4452",
-                "gitDecoration.ignoredResourceForeground": "#636b78",
-                "input.background": "#1d1f23",
-                "input.foreground": "#abb2bf",
-                "list.activeSelectionBackground": "#2c313a",
-                "list.activeSelectionForeground": "#d7dae0",
-                "list.focusBackground": "#323842",
-                "list.focusForeground": "#f0f0f0",
-                "list.highlightForeground": "#ecebeb",
-                "list.hoverBackground": "#2c313a",
-                "list.hoverForeground": "#abb2bf",
-                "list.inactiveSelectionBackground": "#323842",
-                "list.inactiveSelectionForeground": "#d7dae0",
-                "list.warningForeground": "#d19a66",
-                "menu.foreground": "#abb2bf",
-                "menu.separatorBackground": "#343a45",
-                "minimapGutter.addedBackground": "#109868",
-                "minimapGutter.deletedBackground": "#9a353d",
-                "minimapGutter.modifiedBackground": "#948b60",
-                "panel.border": "#3e4452",
-                "panelSectionHeader.background": "#21252b",
-                "peekViewEditor.background": "#1b1d23",
-                "peekViewEditor.matchHighlightBackground": "#29244b",
-                "peekViewResult.background": "#22262b",
-                "scrollbar.shadow": "#23252c",
-                "scrollbarSlider.activeBackground": "#747d9180",
-                "scrollbarSlider.background": "#4e566660",
-                "scrollbarSlider.hoverBackground": "#5a637580",
-                "settings.focusedRowBackground": "#282c34",
-                "settings.headerForeground": "#ffffff",
-                "sideBar.background": "#21252b",
-                "sideBar.foreground": "#abb2bf",
-                "sideBarSectionHeader.background": "#282c34",
-                "sideBarSectionHeader.foreground": "#abb2bf",
-                "statusBar.background": "#21252b",
-                "statusBar.debuggingBackground": "#cc6633",
-                "statusBar.debuggingBorder": "#ff000000",
-                "statusBar.debuggingForeground": "#ffffff",
-                "statusBar.foreground": "#9da5b4",
-                "statusBar.noFolderBackground": "#21252b",
-                "statusBarItem.remoteBackground": "#4d78cc",
-                "statusBarItem.remoteForeground": "#f8fafd",
-                "tab.activeBackground": "#282c34",
-                "tab.activeBorder": "#b4b4b4",
-                "tab.activeForeground": "#dcdcdc",
-                "tab.border": "#181a1f",
-                "tab.hoverBackground": "#323842",
-                "tab.inactiveBackground": "#21252b",
-                "tab.unfocusedHoverBackground": "#323842",
-                "terminal.ansiBlack": "#3f4451",
-                "terminal.ansiBlue": "#4aa5f0",
-                "terminal.ansiBrightBlack": "#4f5666",
-                "terminal.ansiBrightBlue": "#4dc4ff",
-                "terminal.ansiBrightCyan": "#4cd1e0",
-                "terminal.ansiBrightGreen": "#a5e075",
-                "terminal.ansiBrightMagenta": "#de73ff",
-                "terminal.ansiBrightRed": "#ff616e",
-                "terminal.ansiBrightWhite": "#e6e6e6",
-                "terminal.ansiBrightYellow": "#f0a45d",
-                "terminal.ansiCyan": "#42b3c2",
-                "terminal.ansiGreen": "#8cc265",
-                "terminal.ansiMagenta": "#c162de",
-                "terminal.ansiRed": "#e05561",
-                "terminal.ansiWhite": "#d7dae0",
-                "terminal.ansiYellow": "#d18f52",
-                "terminal.background": "#282c34",
-                "terminal.border": "#3e4452",
-                "terminal.foreground": "#abb2bf",
-                "terminal.selectionBackground": "#abb2bf30",
-                "textBlockQuote.background": "#2e3440",
-                "textBlockQuote.border": "#4b5362",
-                "textLink.foreground": "#61afef",
-                "textPreformat.foreground": "#d19a66",
-                "titleBar.activeBackground": "#282c34",
-                "titleBar.activeForeground": "#9da5b4",
-                "titleBar.inactiveBackground": "#282c34",
-                "titleBar.inactiveForeground": "#6b717d",
-                "tree.indentGuidesStroke": "#ffffff1d",
-                "walkThrough.embeddedEditorBackground": "#2e3440"
-            },
-            "rules": [
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.delayed.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.list.begin.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.list.end.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.ability.begin.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.ability.end.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.operator.assignment.as.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.separator.pipe.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.separator.delimiter.unison"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.hash.unison"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "variable.other.generic-type.haskell"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "storage.type.haskell"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.magic.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.period.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.element.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.parenthesis.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.parenthesis.end.python"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.parameter.function.language.special.self.python"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.parameter.function.language.special.cls.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "storage.modifier.lifetime.rust"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.std.rust"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.lifetime.rust"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.language.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.constant.edge"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.word"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "variable.parameter.function"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "comment markup.link"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "markup.changed.diff"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.diff.header.from-file"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.diff.header.to-file"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "punctuation.definition.from-file.diff"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "punctuation.definition.to-file.diff"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inserted.diff"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.deleted.diff"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.function.c"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.function.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.bracket.curly.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.bracket.curly.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.statement.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.bracket.curly.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.bracket.curly.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parens.begin.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parens.end.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parameters.begin.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.parameters.end.bracket.round.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "keyword.operator.expression.import"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property.math"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.annotation.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.object.array.java"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.block.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.method-parameters.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.method-parameters.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method.identifier.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.inner-class.begin.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.inner-class.end.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method-call.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.begin.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.class.end.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.begin.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.method.end.bracket.curly.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.period.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.bracket.angle.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.annotation.java"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.method.body.java"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.method.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.modifier.import.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.generic.java"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.instanceof.java"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.definition.variable.name.java"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.bitwise"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.channel"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property-value.scss"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.property-value.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.scss"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.less"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.css"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.scss"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.list.comma.css"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.color.w3c-standard-color-name.css"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.vendored.property-name.css"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.module.node"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.object.module"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.module.node"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type.module"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.readwrite"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.object.process"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.object.node"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.instanceof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.ternary"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.optional"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.keyof"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.object.console"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.variable.property.process"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.console"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "keyword.operator.misc.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sigil.rust"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.delete"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.object.dom"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.dom"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.arithmetic"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.comparison"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.decrement"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.increment"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.relational"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.comparison.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.increment.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.decrement.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.bitwise.shift.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.comparison.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.increment.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.decrement.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.bitwise.shift.cpp"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.delimiter"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.separator.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.separator.cpp"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.posix-reserved.c"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.posix-reserved.cpp"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sizeof.c"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.sizeof.cpp"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "variable.parameter.function.language.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.python"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.logical.python"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "variable.parameter.function.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.end.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.arguments.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.list.begin.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.list.end.python"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.generic.python"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant.character.format.placeholder.other.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.assignment.compound"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment.compound.js"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment.compound.ts"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "variable.c"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "token.variable.parameter.java"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "import.storage.java"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.package.keyword"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "token.package"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.require"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.function.any-method"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type.namespace"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": " entity.name.type.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.class.identifier.namespace.type"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.class.js"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.class.ts"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.class.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "control.elements"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": " keyword.operator.less"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "keyword.other.special-method"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.storage"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.delete"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.in"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.of"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.instanceof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.typeof"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.void"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "token.storage.type.java"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.toml"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " support.type.property-name.table.toml"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " support.type.property-name.array.toml"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.other.symbol"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "constant"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "entity.other.attribute-name.class.css"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "meta.selector"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "markup.heading punctuation.definition.heading"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": " entity.name.section"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "todo.bold"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.bold"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": " punctuation.definition.italic"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "todo.emphasis"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "emphasis md"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.section.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "punctuation.definition.bold.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.string.begin.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.string.end.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "beginning.punctuation.definition.list.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.definition.metadata.markdown"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.underline.link.markdown"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.underline.link.image.markdown"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.other.link.title.markdown"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.other.link.description.markdown"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.raw.monospace.asciidoc"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "punctuation.definition.asciidoc"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "markup.list.asciidoc"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.link.asciidoc"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "markup.other.url.asciidoc"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "string.unquoted.asciidoc"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "markup.other.url.asciidoc"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": " variable.interpolation"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded.begin"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded.end"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "invalid.illegal.bad-ampersand.html"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "invalid.illegal.unrecognized-tag.html"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.broken"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "invalid.deprecated.entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.unimplemented"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.json meta.structure.dictionary.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.array.json > value.json > string.quoted.json"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "source.json meta.structure.dictionary.json > constant.language.json"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "source.json meta.structure.array.json > constant.language.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.json"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "support.type.property-name.json punctuation"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.other.namespace.use.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.other.namespace.use-as.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.other.alias.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "meta.interface.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.error-control.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.type.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.array.begin.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.array.end.php"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "invalid.illegal.non-null-typehinted.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "meta.other.type.phpdoc.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.other.type.php"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.other.array.phpdoc.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.object.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function-call.static.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.parameters.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.parameters.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.delimiter.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.scope.begin.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.section.scope.end.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.terminator.expression.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.arguments.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.storage-type.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.storage-type.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.array.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.array.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.begin.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.end.bracket.round.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.begin.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.start.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.begin.bracket.curly.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.core.rust"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.ext.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.std.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.core.php"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.parser-token.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "entity.name.goto-label.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.other.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.logical.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.bitwise.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.arithmetic.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.regexp.php"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.comparison.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.heredoc.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.nowdoc.php"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.function.decorator.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.token.decorator.python"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "meta.function.decorator.identifier.python"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.parameter"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.brace"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "function.parameter.ruby"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": " function.parameter.cs"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.ruby"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.hashkey.ruby"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "rgb-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "inline-color-decoration rgb-value"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "less rgb-value"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "selector.sass"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive.ts"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.builtin.ts"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive.tsx"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.builtin.tsx"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "block.scope.end"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "block.scope.begin"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.variable.local.cs"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.definition.template-expression.begin"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.definition.template-expression.end"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.module"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "support.type.type.flowtype"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.primitive"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.property.object"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.js"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.template.begin"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.template.end"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.substitution.begin"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "keyword.other.substitution.end"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.operator.assignment"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "keyword.operator.assignment.go"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.arithmetic.go"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.address.go"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.package.go"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "support.type.prelude.elm"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.constant.elm"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "punctuation.quasi.element"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.character.entity"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.global.clojure"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.symbol.clojure"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.keyword.clojure"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.arguments.coffee"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.coffee"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "source.ini"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.scope.prerequisites.makefile"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "source.makefile"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "storage.modifier.import.groovy"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "meta.method.groovy"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "meta.definition.variable.name.groovy"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "meta.definition.class.inherited.classes.groovy"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.variable.semantic.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.texture.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.sampler.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.rw.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.fx.hlsl"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "support.type.object.hlsl"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "text.variable"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "text.bracketed"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.swift"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "support.type.vb.asp"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.function.xi"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "entity.name.class.xi"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "constant.character.character-class.regexp.xi"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "constant.regexp.xi"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "keyword.control.xi"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "invalid.xi"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "beginning.punctuation.definition.quote.markdown.xi"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "token": "beginning.punctuation.definition.list.markdown.xi"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "constant.character.xi"
-                },
-                {
-                    "foreground": "#61AFEF",
-                    "token": "accent.xi"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "wikiword.xi"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "constant.other.color.rgb-value.xi"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "punctuation.definition.tag.xi"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.label.cs"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.scope-resolution.function.call"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.scope-resolution.function.definition"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.label.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading.setext.1.markdown"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.heading.setext.2.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": " meta.brace.square"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#7F848E",
-                    "fontStyle": "italic",
-                    "token": " punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#5C6370",
-                    "token": "markup.quote.markdown"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.definition.block.sequence.item.yaml"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.elixir"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.language.symbol.double-quoted.elixir"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.name.variable.parameter.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.variable.field.cs"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "markup.inserted"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#BE5046",
-                    "token": "punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#BE5046",
-                    "token": "punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.parameter.function.latex"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "variable.other.object"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.constant.property"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "variable.other.readwrite.c"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "entity.name.variable.parameter.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "punctuation.separator.colon.php"
-                },
-                {
-                    "foreground": "#ABB2BF",
-                    "token": "constant.other.php"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "constant.numeric.decimal.asm.x86_64"
-                },
-                {
-                    "foreground": "#D19A66",
-                    "token": "support.other.parenthesis.regexp"
-                },
-                {
-                    "foreground": "#56B6C2",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#98C379",
-                    "token": "log.info"
-                },
-                {
-                    "foreground": "#E5C07B",
-                    "token": "log.warning"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "log.error"
-                },
-                {
-                    "foreground": "#C678DD",
-                    "token": "keyword.operator.expression.is"
-                },
-                {
-                    "foreground": "#E06C75",
-                    "token": "entity.name.label"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.ts"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.jsx"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "entity.other.attribute-name.tsx"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.parameter"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "variable.language.super"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.line.double-slash"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "comment.block.documentation"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic.markdown"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#282c34",
+        "activityBar.foreground": "#d7dae0",
+        "activityBarBadge.background": "#4d78cc",
+        "activityBarBadge.foreground": "#f8fafd",
+        "badge.background": "#282c34",
+        "button.background": "#404754",
+        "button.secondaryBackground": "#30333d",
+        "button.secondaryForeground": "#c0bdbd",
+        "checkbox.border": "#404754",
+        "debugToolBar.background": "#21252b",
+        "descriptionForeground": "#abb2bf",
+        "diffEditor.insertedTextBackground": "#00809b33",
+        "dropdown.background": "#21252b",
+        "dropdown.border": "#21252b",
+        "editor.background": "#282c34",
+        "editor.findMatchBackground": "#42557b",
+        "editor.findMatchBorder": "#457dff",
+        "editor.findMatchHighlightBackground": "#6199ff2f",
+        "editor.foreground": "#abb2bf",
+        "editor.lineHighlightBackground": "#2c313c",
+        "editor.selectionBackground": "#67769660",
+        "editor.selectionHighlightBackground": "#ffffff10",
+        "editor.selectionHighlightBorder": "#dddddd",
+        "editor.wordHighlightBackground": "#d2e0ff2f",
+        "editor.wordHighlightBorder": "#7f848e",
+        "editor.wordHighlightStrongBackground": "#abb2bf26",
+        "editor.wordHighlightStrongBorder": "#7f848e",
+        "editorBracketHighlight.foreground1": "#d19a66",
+        "editorBracketHighlight.foreground2": "#c678dd",
+        "editorBracketHighlight.foreground3": "#56b6c2",
+        "editorBracketMatch.background": "#515a6b",
+        "editorBracketMatch.border": "#515a6b",
+        "editorCursor.background": "#ffffffc9",
+        "editorCursor.foreground": "#528bff",
+        "editorError.foreground": "#c24038",
+        "editorGroup.border": "#181a1f",
+        "editorGroupHeader.tabsBackground": "#21252b",
+        "editorGutter.addedBackground": "#109868",
+        "editorGutter.deletedBackground": "#9a353d",
+        "editorGutter.modifiedBackground": "#948b60",
+        "editorHoverWidget.background": "#21252b",
+        "editorHoverWidget.border": "#181a1f",
+        "editorHoverWidget.highlightForeground": "#61afef",
+        "editorIndentGuide.activeBackground": "#c8c8c859",
+        "editorIndentGuide.background": "#3b4048",
+        "editorInlayHint.background": "#2c313c",
+        "editorInlayHint.foreground": "#abb2bf",
+        "editorLineNumber.activeForeground": "#abb2bf",
+        "editorLineNumber.foreground": "#495162",
+        "editorMarkerNavigation.background": "#21252b",
+        "editorRuler.foreground": "#abb2bf26",
+        "editorSuggestWidget.background": "#21252b",
+        "editorSuggestWidget.border": "#181a1f",
+        "editorSuggestWidget.selectedBackground": "#2c313a",
+        "editorWarning.foreground": "#d19a66",
+        "editorWhitespace.foreground": "#ffffff1d",
+        "editorWidget.background": "#21252b",
+        "focusBorder": "#3e4452",
+        "gitDecoration.ignoredResourceForeground": "#636b78",
+        "input.background": "#1d1f23",
+        "input.foreground": "#abb2bf",
+        "list.activeSelectionBackground": "#2c313a",
+        "list.activeSelectionForeground": "#d7dae0",
+        "list.focusBackground": "#323842",
+        "list.focusForeground": "#f0f0f0",
+        "list.highlightForeground": "#ecebeb",
+        "list.hoverBackground": "#2c313a",
+        "list.hoverForeground": "#abb2bf",
+        "list.inactiveSelectionBackground": "#323842",
+        "list.inactiveSelectionForeground": "#d7dae0",
+        "list.warningForeground": "#d19a66",
+        "menu.foreground": "#abb2bf",
+        "menu.separatorBackground": "#343a45",
+        "minimapGutter.addedBackground": "#109868",
+        "minimapGutter.deletedBackground": "#9a353d",
+        "minimapGutter.modifiedBackground": "#948b60",
+        "panel.border": "#3e4452",
+        "panelSectionHeader.background": "#21252b",
+        "peekViewEditor.background": "#1b1d23",
+        "peekViewEditor.matchHighlightBackground": "#29244b",
+        "peekViewResult.background": "#22262b",
+        "scrollbar.shadow": "#23252c",
+        "scrollbarSlider.activeBackground": "#747d9180",
+        "scrollbarSlider.background": "#4e566660",
+        "scrollbarSlider.hoverBackground": "#5a637580",
+        "settings.focusedRowBackground": "#282c34",
+        "settings.headerForeground": "#ffffff",
+        "sideBar.background": "#21252b",
+        "sideBar.foreground": "#abb2bf",
+        "sideBarSectionHeader.background": "#282c34",
+        "sideBarSectionHeader.foreground": "#abb2bf",
+        "statusBar.background": "#21252b",
+        "statusBar.debuggingBackground": "#cc6633",
+        "statusBar.debuggingBorder": "#ff000000",
+        "statusBar.debuggingForeground": "#ffffff",
+        "statusBar.foreground": "#9da5b4",
+        "statusBar.noFolderBackground": "#21252b",
+        "statusBarItem.remoteBackground": "#4d78cc",
+        "statusBarItem.remoteForeground": "#f8fafd",
+        "tab.activeBackground": "#282c34",
+        "tab.activeBorder": "#b4b4b4",
+        "tab.activeForeground": "#dcdcdc",
+        "tab.border": "#181a1f",
+        "tab.hoverBackground": "#323842",
+        "tab.inactiveBackground": "#21252b",
+        "tab.unfocusedHoverBackground": "#323842",
+        "terminal.ansiBlack": "#3f4451",
+        "terminal.ansiBlue": "#4aa5f0",
+        "terminal.ansiBrightBlack": "#4f5666",
+        "terminal.ansiBrightBlue": "#4dc4ff",
+        "terminal.ansiBrightCyan": "#4cd1e0",
+        "terminal.ansiBrightGreen": "#a5e075",
+        "terminal.ansiBrightMagenta": "#de73ff",
+        "terminal.ansiBrightRed": "#ff616e",
+        "terminal.ansiBrightWhite": "#e6e6e6",
+        "terminal.ansiBrightYellow": "#f0a45d",
+        "terminal.ansiCyan": "#42b3c2",
+        "terminal.ansiGreen": "#8cc265",
+        "terminal.ansiMagenta": "#c162de",
+        "terminal.ansiRed": "#e05561",
+        "terminal.ansiWhite": "#d7dae0",
+        "terminal.ansiYellow": "#d18f52",
+        "terminal.background": "#282c34",
+        "terminal.border": "#3e4452",
+        "terminal.foreground": "#abb2bf",
+        "terminal.selectionBackground": "#abb2bf30",
+        "textBlockQuote.background": "#2e3440",
+        "textBlockQuote.border": "#4b5362",
+        "textLink.foreground": "#61afef",
+        "textPreformat.foreground": "#d19a66",
+        "titleBar.activeBackground": "#282c34",
+        "titleBar.activeForeground": "#9da5b4",
+        "titleBar.inactiveBackground": "#282c34",
+        "titleBar.inactiveForeground": "#6b717d",
+        "tree.indentGuidesStroke": "#ffffff1d",
+        "walkThrough.embeddedEditorBackground": "#2e3440"
+    },
+    "rules": [
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.delayed.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.list.begin.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.list.end.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.ability.begin.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.ability.end.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.operator.assignment.as.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.separator.pipe.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.separator.delimiter.unison"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.hash.unison"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "variable.other.generic-type.haskell"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "storage.type.haskell"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.magic.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.period.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.element.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.parenthesis.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.parenthesis.end.python"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.parameter.function.language.special.self.python"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.parameter.function.language.special.cls.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "storage.modifier.lifetime.rust"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.std.rust"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.lifetime.rust"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.language.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.constant.edge"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.word"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "variable.parameter.function"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "comment markup.link"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "markup.changed.diff"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.diff.header.from-file"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.diff.header.to-file"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "punctuation.definition.from-file.diff"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "punctuation.definition.to-file.diff"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inserted.diff"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.deleted.diff"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.function.c"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.function.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.bracket.curly.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.bracket.curly.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.statement.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.bracket.curly.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.bracket.curly.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parens.begin.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parens.end.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parameters.begin.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.parameters.end.bracket.round.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "keyword.operator.expression.import"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property.math"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.annotation.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.object.array.java"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.block.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.method-parameters.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.method-parameters.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method.identifier.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.inner-class.begin.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.inner-class.end.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method-call.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.begin.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.class.end.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.begin.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.method.end.bracket.curly.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.period.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.bracket.angle.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.annotation.java"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.method.body.java"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.method.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.modifier.import.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.generic.java"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.instanceof.java"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.definition.variable.name.java"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.bitwise"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.channel"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property-value.scss"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.property-value.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.scss"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.less"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.css"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.scss"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.list.comma.css"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.color.w3c-standard-color-name.css"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.vendored.property-name.css"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.module.node"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.object.module"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.module.node"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type.module"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.readwrite"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.object.process"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.object.node"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.instanceof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.ternary"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.optional"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.keyof"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.object.console"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.variable.property.process"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.console"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "keyword.operator.misc.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sigil.rust"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.delete"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.object.dom"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.dom"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.arithmetic"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.comparison"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.decrement"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.increment"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.relational"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.comparison.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.increment.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.decrement.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.bitwise.shift.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.comparison.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.increment.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.decrement.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.bitwise.shift.cpp"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.delimiter"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.separator.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.separator.cpp"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.posix-reserved.c"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.posix-reserved.cpp"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sizeof.c"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.sizeof.cpp"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "variable.parameter.function.language.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.python"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.logical.python"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "variable.parameter.function.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.end.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.arguments.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.list.begin.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.list.end.python"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.generic.python"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant.character.format.placeholder.other.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.assignment.compound"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment.compound.js"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment.compound.ts"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "variable.c"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "token.variable.parameter.java"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "import.storage.java"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.package.keyword"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "token.package"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.require"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.function.any-method"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type.namespace"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": " entity.name.type.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.class.identifier.namespace.type"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.class.js"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.class.ts"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.class.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "control.elements"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": " keyword.operator.less"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "keyword.other.special-method"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "storage"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.storage"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.delete"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.in"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.of"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.instanceof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.typeof"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.void"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "token.storage.type.java"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.toml"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " support.type.property-name.table.toml"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " support.type.property-name.array.toml"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "string"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.other.symbol"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "constant"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "entity.other.attribute-name.class.css"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "meta.selector"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "markup.heading punctuation.definition.heading"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": " entity.name.section"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "todo.bold"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.bold"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": " punctuation.definition.italic"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "todo.emphasis"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "emphasis md"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.section.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "markup.heading.setext"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "punctuation.definition.bold.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.string.begin.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.string.end.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "beginning.punctuation.definition.list.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.definition.metadata.markdown"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.underline.link.markdown"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.underline.link.image.markdown"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.other.link.title.markdown"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.other.link.description.markdown"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.raw.monospace.asciidoc"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "punctuation.definition.asciidoc"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "markup.list.asciidoc"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.link.asciidoc"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "markup.other.url.asciidoc"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "string.unquoted.asciidoc"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "markup.other.url.asciidoc"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": " variable.interpolation"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded.begin"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded.end"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "invalid.illegal.bad-ampersand.html"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "invalid.illegal.unrecognized-tag.html"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.broken"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "invalid.deprecated.entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.unimplemented"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.json meta.structure.dictionary.json > string.quoted.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.array.json > value.json > string.quoted.json"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "source.json meta.structure.dictionary.json > constant.language.json"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "source.json meta.structure.array.json > constant.language.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.json"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "support.type.property-name.json punctuation"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.other.namespace.use.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.other.namespace.use-as.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.other.alias.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "meta.interface.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.error-control.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.type.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.array.begin.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.array.end.php"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "invalid.illegal.non-null-typehinted.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "meta.other.type.phpdoc.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.other.type.php"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.other.array.phpdoc.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.object.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function-call.static.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.parameters.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.parameters.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.delimiter.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.scope.begin.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.section.scope.end.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.terminator.expression.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.arguments.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.storage-type.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.storage-type.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.array.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.array.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.begin.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.end.bracket.round.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.begin.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.start.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.begin.bracket.curly.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.section.switch-block.end.bracket.curly.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.core.rust"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.ext.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.std.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.core.php"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.parser-token.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "entity.name.goto-label.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.other.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.logical.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.bitwise.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.arithmetic.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.regexp.php"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.comparison.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.heredoc.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.nowdoc.php"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.function.decorator.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.token.decorator.python"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "meta.function.decorator.identifier.python"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.parameter"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.brace"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "function.parameter.ruby"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": " function.parameter.cs"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.ruby"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.hashkey.ruby"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "rgb-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "inline-color-decoration rgb-value"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "less rgb-value"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "selector.sass"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive.ts"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.builtin.ts"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive.tsx"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.builtin.tsx"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "block.scope.end"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "block.scope.begin"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.variable.local.cs"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.definition.template-expression.begin"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.definition.template-expression.end"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.module"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "support.type.type.flowtype"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.primitive"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.property.object"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.js"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.template.begin"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.template.end"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.substitution.begin"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "keyword.other.substitution.end"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.operator.assignment"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "keyword.operator.assignment.go"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.arithmetic.go"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.address.go"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.package.go"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "support.type.prelude.elm"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.constant.elm"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "punctuation.quasi.element"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.character.entity"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.global.clojure"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.symbol.clojure"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.keyword.clojure"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.arguments.coffee"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.coffee"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "source.ini"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.scope.prerequisites.makefile"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "source.makefile"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "storage.modifier.import.groovy"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "meta.method.groovy"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "meta.definition.variable.name.groovy"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "meta.definition.class.inherited.classes.groovy"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.variable.semantic.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.texture.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.sampler.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.rw.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.fx.hlsl"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "support.type.object.hlsl"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "text.variable"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "text.bracketed"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.swift"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "support.type.vb.asp"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.function.xi"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "entity.name.class.xi"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "constant.character.character-class.regexp.xi"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "constant.regexp.xi"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "keyword.control.xi"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "invalid.xi"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "beginning.punctuation.definition.quote.markdown.xi"
+        },
+        {
+            "foreground": "#7F848E",
+            "token": "beginning.punctuation.definition.list.markdown.xi"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "constant.character.xi"
+        },
+        {
+            "foreground": "#61AFEF",
+            "token": "accent.xi"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "wikiword.xi"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "constant.other.color.rgb-value.xi"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "punctuation.definition.tag.xi"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.label.cs"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.scope-resolution.function.call"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.scope-resolution.function.definition"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.label.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading.setext.1.markdown"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.heading.setext.2.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": " meta.brace.square"
+        },
+        {
+            "foreground": "#7F848E",
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "foreground": "#7F848E",
+            "fontStyle": "italic",
+            "token": " punctuation.definition.comment"
+        },
+        {
+            "foreground": "#5C6370",
+            "token": "markup.quote.markdown"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.definition.block.sequence.item.yaml"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.elixir"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.language.symbol.double-quoted.elixir"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.name.variable.parameter.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.variable.field.cs"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "markup.inserted"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#BE5046",
+            "token": "punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#BE5046",
+            "token": "punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.parameter.function.latex"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "variable.other.object"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.constant.property"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "variable.other.readwrite.c"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "entity.name.variable.parameter.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "punctuation.separator.colon.php"
+        },
+        {
+            "foreground": "#ABB2BF",
+            "token": "constant.other.php"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "constant.numeric.decimal.asm.x86_64"
+        },
+        {
+            "foreground": "#D19A66",
+            "token": "support.other.parenthesis.regexp"
+        },
+        {
+            "foreground": "#56B6C2",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#98C379",
+            "token": "log.info"
+        },
+        {
+            "foreground": "#E5C07B",
+            "token": "log.warning"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "log.error"
+        },
+        {
+            "foreground": "#C678DD",
+            "token": "keyword.operator.expression.is"
+        },
+        {
+            "foreground": "#E06C75",
+            "token": "entity.name.label"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.ts"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.jsx"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "entity.other.attribute-name.tsx"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.parameter"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "variable.language.super"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.line.double-slash"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "comment.block.documentation"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic.markdown"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/solarized-dark/solarized-dark-monaco.json
+++ b/themes/solarized-dark/solarized-dark-monaco.json
@@ -1,350 +1,346 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#003847",
-                "badge.background": "#047aa6",
-                "button.background": "#2aa19899",
-                "debugExceptionWidget.background": "#00212b",
-                "debugExceptionWidget.border": "#ab395b",
-                "debugToolBar.background": "#00212b",
-                "dropdown.background": "#00212b",
-                "dropdown.border": "#2aa19899",
-                "editor.background": "#002b36",
-                "editor.foreground": "#839496",
-                "editor.lineHighlightBackground": "#073642",
-                "editor.selectionBackground": "#274642",
-                "editor.selectionHighlightBackground": "#005a6faa",
-                "editor.wordHighlightBackground": "#004454aa",
-                "editor.wordHighlightStrongBackground": "#005a6faa",
-                "editorBracketHighlight.foreground1": "#cdcdcd",
-                "editorBracketHighlight.foreground2": "#b58900",
-                "editorBracketHighlight.foreground3": "#d33682",
-                "editorCursor.foreground": "#d30102",
-                "editorGroup.border": "#00212b",
-                "editorGroup.dropBackground": "#2aa19844",
-                "editorGroupHeader.tabsBackground": "#004052",
-                "editorHoverWidget.background": "#004052",
-                "editorIndentGuide.activeBackground": "#c3e1e180",
-                "editorIndentGuide.background": "#93a1a180",
-                "editorLineNumber.activeForeground": "#949494",
-                "editorMarkerNavigationError.background": "#ab395b",
-                "editorMarkerNavigationWarning.background": "#5b7e7a",
-                "editorWhitespace.foreground": "#93a1a180",
-                "editorWidget.background": "#00212b",
-                "errorForeground": "#ffeaea",
-                "focusBorder": "#2aa19899",
-                "input.background": "#003847",
-                "input.foreground": "#93a1a1",
-                "input.placeholderForeground": "#93a1a1aa",
-                "inputOption.activeBorder": "#2aa19899",
-                "inputValidation.errorBackground": "#571b26",
-                "inputValidation.errorBorder": "#a92049",
-                "inputValidation.infoBackground": "#052730",
-                "inputValidation.infoBorder": "#363b5f",
-                "inputValidation.warningBackground": "#5d5938",
-                "inputValidation.warningBorder": "#9d8a5e",
-                "list.activeSelectionBackground": "#005a6f",
-                "list.dropBackground": "#00445488",
-                "list.highlightForeground": "#1ebcc5",
-                "list.hoverBackground": "#004454aa",
-                "list.inactiveSelectionBackground": "#00445488",
-                "minimap.selectionHighlight": "#274642",
-                "panel.border": "#2b2b4a",
-                "peekView.border": "#2b2b4a",
-                "peekViewEditor.background": "#10192c",
-                "peekViewEditor.matchHighlightBackground": "#7744aa40",
-                "peekViewResult.background": "#00212b",
-                "peekViewTitle.background": "#00212b",
-                "pickerGroup.border": "#2aa19899",
-                "pickerGroup.foreground": "#2aa19899",
-                "ports.iconRunningProcessForeground": "#369432",
-                "progressBar.background": "#047aa6",
-                "quickInputList.focusBackground": "#005a6f",
-                "selection.background": "#2aa19899",
-                "sideBar.background": "#00212b",
-                "sideBarTitle.foreground": "#93a1a1",
-                "statusBar.background": "#00212b",
-                "statusBar.debuggingBackground": "#00212b",
-                "statusBar.foreground": "#93a1a1",
-                "statusBar.noFolderBackground": "#00212b",
-                "statusBarItem.prominentBackground": "#003847",
-                "statusBarItem.prominentHoverBackground": "#003847",
-                "statusBarItem.remoteBackground": "#2aa19899",
-                "tab.activeBackground": "#002b37",
-                "tab.activeForeground": "#d6dbdb",
-                "tab.border": "#003847",
-                "tab.inactiveBackground": "#004052",
-                "tab.inactiveForeground": "#93a1a1",
-                "tab.lastPinnedBorder": "#2aa19844",
-                "terminal.ansiBlack": "#073642",
-                "terminal.ansiBlue": "#268bd2",
-                "terminal.ansiBrightBlack": "#002b36",
-                "terminal.ansiBrightBlue": "#839496",
-                "terminal.ansiBrightCyan": "#93a1a1",
-                "terminal.ansiBrightGreen": "#586e75",
-                "terminal.ansiBrightMagenta": "#6c71c4",
-                "terminal.ansiBrightRed": "#cb4b16",
-                "terminal.ansiBrightWhite": "#fdf6e3",
-                "terminal.ansiBrightYellow": "#657b83",
-                "terminal.ansiCyan": "#2aa198",
-                "terminal.ansiGreen": "#859900",
-                "terminal.ansiMagenta": "#d33682",
-                "terminal.ansiRed": "#dc322f",
-                "terminal.ansiWhite": "#eee8d5",
-                "terminal.ansiYellow": "#b58900",
-                "titleBar.activeBackground": "#002c39"
-            },
-            "rules": [
-                {
-                    "foreground": "#839496",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#839496",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#839496",
-                    "token": "string meta.image.inline.markdown"
-                },
-                {
-                    "foreground": "#839496",
-                    "token": "variable.legacy.builtin.python"
-                },
-                {
-                    "foreground": "#586E75",
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#2AA198",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#93A1A1",
-                    "fontStyle": "bold",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.section.embedded.begin"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.section.embedded.end"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "support.function.construct"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "keyword.other.new"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "constant.other"
-                },
-                {
-                    "foreground": "#6C71C4",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#586E75",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#93A1A1",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.separator.continuation"
-                },
-                {
-                    "token": "support.constant"
-                },
-                {
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "support.type.exception"
-                },
-                {
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "italic",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "italic",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "fontStyle": "",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "markup.list"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#2AA198",
-                    "fontStyle": "",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#003847",
+        "badge.background": "#047aa6",
+        "button.background": "#2aa19899",
+        "debugExceptionWidget.background": "#00212b",
+        "debugExceptionWidget.border": "#ab395b",
+        "debugToolBar.background": "#00212b",
+        "dropdown.background": "#00212b",
+        "dropdown.border": "#2aa19899",
+        "editor.background": "#002b36",
+        "editor.foreground": "#839496",
+        "editor.lineHighlightBackground": "#073642",
+        "editor.selectionBackground": "#274642",
+        "editor.selectionHighlightBackground": "#005a6faa",
+        "editor.wordHighlightBackground": "#004454aa",
+        "editor.wordHighlightStrongBackground": "#005a6faa",
+        "editorBracketHighlight.foreground1": "#cdcdcd",
+        "editorBracketHighlight.foreground2": "#b58900",
+        "editorBracketHighlight.foreground3": "#d33682",
+        "editorCursor.foreground": "#d30102",
+        "editorGroup.border": "#00212b",
+        "editorGroup.dropBackground": "#2aa19844",
+        "editorGroupHeader.tabsBackground": "#004052",
+        "editorHoverWidget.background": "#004052",
+        "editorIndentGuide.activeBackground": "#c3e1e180",
+        "editorIndentGuide.background": "#93a1a180",
+        "editorLineNumber.activeForeground": "#949494",
+        "editorMarkerNavigationError.background": "#ab395b",
+        "editorMarkerNavigationWarning.background": "#5b7e7a",
+        "editorWhitespace.foreground": "#93a1a180",
+        "editorWidget.background": "#00212b",
+        "errorForeground": "#ffeaea",
+        "focusBorder": "#2aa19899",
+        "input.background": "#003847",
+        "input.foreground": "#93a1a1",
+        "input.placeholderForeground": "#93a1a1aa",
+        "inputOption.activeBorder": "#2aa19899",
+        "inputValidation.errorBackground": "#571b26",
+        "inputValidation.errorBorder": "#a92049",
+        "inputValidation.infoBackground": "#052730",
+        "inputValidation.infoBorder": "#363b5f",
+        "inputValidation.warningBackground": "#5d5938",
+        "inputValidation.warningBorder": "#9d8a5e",
+        "list.activeSelectionBackground": "#005a6f",
+        "list.dropBackground": "#00445488",
+        "list.highlightForeground": "#1ebcc5",
+        "list.hoverBackground": "#004454aa",
+        "list.inactiveSelectionBackground": "#00445488",
+        "minimap.selectionHighlight": "#274642",
+        "panel.border": "#2b2b4a",
+        "peekView.border": "#2b2b4a",
+        "peekViewEditor.background": "#10192c",
+        "peekViewEditor.matchHighlightBackground": "#7744aa40",
+        "peekViewResult.background": "#00212b",
+        "peekViewTitle.background": "#00212b",
+        "pickerGroup.border": "#2aa19899",
+        "pickerGroup.foreground": "#2aa19899",
+        "ports.iconRunningProcessForeground": "#369432",
+        "progressBar.background": "#047aa6",
+        "quickInputList.focusBackground": "#005a6f",
+        "selection.background": "#2aa19899",
+        "sideBar.background": "#00212b",
+        "sideBarTitle.foreground": "#93a1a1",
+        "statusBar.background": "#00212b",
+        "statusBar.debuggingBackground": "#00212b",
+        "statusBar.foreground": "#93a1a1",
+        "statusBar.noFolderBackground": "#00212b",
+        "statusBarItem.prominentBackground": "#003847",
+        "statusBarItem.prominentHoverBackground": "#003847",
+        "statusBarItem.remoteBackground": "#2aa19899",
+        "tab.activeBackground": "#002b37",
+        "tab.activeForeground": "#d6dbdb",
+        "tab.border": "#003847",
+        "tab.inactiveBackground": "#004052",
+        "tab.inactiveForeground": "#93a1a1",
+        "tab.lastPinnedBorder": "#2aa19844",
+        "terminal.ansiBlack": "#073642",
+        "terminal.ansiBlue": "#268bd2",
+        "terminal.ansiBrightBlack": "#002b36",
+        "terminal.ansiBrightBlue": "#839496",
+        "terminal.ansiBrightCyan": "#93a1a1",
+        "terminal.ansiBrightGreen": "#586e75",
+        "terminal.ansiBrightMagenta": "#6c71c4",
+        "terminal.ansiBrightRed": "#cb4b16",
+        "terminal.ansiBrightWhite": "#fdf6e3",
+        "terminal.ansiBrightYellow": "#657b83",
+        "terminal.ansiCyan": "#2aa198",
+        "terminal.ansiGreen": "#859900",
+        "terminal.ansiMagenta": "#d33682",
+        "terminal.ansiRed": "#dc322f",
+        "terminal.ansiWhite": "#eee8d5",
+        "terminal.ansiYellow": "#b58900",
+        "titleBar.activeBackground": "#002c39"
+    },
+    "rules": [
+        {
+            "foreground": "#839496",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#839496",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#839496",
+            "token": "string meta.image.inline.markdown"
+        },
+        {
+            "foreground": "#839496",
+            "token": "variable.legacy.builtin.python"
+        },
+        {
+            "foreground": "#586E75",
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "foreground": "#2AA198",
+            "token": "string"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#859900",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#93A1A1",
+            "fontStyle": "bold",
+            "token": "storage"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#859900",
+            "token": "punctuation.definition.variable"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.section.embedded.begin"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.section.embedded.end"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "support.function.construct"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "keyword.other.new"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "constant.other"
+        },
+        {
+            "foreground": "#6C71C4",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#586E75",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#93A1A1",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.separator.continuation"
+        },
+        {
+            "token": "support.constant"
+        },
+        {
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#859900",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#859900",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "support.type.exception"
+        },
+        {
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "italic",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "italic",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#DC322F",
+            "fontStyle": "",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#859900",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#859900",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "markup.list"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#2AA198",
+            "fontStyle": "",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "",
+            "token": "markup.heading.setext"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/solarized-light/solarized-light-monaco.json
+++ b/themes/solarized-light/solarized-light-monaco.json
@@ -1,342 +1,338 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#ddd6c1",
-                "activityBar.foreground": "#584c27",
-                "activityBarBadge.background": "#b58900",
-                "badge.background": "#b58900aa",
-                "button.background": "#ac9d57",
-                "debugExceptionWidget.background": "#ddd6c1",
-                "debugExceptionWidget.border": "#ab395b",
-                "debugToolBar.background": "#ddd6c1",
-                "dropdown.background": "#eee8d5",
-                "dropdown.border": "#d3af86",
-                "editor.background": "#fdf6e3",
-                "editor.foreground": "#657b83",
-                "editor.lineHighlightBackground": "#eee8d5",
-                "editor.selectionBackground": "#eee8d5",
-                "editorCursor.foreground": "#657b83",
-                "editorGroup.border": "#ddd6c1",
-                "editorGroup.dropBackground": "#ddd6c1aa",
-                "editorGroupHeader.tabsBackground": "#d9d2c2",
-                "editorHoverWidget.background": "#ccc4b0",
-                "editorIndentGuide.activeBackground": "#081e2580",
-                "editorIndentGuide.background": "#586e7580",
-                "editorLineNumber.activeForeground": "#567983",
-                "editorWhitespace.foreground": "#586e7580",
-                "editorWidget.background": "#eee8d5",
-                "extensionButton.prominentBackground": "#b58900",
-                "extensionButton.prominentHoverBackground": "#584c27aa",
-                "focusBorder": "#b49471",
-                "input.background": "#ddd6c1",
-                "input.foreground": "#586e75",
-                "input.placeholderForeground": "#586e75aa",
-                "inputOption.activeBorder": "#d3af86",
-                "list.activeSelectionBackground": "#dfca88",
-                "list.activeSelectionForeground": "#6c6c6c",
-                "list.highlightForeground": "#b58900",
-                "list.hoverBackground": "#dfca8844",
-                "list.inactiveSelectionBackground": "#d1cbb8",
-                "minimap.selectionHighlight": "#eee8d5",
-                "notebook.cellEditorBackground": "#f7f0e0",
-                "panel.border": "#ddd6c1",
-                "peekView.border": "#b58900",
-                "peekViewEditor.background": "#fffbf2",
-                "peekViewEditor.matchHighlightBackground": "#7744aa40",
-                "peekViewResult.background": "#eee8d5",
-                "peekViewTitle.background": "#eee8d5",
-                "pickerGroup.border": "#2aa19899",
-                "pickerGroup.foreground": "#2aa19899",
-                "ports.iconRunningProcessForeground": "#2aa19899",
-                "progressBar.background": "#b58900",
-                "quickInputList.focusBackground": "#dfca8866",
-                "selection.background": "#878b9180",
-                "sideBar.background": "#eee8d5",
-                "sideBarTitle.foreground": "#586e75",
-                "statusBar.background": "#eee8d5",
-                "statusBar.debuggingBackground": "#eee8d5",
-                "statusBar.foreground": "#586e75",
-                "statusBar.noFolderBackground": "#eee8d5",
-                "statusBarItem.prominentBackground": "#ddd6c1",
-                "statusBarItem.prominentHoverBackground": "#ddd6c199",
-                "statusBarItem.remoteBackground": "#ac9d57",
-                "tab.activeBackground": "#fdf6e3",
-                "tab.activeModifiedBorder": "#cb4b16",
-                "tab.border": "#ddd6c1",
-                "tab.inactiveBackground": "#d3cbb7",
-                "tab.inactiveForeground": "#586e75",
-                "tab.lastPinnedBorder": "#fdf6e3",
-                "terminal.ansiBlack": "#073642",
-                "terminal.ansiBlue": "#268bd2",
-                "terminal.ansiBrightBlack": "#002b36",
-                "terminal.ansiBrightBlue": "#839496",
-                "terminal.ansiBrightCyan": "#93a1a1",
-                "terminal.ansiBrightGreen": "#586e75",
-                "terminal.ansiBrightMagenta": "#6c71c4",
-                "terminal.ansiBrightRed": "#cb4b16",
-                "terminal.ansiBrightWhite": "#fdf6e3",
-                "terminal.ansiBrightYellow": "#657b83",
-                "terminal.ansiCyan": "#2aa198",
-                "terminal.ansiGreen": "#859900",
-                "terminal.ansiMagenta": "#d33682",
-                "terminal.ansiRed": "#dc322f",
-                "terminal.ansiWhite": "#eee8d5",
-                "terminal.ansiYellow": "#b58900",
-                "terminal.background": "#fdf6e3",
-                "titleBar.activeBackground": "#eee8d5",
-                "walkThrough.embeddedEditorBackground": "#00000014"
-            },
-            "rules": [
-                {
-                    "foreground": "#657B83",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#657B83",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#657B83",
-                    "token": "string meta.image.inline.markdown"
-                },
-                {
-                    "foreground": "#657B83",
-                    "token": "variable.legacy.builtin.python"
-                },
-                {
-                    "foreground": "#93A1A1",
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#2AA198",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "variable.other"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#586E75",
-                    "fontStyle": "bold",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.section.embedded.begin"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.section.embedded.end"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "support.function.construct"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "keyword.other.new"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "constant.other"
-                },
-                {
-                    "foreground": "#6C71C4",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#93A1A1",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#93A1A1",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "punctuation.separator.continuation"
-                },
-                {
-                    "token": "support.constant"
-                },
-                {
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "token": "support.type.exception"
-                },
-                {
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "italic",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "italic",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#DC322F",
-                    "fontStyle": "",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#CB4B16",
-                    "fontStyle": "",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#859900",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#B58900",
-                    "token": "markup.list"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#D33682",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#2AA198",
-                    "fontStyle": "",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "foreground": "#268BD2",
-                    "fontStyle": "",
-                    "token": "markup.heading.setext"
-                },
-                {
-                    "foreground": "#316BCD",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#CD3131",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#800080",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#ddd6c1",
+        "activityBar.foreground": "#584c27",
+        "activityBarBadge.background": "#b58900",
+        "badge.background": "#b58900aa",
+        "button.background": "#ac9d57",
+        "debugExceptionWidget.background": "#ddd6c1",
+        "debugExceptionWidget.border": "#ab395b",
+        "debugToolBar.background": "#ddd6c1",
+        "dropdown.background": "#eee8d5",
+        "dropdown.border": "#d3af86",
+        "editor.background": "#fdf6e3",
+        "editor.foreground": "#657b83",
+        "editor.lineHighlightBackground": "#eee8d5",
+        "editor.selectionBackground": "#eee8d5",
+        "editorCursor.foreground": "#657b83",
+        "editorGroup.border": "#ddd6c1",
+        "editorGroup.dropBackground": "#ddd6c1aa",
+        "editorGroupHeader.tabsBackground": "#d9d2c2",
+        "editorHoverWidget.background": "#ccc4b0",
+        "editorIndentGuide.activeBackground": "#081e2580",
+        "editorIndentGuide.background": "#586e7580",
+        "editorLineNumber.activeForeground": "#567983",
+        "editorWhitespace.foreground": "#586e7580",
+        "editorWidget.background": "#eee8d5",
+        "extensionButton.prominentBackground": "#b58900",
+        "extensionButton.prominentHoverBackground": "#584c27aa",
+        "focusBorder": "#b49471",
+        "input.background": "#ddd6c1",
+        "input.foreground": "#586e75",
+        "input.placeholderForeground": "#586e75aa",
+        "inputOption.activeBorder": "#d3af86",
+        "list.activeSelectionBackground": "#dfca88",
+        "list.activeSelectionForeground": "#6c6c6c",
+        "list.highlightForeground": "#b58900",
+        "list.hoverBackground": "#dfca8844",
+        "list.inactiveSelectionBackground": "#d1cbb8",
+        "minimap.selectionHighlight": "#eee8d5",
+        "notebook.cellEditorBackground": "#f7f0e0",
+        "panel.border": "#ddd6c1",
+        "peekView.border": "#b58900",
+        "peekViewEditor.background": "#fffbf2",
+        "peekViewEditor.matchHighlightBackground": "#7744aa40",
+        "peekViewResult.background": "#eee8d5",
+        "peekViewTitle.background": "#eee8d5",
+        "pickerGroup.border": "#2aa19899",
+        "pickerGroup.foreground": "#2aa19899",
+        "ports.iconRunningProcessForeground": "#2aa19899",
+        "progressBar.background": "#b58900",
+        "quickInputList.focusBackground": "#dfca8866",
+        "selection.background": "#878b9180",
+        "sideBar.background": "#eee8d5",
+        "sideBarTitle.foreground": "#586e75",
+        "statusBar.background": "#eee8d5",
+        "statusBar.debuggingBackground": "#eee8d5",
+        "statusBar.foreground": "#586e75",
+        "statusBar.noFolderBackground": "#eee8d5",
+        "statusBarItem.prominentBackground": "#ddd6c1",
+        "statusBarItem.prominentHoverBackground": "#ddd6c199",
+        "statusBarItem.remoteBackground": "#ac9d57",
+        "tab.activeBackground": "#fdf6e3",
+        "tab.activeModifiedBorder": "#cb4b16",
+        "tab.border": "#ddd6c1",
+        "tab.inactiveBackground": "#d3cbb7",
+        "tab.inactiveForeground": "#586e75",
+        "tab.lastPinnedBorder": "#fdf6e3",
+        "terminal.ansiBlack": "#073642",
+        "terminal.ansiBlue": "#268bd2",
+        "terminal.ansiBrightBlack": "#002b36",
+        "terminal.ansiBrightBlue": "#839496",
+        "terminal.ansiBrightCyan": "#93a1a1",
+        "terminal.ansiBrightGreen": "#586e75",
+        "terminal.ansiBrightMagenta": "#6c71c4",
+        "terminal.ansiBrightRed": "#cb4b16",
+        "terminal.ansiBrightWhite": "#fdf6e3",
+        "terminal.ansiBrightYellow": "#657b83",
+        "terminal.ansiCyan": "#2aa198",
+        "terminal.ansiGreen": "#859900",
+        "terminal.ansiMagenta": "#d33682",
+        "terminal.ansiRed": "#dc322f",
+        "terminal.ansiWhite": "#eee8d5",
+        "terminal.ansiYellow": "#b58900",
+        "terminal.background": "#fdf6e3",
+        "titleBar.activeBackground": "#eee8d5",
+        "walkThrough.embeddedEditorBackground": "#00000014"
+    },
+    "rules": [
+        {
+            "foreground": "#657B83",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#657B83",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#657B83",
+            "token": "string meta.image.inline.markdown"
+        },
+        {
+            "foreground": "#657B83",
+            "token": "variable.legacy.builtin.python"
+        },
+        {
+            "foreground": "#93A1A1",
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "foreground": "#2AA198",
+            "token": "string"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "variable.other"
+        },
+        {
+            "foreground": "#859900",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#586E75",
+            "fontStyle": "bold",
+            "token": "storage"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#859900",
+            "token": "punctuation.definition.variable"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.section.embedded.begin"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.section.embedded.end"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "support.function.construct"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "keyword.other.new"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "constant.other"
+        },
+        {
+            "foreground": "#6C71C4",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#93A1A1",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#93A1A1",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#268BD2",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "punctuation.separator.continuation"
+        },
+        {
+            "token": "support.constant"
+        },
+        {
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#859900",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#859900",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#CB4B16",
+            "token": "support.type.exception"
+        },
+        {
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#DC322F",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "italic",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "italic",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#DC322F",
+            "fontStyle": "",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#CB4B16",
+            "fontStyle": "",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#859900",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#859900",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#B58900",
+            "token": "markup.list"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#D33682",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#2AA198",
+            "fontStyle": "",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "foreground": "#268BD2",
+            "fontStyle": "",
+            "token": "markup.heading.setext"
+        },
+        {
+            "foreground": "#316BCD",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#CD3131",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#800080",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/tokyo-night-light/tokyo-night-light-monaco.json
+++ b/themes/tokyo-night-light/tokyo-night-light-monaco.json
@@ -1,1697 +1,1693 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#cbccd1",
-                "activityBar.border": "#cbccd1",
-                "activityBar.foreground": "#4c505e",
-                "activityBar.inactiveForeground": "#828594",
-                "activityBarBadge.background": "#34548a",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#979db833",
-                "badge.foreground": "#4c505e",
-                "breadcrumb.activeSelectionForeground": "#4c505e",
-                "breadcrumb.background": "#cbccd1",
-                "breadcrumb.focusForeground": "#4c505e",
-                "breadcrumb.foreground": "#828594",
-                "breadcrumbPicker.background": "#cbccd1",
-                "button.background": "#34548add",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#34548aaa",
-                "button.secondaryBackground": "#828594",
-                "charts.blue": "#34548a",
-                "charts.foreground": "#565a6e",
-                "charts.green": "#33635c",
-                "charts.lines": "#f4f5f8",
-                "charts.orange": "#965027",
-                "charts.purple": "#5a4a78",
-                "charts.red": "#8c4351",
-                "charts.yellow": "#8f5e15",
-                "debugConsole.errorForeground": "#942f2f",
-                "debugConsole.infoForeground": "#166775",
-                "debugExceptionWidget.background": "#fafbff40",
-                "debugExceptionWidget.border": "#942f2f",
-                "debugIcon.breakpointDisabledForeground": "#828594",
-                "debugIcon.breakpointForeground": "#db4b4b",
-                "debugIcon.breakpointUnverifiedForeground": "#c24242",
-                "debugIcon.continueForeground": "#3e6396",
-                "debugIcon.pauseForeground": "#3e6396",
-                "debugIcon.startForeground": "#34548a",
-                "debugIcon.stepBackForeground": "#3e6396",
-                "debugIcon.stepIntoForeground": "#3e6396",
-                "debugIcon.stepOutForeground": "#3e6396",
-                "debugIcon.stepOverForeground": "#3e6396",
-                "debugTokenExpression.boolean": "#965027",
-                "debugTokenExpression.error": "#942f2f",
-                "debugTokenExpression.name": "#34548a",
-                "debugTokenExpression.number": "#965027",
-                "debugTokenExpression.string": "#485e30",
-                "debugTokenExpression.value": "#565a6e",
-                "debugToolBar.background": "#d5d6db",
-                "debugView.stateLabelBackground": "#d5d6db",
-                "debugView.stateLabelForeground": "#4c505e",
-                "debugView.valueChangedHighlight": "#f4f5f8",
-                "descriptionForeground": "#7b7f8c",
-                "diffEditor.diagonalFill": "#cacbcf",
-                "diffEditor.insertedLineBackground": "#3f919e15",
-                "diffEditor.insertedTextBackground": "#3f919e15",
-                "diffEditor.removedLineBackground": "#e8686812",
-                "diffEditor.removedTextBackground": "#e8686812",
-                "diffEditorGutter.insertedLineBackground": "#3f919e15",
-                "diffEditorGutter.removedLineBackground": "#e8686812",
-                "diffEditorOverview.insertedForeground": "#3f919e15",
-                "diffEditorOverview.removedForeground": "#e8686812",
-                "dropdown.background": "#d5d6db",
-                "dropdown.border": "#c1c2c7",
-                "dropdown.foreground": "#4c505e",
-                "dropdown.listBackground": "#d5d6db",
-                "editor.background": "#d5d6db",
-                "editor.findMatchBackground": "#fafbff66",
-                "editor.findMatchBorder": "#637dbf",
-                "editor.findMatchHighlightBackground": "#fafbff66",
-                "editor.findRangeHighlightBackground": "#34548a15",
-                "editor.focusedStackFrameHighlightBackground": "#c5e3d0",
-                "editor.foldBackground": "#b2b3b833",
-                "editor.foreground": "#343b59",
-                "editor.inactiveSelectionBackground": "#fafbff15",
-                "editor.lineHighlightBackground": "#dcdee3",
-                "editor.rangeHighlightBackground": "#fafbff20",
-                "editor.selectionBackground": "#fafbff40",
-                "editor.selectionHighlightBackground": "#fafbff55",
-                "editor.stackFrameHighlightBackground": "#e7e8c8",
-                "editor.wordHighlightBackground": "#fafbff33",
-                "editor.wordHighlightStrongBackground": "#fafbff66",
-                "editorBracketHighlight.foreground1": "#34548a",
-                "editorBracketHighlight.foreground2": "#34548a",
-                "editorBracketHighlight.foreground3": "#343b58",
-                "editorBracketHighlight.foreground4": "#166775",
-                "editorBracketHighlight.foreground5": "#485e30",
-                "editorBracketHighlight.foreground6": "#8f5e15",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#bd4040",
-                "editorBracketMatch.background": "#cdced1",
-                "editorBracketMatch.border": "#dcdee3",
-                "editorBracketPairGuide.activeBackground1": "#34548a",
-                "editorBracketPairGuide.activeBackground2": "#34548a",
-                "editorBracketPairGuide.activeBackground3": "#343b58",
-                "editorBracketPairGuide.activeBackground4": "#166775",
-                "editorBracketPairGuide.activeBackground5": "#485e30",
-                "editorBracketPairGuide.activeBackground6": "#8f5e15",
-                "editorCodeLens.foreground": "#868891",
-                "editorCursor.foreground": "#4c505e",
-                "editorError.foreground": "#bd4040",
-                "editorGhostText.foreground": "#73767d",
-                "editorGroup.border": "#c1c2c7",
-                "editorGroup.dropBackground": "#c1c2c7",
-                "editorGroupHeader.border": "#c1c2c7",
-                "editorGroupHeader.noTabsBackground": "#cbccd1",
-                "editorGroupHeader.tabsBackground": "#cbccd1",
-                "editorGroupHeader.tabsBorder": "#c1c2c7",
-                "editorGutter.addedBackground": "#71b6bd",
-                "editorGutter.deletedBackground": "#a8626a",
-                "editorGutter.modifiedBackground": "#637dbf",
-                "editorHint.foreground": "#0da0ba",
-                "editorHoverWidget.background": "#dcdee3",
-                "editorHoverWidget.border": "#c1c2c7",
-                "editorIndentGuide.activeBackground": "#f4f5f8",
-                "editorIndentGuide.background": "#cacbcf",
-                "editorInfo.foreground": "#0da0ba",
-                "editorLineNumber.activeForeground": "#4c505e",
-                "editorLineNumber.foreground": "#9da0ab",
-                "editorLink.activeForeground": "#1f2335",
-                "editorMarkerNavigation.background": "#cbccd1",
-                "editorOverviewRuler.addedForeground": "#71b6bd",
-                "editorOverviewRuler.border": "#c1c2c7",
-                "editorOverviewRuler.bracketMatchForeground": "#c1c2c7",
-                "editorOverviewRuler.deletedForeground": "#a8626a",
-                "editorOverviewRuler.errorForeground": "#bd4040",
-                "editorOverviewRuler.findMatchForeground": "#4c505e44",
-                "editorOverviewRuler.infoForeground": "#1abc9c",
-                "editorOverviewRuler.modifiedForeground": "#637dbf",
-                "editorOverviewRuler.rangeHighlightForeground": "#4c505e44",
-                "editorOverviewRuler.selectionHighlightForeground": "#4c505e22",
-                "editorOverviewRuler.warningForeground": "#8f5e15",
-                "editorOverviewRuler.wordHighlightForeground": "#5a4a7855",
-                "editorOverviewRuler.wordHighlightStrongForeground": "#5a4a7866",
-                "editorPane.background": "#cbccd1",
-                "editorRuler.foreground": "#c1c2c7",
-                "editorSuggestWidget.background": "#dcdee3",
-                "editorSuggestWidget.border": "#c1c2c7",
-                "editorSuggestWidget.highlightForeground": "#34548a",
-                "editorSuggestWidget.selectedBackground": "#e8e9ed",
-                "editorWarning.foreground": "#8f5e15",
-                "editorWhitespace.foreground": "#d5d6db",
-                "editorWidget.background": "#cbccd1",
-                "editorWidget.foreground": "#4c505e",
-                "editorWidget.resizeBorder": "#82859433",
-                "errorForeground": "#5a607d",
-                "extensionBadge.remoteBackground": "#34548a",
-                "extensionBadge.remoteForeground": "#ffffff",
-                "extensionButton.prominentBackground": "#34548add",
-                "extensionButton.prominentForeground": "#ffffff",
-                "extensionButton.prominentHoverBackground": "#34548aaa",
-                "focusBorder": "#82859433",
-                "foreground": "#4c505e",
-                "gitDecoration.addedResourceForeground": "#166775",
-                "gitDecoration.conflictingResourceForeground": "#8f5e15",
-                "gitDecoration.deletedResourceForeground": "#914c54",
-                "gitDecoration.ignoredResourceForeground": "#828594",
-                "gitDecoration.modifiedResourceForeground": "#34548a",
-                "gitDecoration.renamedResourceForeground": "#166775",
-                "gitDecoration.stageDeletedResourceForeground": "#914c54",
-                "gitDecoration.stageModifiedResourceForeground": "#34548a",
-                "gitDecoration.untrackedResourceForeground": "#166775",
-                "gitlens.gutterBackgroundColor": "#dcdee3",
-                "gitlens.gutterForegroundColor": "#4c505e",
-                "gitlens.gutterUncommittedForegroundColor": "#34548a",
-                "gitlens.trailingLineForegroundColor": "#73767d",
-                "icon.foreground": "#4c505e",
-                "input.background": "#d5d6db",
-                "input.border": "#c1c2c7",
-                "input.foreground": "#4c505e",
-                "input.placeholderForeground": "#4a5272",
-                "inputOption.activeBackground": "#34548a44",
-                "inputValidation.errorBackground": "#85353e",
-                "inputValidation.errorBorder": "#942f2f",
-                "inputValidation.errorForeground": "#e8e9ed",
-                "inputValidation.infoBackground": "#3d59a15c",
-                "inputValidation.infoBorder": "#3d59a1",
-                "inputValidation.infoForeground": "#000000",
-                "inputValidation.warningBackground": "#c2985b",
-                "inputValidation.warningBorder": "#8f5e15",
-                "inputValidation.warningForeground": "#000000",
-                "list.activeSelectionBackground": "#d5d6db",
-                "list.activeSelectionForeground": "#4c505e",
-                "list.deemphasizedForeground": "#4c505e",
-                "list.dropBackground": "#c1c2c7",
-                "list.errorForeground": "#942f2f",
-                "list.focusBackground": "#d5d6db",
-                "list.focusForeground": "#4c505e",
-                "list.highlightForeground": "#34548a",
-                "list.hoverBackground": "#d5d6db",
-                "list.hoverForeground": "#4c505e",
-                "list.inactiveSelectionBackground": "#d5d6db",
-                "list.inactiveSelectionForeground": "#4c505e",
-                "list.invalidItemForeground": "#c97018",
-                "list.warningForeground": "#8f5e15",
-                "listFilterWidget.background": "#d5d6db",
-                "listFilterWidget.noMatchesOutline": "#a6333f",
-                "listFilterWidget.outline": "#34548a",
-                "menu.background": "#cbccd1",
-                "menu.border": "#c1c2c7",
-                "menu.foreground": "#4c505e",
-                "menu.selectionBackground": "#7a85a8",
-                "menu.selectionForeground": "#343b58",
-                "menu.separatorBackground": "#c1c2c7",
-                "menubar.selectionBackground": "#7a85a8",
-                "menubar.selectionBorder": "#c1c2c7",
-                "menubar.selectionForeground": "#343b58",
-                "merge.currentContentBackground": "#007a7544",
-                "merge.currentHeaderBackground": "#007a75aa",
-                "merge.incomingContentBackground": "#34548a44",
-                "merge.incomingHeaderBackground": "#34548aaa",
-                "mergeEditor.change.background": "#007a7522",
-                "mergeEditor.change.word.background": "#007a7522",
-                "mergeEditor.conflict.handled.minimapOverViewRuler": "#007a75",
-                "mergeEditor.conflict.handledFocused.border": "#007a7525",
-                "mergeEditor.conflict.handledUnfocused.border": "#007a7525",
-                "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#bb7a61",
-                "mergeEditor.conflict.unhandledFocused.border": "#bb7a61",
-                "mergeEditor.conflict.unhandledUnfocused.border": "#bb7a6188",
-                "minimap.errorHighlight": "#bd4040",
-                "notebook.cellBorderColor": "#c1c2c7",
-                "notebook.cellEditorBackground": "#cbccd1",
-                "notebook.cellStatusBarItemHoverBackground": "#d5d6db",
-                "notebook.editorBackground": "#d5d6db",
-                "notebook.focusedCellBorder": "#828594",
-                "notificationCenterHeader.background": "#dcdee3",
-                "notificationLink.foreground": "#34548a",
-                "notifications.background": "#dcdee3",
-                "notificationsErrorIcon.foreground": "#bb616b",
-                "notificationsInfoIcon.foreground": "#637dbf",
-                "notificationsWarningIcon.foreground": "#bba461",
-                "panel.background": "#cbccd1",
-                "panel.border": "#c1c2c7",
-                "panelInput.border": "#d5d6db",
-                "panelTitle.activeBorder": "#637dbf",
-                "panelTitle.activeForeground": "#4c505e",
-                "panelTitle.inactiveForeground": "#828594",
-                "peekView.border": "#c1c2c7",
-                "peekViewEditor.background": "#dcdee3",
-                "peekViewEditor.matchHighlightBackground": "#34548a22",
-                "peekViewResult.background": "#d7d9de",
-                "peekViewResult.fileForeground": "#4c505e",
-                "peekViewResult.lineForeground": "#4c505e",
-                "peekViewResult.matchHighlightBackground": "#34548a22",
-                "peekViewResult.selectionBackground": "#34548a33",
-                "peekViewResult.selectionForeground": "#4c505e",
-                "peekViewTitle.background": "#cbccd1",
-                "peekViewTitleDescription.foreground": "#4c505e",
-                "peekViewTitleLabel.foreground": "#4c505e",
-                "pickerGroup.border": "#c1c2c7",
-                "pickerGroup.foreground": "#4c505e",
-                "progressBar.background": "#34548a",
-                "sash.hoverBorder": "#828594",
-                "scrollbar.shadow": "#00000033",
-                "scrollbarSlider.activeBackground": "#90929632",
-                "scrollbarSlider.background": "#90929625",
-                "scrollbarSlider.hoverBackground": "#90929620",
-                "selection.background": "#fafbff55",
-                "settings.headerForeground": "#34548a",
-                "sideBar.background": "#cbccd1",
-                "sideBar.border": "#c1c2c7",
-                "sideBar.dropBackground": "#c1c2c7",
-                "sideBar.foreground": "#4c505e",
-                "sideBarSectionHeader.background": "#cbccd1",
-                "sideBarSectionHeader.border": "#c1c2c7",
-                "sideBarSectionHeader.foreground": "#4c505e",
-                "sideBarTitle.foreground": "#4c505e",
-                "statusBar.background": "#cbccd1",
-                "statusBar.border": "#c1c2c7",
-                "statusBar.debuggingBackground": "#d5d6db",
-                "statusBar.debuggingForeground": "#4c505e",
-                "statusBar.foreground": "#4c505e",
-                "statusBar.noFolderBackground": "#d5d6db",
-                "statusBarItem.activeBackground": "#c1c2c7",
-                "statusBarItem.hoverBackground": "#d5d6db",
-                "statusBarItem.prominentBackground": "#c1c2c7",
-                "statusBarItem.prominentHoverBackground": "#d5d6db",
-                "tab.activeBackground": "#cbccd1",
-                "tab.activeBorder": "#637dbf",
-                "tab.activeForeground": "#383b45",
-                "tab.activeModifiedBorder": "#d5d6db",
-                "tab.border": "#c1c2c7",
-                "tab.hoverForeground": "#383b45",
-                "tab.inactiveBackground": "#cbccd1",
-                "tab.inactiveForeground": "#4c505e",
-                "tab.inactiveModifiedBorder": "#d5d6db",
-                "tab.lastPinnedBorder": "#dadbe0",
-                "tab.unfocusedActiveBorder": "#9da0ab",
-                "tab.unfocusedActiveForeground": "#383b45",
-                "tab.unfocusedHoverForeground": "#383b45",
-                "tab.unfocusedInactiveForeground": "#4c505e",
-                "terminal.ansiBlack": "#0f0f14",
-                "terminal.ansiBlue": "#34548a",
-                "terminal.ansiBrightBlack": "#0f0f14",
-                "terminal.ansiBrightBlue": "#34548a",
-                "terminal.ansiBrightCyan": "#0f4b6e",
-                "terminal.ansiBrightGreen": "#33635c",
-                "terminal.ansiBrightMagenta": "#5a4a78",
-                "terminal.ansiBrightRed": "#8c4351",
-                "terminal.ansiBrightWhite": "#828594",
-                "terminal.ansiBrightYellow": "#8f5e15",
-                "terminal.ansiCyan": "#0f4b6e",
-                "terminal.ansiGreen": "#33635c",
-                "terminal.ansiMagenta": "#5a4a78",
-                "terminal.ansiRed": "#8c4351",
-                "terminal.ansiWhite": "#828594",
-                "terminal.ansiYellow": "#8f5e15",
-                "terminal.background": "#cbccd1",
-                "terminal.foreground": "#4c505e",
-                "terminal.selectionBackground": "#fafbff40",
-                "terminalCursor.foreground": "#828594",
-                "textBlockQuote.background": "#cbccd1",
-                "textCodeBlock.background": "#d5d6db",
-                "textLink.activeForeground": "#4c505e",
-                "textLink.foreground": "#34548a",
-                "textPreformat.foreground": "#33635c",
-                "textSeparator.foreground": "#828594",
-                "titleBar.activeBackground": "#cbccd1",
-                "titleBar.activeForeground": "#4c505e",
-                "titleBar.border": "#c1c2c7",
-                "titleBar.inactiveBackground": "#cbccd1",
-                "titleBar.inactiveForeground": "#4c505e",
-                "toolbar.activeBackground": "#fafbff40",
-                "toolbar.hoverBackground": "#fafbff40",
-                "tree.indentGuidesStroke": "#c1c2c7",
-                "walkThrough.embeddedEditorBackground": "#cbccd1",
-                "widget.shadow": "#ffffff00",
-                "window.activeBorder": "#cdced1",
-                "window.inactiveBorder": "#cdced1"
-            },
-            "rules": [
-                {
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.flow"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.return"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.modifier"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.block-scalar.literal"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.python"
-                },
-                {
-                    "foreground": "#9699A3",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#9699A3",
-                    "token": "comment.block.documentation"
-                },
-                {
-                    "foreground": "#9699A3",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#9699A3",
-                    "token": "comment.block.documentation punctuation"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "keyword.operator.assignment.jsdoc"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation variable"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation storage"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation keyword"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation support"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation markup"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "comment.block.documentation markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "meta.other.type.phpdoc.php keyword.other.type.php"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "meta.other.type.phpdoc.php support.other.namespace.php"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "keyword.other.phpdoc.php"
-                },
-                {
-                    "foreground": "#7C7F87",
-                    "token": "log.date"
-                },
-                {
-                    "foreground": "#73767D",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#73767D",
-                    "token": "comment.block.documentation storage.type"
-                },
-                {
-                    "foreground": "#73767D",
-                    "token": "comment.block.documentation punctuation.definition.block.tag"
-                },
-                {
-                    "foreground": "#73767D",
-                    "token": "comment.block.documentation entity.name.type.instance"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "constant.other.caps"
-                },
-                {
-                    "foreground": "#485E30",
-                    "fontStyle": "",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#485E30",
-                    "fontStyle": "",
-                    "token": "constant.other.symbol"
-                },
-                {
-                    "foreground": "#485E30",
-                    "fontStyle": "",
-                    "token": "constant.other.key"
-                },
-                {
-                    "foreground": "#485E30",
-                    "fontStyle": "",
-                    "token": "meta.attribute-selector"
-                },
-                {
-                    "foreground": "#485E30",
-                    "fontStyle": "",
-                    "token": "string constant.character"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "constant.other.color"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#942F2F",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#942F2F",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "meta.embedded.line.tag.smarty"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "punctuation.section.tag.twig"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "keyword.control.smarty"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "keyword.control.twig"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.constant.handlebars keyword.control"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "keyword.operator.comparison.twig"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "keyword.blade"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "entity.name.function.blade"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.spread"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.rest"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.control.as"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.other"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.operator.bitwise.shift"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "expression.embbeded.vue punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "text.html.twig meta.tag.inline.any.html"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.tag.template.value.twig meta.function.arguments.twig"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.definition.constant.markdown"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.support.type.property-name"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "text.html.vue-html meta.tag"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.attribute.directive"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.terminator.rule"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.other.template"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "keyword.other.substitution"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "entity.name.operator"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.property-list punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.at-rule.mixin punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "meta.at-rule.function variable.parameter.url"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.control.module"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.control.import"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.control.export"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.control.from"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.control.default"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "meta.import keyword.other"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.other.important"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "keyword.other.DML"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "storage.type.function"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.bitwise"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.ternary"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.comparison"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.relational"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.or.regexp"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "entity.name.tag support.class.component"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "meta.tag.custom entity.name.tag"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#B05467",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "meta.tag.custom punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#69323D",
-                    "token": "meta.jsx punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "constant.other.php"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.other.global.safer"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.other.global.safer punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.other.global"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.other.global punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "constant.other.haskell"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "string constant.other.placeholder"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.parameter.handlebars"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.other.object"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "meta.fstring"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "meta.function-call meta.function-call.arguments"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "meta.array.literal variable"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "entity.name.type.hcl"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "string.alias.graphql"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "string.unquoted.graphql"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "string.unquoted.alias.graphql"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "meta.field.declaration.ts variable.object.property"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "meta.block entity.name.label"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "variable.other.property"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "meta.function-call variable.other.object.property"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "variable.other.object.property.cs"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.other.object.property"
-                },
-                {
-                    "foreground": "#296973",
-                    "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "source.cpp meta.block variable.other"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "meta.class-method.js entity.name.function.js"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "entity.name.method.js"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "variable.function.constructor"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "keyword.other.special-method"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "meta.function-call"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "meta.function-call entity.name.function"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "meta.definition.method entity.name.function"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "meta.object-literal entity.name.function"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "meta.function.parameters punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "meta.function.parameter variable"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.other.type.php"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "constant.escape"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.definition.variable variable.other.constant"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.definition.variable variable.other.readwrite"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "variable.declaration.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "variable.other.declaration"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "fontStyle": "",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "variable.other.readwrite.alias"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.orther.namespace.use.php"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "meta.use.php"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.type.sys-types"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.variable.dom"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.type.object.module"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "meta.import.qualifier"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "variable.other.constant.object"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.css support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.sass support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.scss support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.less support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.stylus support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.postcss support.type.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "support.type.property-name.css"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "support.type.vendored.property-name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "support.type.map.key"
-                },
-                {
-                    "foreground": "#485E30",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#485E30",
-                    "token": "meta.definition.variable"
-                },
-                {
-                    "foreground": "#485E30",
-                    "token": "entity.other.attribute-name.class"
-                },
-                {
-                    "foreground": "#485E30",
-                    "token": "meta.at-rule.mixin.scss entity.name.function.scss"
-                },
-                {
-                    "foreground": "#942F2F",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "entity.name.tag.css"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "entity.other.attribute-name.class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "entity.name.tag.reference"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "meta.property-list"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "meta.property-list meta.at-rule.if"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "meta.at-rule.return variable.parameter.url"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "meta.property-list meta.at-rule.else"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "meta.property-list meta.property-list"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.at-rule.include entity.name.function.scss"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "keyword.control.at-rule.include punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "meta.at-rule.extend keyword.control.at-rule.extend"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "meta.at-rule.media keyword.control.at-rule.media"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "meta.at-rule.function keyword.control.at-rule.function"
-                },
-                {
-                    "foreground": "#4F4168",
-                    "token": "keyword.control punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "meta.property-list meta.at-rule.include"
-                },
-                {
-                    "foreground": "#965027",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "entity.name.module.js"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.import.parameter.js"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.other.class.js"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "variable.other punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "source.js constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "variable.language.this punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "keyword.other.this"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "text.html.basic entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "text.html.basic entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "text.html constant.character.entity"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "text.html punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "entity.other.attribute-name.id.html"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.sass keyword.control"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "entity.other.attribute-name.placeholder"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "meta.property-list meta.property-value"
-                },
-                {
-                    "foreground": "#449DAB",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#914C54",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#3E6968",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "punctuation.definition.group"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "constant.character.escape.backslash"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#8F5E15",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#166775",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#485E30",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.list_item.markdown"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "meta.block"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "meta.brace"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.block"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.use"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.class"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.begin.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.end.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.switch-expression.begin.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.switch-expression.end.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.section.switch-block.begin.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.section.switch-block.end.bracket"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.group.shell"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.arguments"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.dictionary"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.definition.array"
-                },
-                {
-                    "foreground": "#484C61",
-                    "token": "punctuation.section"
-                },
-                {
-                    "foreground": "#343B58",
-                    "token": "meta.embedded.block"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "meta.tag JSXNested"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "text.html"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "token": "text.log"
-                },
-                {
-                    "foreground": "#5A4A78",
-                    "token": "text.html.markdown markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "#383B45",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown entity.name"
-                },
-                {
-                    "foreground": "#383B45",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown entity.name"
-                },
-                {
-                    "foreground": "#0F4B6E",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#34548A",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown entity.name"
-                },
-                {
-                    "foreground": "#34548A",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#395B96",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown entity.name"
-                },
-                {
-                    "foreground": "#395B96",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown entity.name"
-                },
-                {
-                    "foreground": "#565A6E",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown entity.name"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "italic",
-                    "token": "markup.italic punctuation"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "bold",
-                    "token": "markup.bold punctuation"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic"
-                },
-                {
-                    "foreground": "#343B58",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic punctuation"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline punctuation"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "markup.quote punctuation.definition.blockquote.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "markup.underline.link"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "constant.other.reference.link.markdown"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "string.other.link.description.title.markdown"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "markup.fenced_code.block.markdown"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#4C505E",
-                    "token": "variable.language.fenced.markdown"
-                },
-                {
-                    "foreground": "#868891",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#C0CEFC",
-                    "token": "markup.table"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#FFDB69",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#942F2F",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#8C4351",
-                    "token": "entity.tag.apacheconf"
-                },
-                {
-                    "foreground": "#33635C",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#34548A",
-                    "token": "source.env"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#cbccd1",
+        "activityBar.border": "#cbccd1",
+        "activityBar.foreground": "#4c505e",
+        "activityBar.inactiveForeground": "#828594",
+        "activityBarBadge.background": "#34548a",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#979db833",
+        "badge.foreground": "#4c505e",
+        "breadcrumb.activeSelectionForeground": "#4c505e",
+        "breadcrumb.background": "#cbccd1",
+        "breadcrumb.focusForeground": "#4c505e",
+        "breadcrumb.foreground": "#828594",
+        "breadcrumbPicker.background": "#cbccd1",
+        "button.background": "#34548add",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#34548aaa",
+        "button.secondaryBackground": "#828594",
+        "charts.blue": "#34548a",
+        "charts.foreground": "#565a6e",
+        "charts.green": "#33635c",
+        "charts.lines": "#f4f5f8",
+        "charts.orange": "#965027",
+        "charts.purple": "#5a4a78",
+        "charts.red": "#8c4351",
+        "charts.yellow": "#8f5e15",
+        "debugConsole.errorForeground": "#942f2f",
+        "debugConsole.infoForeground": "#166775",
+        "debugExceptionWidget.background": "#fafbff40",
+        "debugExceptionWidget.border": "#942f2f",
+        "debugIcon.breakpointDisabledForeground": "#828594",
+        "debugIcon.breakpointForeground": "#db4b4b",
+        "debugIcon.breakpointUnverifiedForeground": "#c24242",
+        "debugIcon.continueForeground": "#3e6396",
+        "debugIcon.pauseForeground": "#3e6396",
+        "debugIcon.startForeground": "#34548a",
+        "debugIcon.stepBackForeground": "#3e6396",
+        "debugIcon.stepIntoForeground": "#3e6396",
+        "debugIcon.stepOutForeground": "#3e6396",
+        "debugIcon.stepOverForeground": "#3e6396",
+        "debugTokenExpression.boolean": "#965027",
+        "debugTokenExpression.error": "#942f2f",
+        "debugTokenExpression.name": "#34548a",
+        "debugTokenExpression.number": "#965027",
+        "debugTokenExpression.string": "#485e30",
+        "debugTokenExpression.value": "#565a6e",
+        "debugToolBar.background": "#d5d6db",
+        "debugView.stateLabelBackground": "#d5d6db",
+        "debugView.stateLabelForeground": "#4c505e",
+        "debugView.valueChangedHighlight": "#f4f5f8",
+        "descriptionForeground": "#7b7f8c",
+        "diffEditor.diagonalFill": "#cacbcf",
+        "diffEditor.insertedLineBackground": "#3f919e15",
+        "diffEditor.insertedTextBackground": "#3f919e15",
+        "diffEditor.removedLineBackground": "#e8686812",
+        "diffEditor.removedTextBackground": "#e8686812",
+        "diffEditorGutter.insertedLineBackground": "#3f919e15",
+        "diffEditorGutter.removedLineBackground": "#e8686812",
+        "diffEditorOverview.insertedForeground": "#3f919e15",
+        "diffEditorOverview.removedForeground": "#e8686812",
+        "dropdown.background": "#d5d6db",
+        "dropdown.border": "#c1c2c7",
+        "dropdown.foreground": "#4c505e",
+        "dropdown.listBackground": "#d5d6db",
+        "editor.background": "#d5d6db",
+        "editor.findMatchBackground": "#fafbff66",
+        "editor.findMatchBorder": "#637dbf",
+        "editor.findMatchHighlightBackground": "#fafbff66",
+        "editor.findRangeHighlightBackground": "#34548a15",
+        "editor.focusedStackFrameHighlightBackground": "#c5e3d0",
+        "editor.foldBackground": "#b2b3b833",
+        "editor.foreground": "#343b59",
+        "editor.inactiveSelectionBackground": "#fafbff15",
+        "editor.lineHighlightBackground": "#dcdee3",
+        "editor.rangeHighlightBackground": "#fafbff20",
+        "editor.selectionBackground": "#fafbff40",
+        "editor.selectionHighlightBackground": "#fafbff55",
+        "editor.stackFrameHighlightBackground": "#e7e8c8",
+        "editor.wordHighlightBackground": "#fafbff33",
+        "editor.wordHighlightStrongBackground": "#fafbff66",
+        "editorBracketHighlight.foreground1": "#34548a",
+        "editorBracketHighlight.foreground2": "#34548a",
+        "editorBracketHighlight.foreground3": "#343b58",
+        "editorBracketHighlight.foreground4": "#166775",
+        "editorBracketHighlight.foreground5": "#485e30",
+        "editorBracketHighlight.foreground6": "#8f5e15",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#bd4040",
+        "editorBracketMatch.background": "#cdced1",
+        "editorBracketMatch.border": "#dcdee3",
+        "editorBracketPairGuide.activeBackground1": "#34548a",
+        "editorBracketPairGuide.activeBackground2": "#34548a",
+        "editorBracketPairGuide.activeBackground3": "#343b58",
+        "editorBracketPairGuide.activeBackground4": "#166775",
+        "editorBracketPairGuide.activeBackground5": "#485e30",
+        "editorBracketPairGuide.activeBackground6": "#8f5e15",
+        "editorCodeLens.foreground": "#868891",
+        "editorCursor.foreground": "#4c505e",
+        "editorError.foreground": "#bd4040",
+        "editorGhostText.foreground": "#73767d",
+        "editorGroup.border": "#c1c2c7",
+        "editorGroup.dropBackground": "#c1c2c7",
+        "editorGroupHeader.border": "#c1c2c7",
+        "editorGroupHeader.noTabsBackground": "#cbccd1",
+        "editorGroupHeader.tabsBackground": "#cbccd1",
+        "editorGroupHeader.tabsBorder": "#c1c2c7",
+        "editorGutter.addedBackground": "#71b6bd",
+        "editorGutter.deletedBackground": "#a8626a",
+        "editorGutter.modifiedBackground": "#637dbf",
+        "editorHint.foreground": "#0da0ba",
+        "editorHoverWidget.background": "#dcdee3",
+        "editorHoverWidget.border": "#c1c2c7",
+        "editorIndentGuide.activeBackground": "#f4f5f8",
+        "editorIndentGuide.background": "#cacbcf",
+        "editorInfo.foreground": "#0da0ba",
+        "editorLineNumber.activeForeground": "#4c505e",
+        "editorLineNumber.foreground": "#9da0ab",
+        "editorLink.activeForeground": "#1f2335",
+        "editorMarkerNavigation.background": "#cbccd1",
+        "editorOverviewRuler.addedForeground": "#71b6bd",
+        "editorOverviewRuler.border": "#c1c2c7",
+        "editorOverviewRuler.bracketMatchForeground": "#c1c2c7",
+        "editorOverviewRuler.deletedForeground": "#a8626a",
+        "editorOverviewRuler.errorForeground": "#bd4040",
+        "editorOverviewRuler.findMatchForeground": "#4c505e44",
+        "editorOverviewRuler.infoForeground": "#1abc9c",
+        "editorOverviewRuler.modifiedForeground": "#637dbf",
+        "editorOverviewRuler.rangeHighlightForeground": "#4c505e44",
+        "editorOverviewRuler.selectionHighlightForeground": "#4c505e22",
+        "editorOverviewRuler.warningForeground": "#8f5e15",
+        "editorOverviewRuler.wordHighlightForeground": "#5a4a7855",
+        "editorOverviewRuler.wordHighlightStrongForeground": "#5a4a7866",
+        "editorPane.background": "#cbccd1",
+        "editorRuler.foreground": "#c1c2c7",
+        "editorSuggestWidget.background": "#dcdee3",
+        "editorSuggestWidget.border": "#c1c2c7",
+        "editorSuggestWidget.highlightForeground": "#34548a",
+        "editorSuggestWidget.selectedBackground": "#e8e9ed",
+        "editorWarning.foreground": "#8f5e15",
+        "editorWhitespace.foreground": "#d5d6db",
+        "editorWidget.background": "#cbccd1",
+        "editorWidget.foreground": "#4c505e",
+        "editorWidget.resizeBorder": "#82859433",
+        "errorForeground": "#5a607d",
+        "extensionBadge.remoteBackground": "#34548a",
+        "extensionBadge.remoteForeground": "#ffffff",
+        "extensionButton.prominentBackground": "#34548add",
+        "extensionButton.prominentForeground": "#ffffff",
+        "extensionButton.prominentHoverBackground": "#34548aaa",
+        "focusBorder": "#82859433",
+        "foreground": "#4c505e",
+        "gitDecoration.addedResourceForeground": "#166775",
+        "gitDecoration.conflictingResourceForeground": "#8f5e15",
+        "gitDecoration.deletedResourceForeground": "#914c54",
+        "gitDecoration.ignoredResourceForeground": "#828594",
+        "gitDecoration.modifiedResourceForeground": "#34548a",
+        "gitDecoration.renamedResourceForeground": "#166775",
+        "gitDecoration.stageDeletedResourceForeground": "#914c54",
+        "gitDecoration.stageModifiedResourceForeground": "#34548a",
+        "gitDecoration.untrackedResourceForeground": "#166775",
+        "gitlens.gutterBackgroundColor": "#dcdee3",
+        "gitlens.gutterForegroundColor": "#4c505e",
+        "gitlens.gutterUncommittedForegroundColor": "#34548a",
+        "gitlens.trailingLineForegroundColor": "#73767d",
+        "icon.foreground": "#4c505e",
+        "input.background": "#d5d6db",
+        "input.border": "#c1c2c7",
+        "input.foreground": "#4c505e",
+        "input.placeholderForeground": "#4a5272",
+        "inputOption.activeBackground": "#34548a44",
+        "inputValidation.errorBackground": "#85353e",
+        "inputValidation.errorBorder": "#942f2f",
+        "inputValidation.errorForeground": "#e8e9ed",
+        "inputValidation.infoBackground": "#3d59a15c",
+        "inputValidation.infoBorder": "#3d59a1",
+        "inputValidation.infoForeground": "#000000",
+        "inputValidation.warningBackground": "#c2985b",
+        "inputValidation.warningBorder": "#8f5e15",
+        "inputValidation.warningForeground": "#000000",
+        "list.activeSelectionBackground": "#d5d6db",
+        "list.activeSelectionForeground": "#4c505e",
+        "list.deemphasizedForeground": "#4c505e",
+        "list.dropBackground": "#c1c2c7",
+        "list.errorForeground": "#942f2f",
+        "list.focusBackground": "#d5d6db",
+        "list.focusForeground": "#4c505e",
+        "list.highlightForeground": "#34548a",
+        "list.hoverBackground": "#d5d6db",
+        "list.hoverForeground": "#4c505e",
+        "list.inactiveSelectionBackground": "#d5d6db",
+        "list.inactiveSelectionForeground": "#4c505e",
+        "list.invalidItemForeground": "#c97018",
+        "list.warningForeground": "#8f5e15",
+        "listFilterWidget.background": "#d5d6db",
+        "listFilterWidget.noMatchesOutline": "#a6333f",
+        "listFilterWidget.outline": "#34548a",
+        "menu.background": "#cbccd1",
+        "menu.border": "#c1c2c7",
+        "menu.foreground": "#4c505e",
+        "menu.selectionBackground": "#7a85a8",
+        "menu.selectionForeground": "#343b58",
+        "menu.separatorBackground": "#c1c2c7",
+        "menubar.selectionBackground": "#7a85a8",
+        "menubar.selectionBorder": "#c1c2c7",
+        "menubar.selectionForeground": "#343b58",
+        "merge.currentContentBackground": "#007a7544",
+        "merge.currentHeaderBackground": "#007a75aa",
+        "merge.incomingContentBackground": "#34548a44",
+        "merge.incomingHeaderBackground": "#34548aaa",
+        "mergeEditor.change.background": "#007a7522",
+        "mergeEditor.change.word.background": "#007a7522",
+        "mergeEditor.conflict.handled.minimapOverViewRuler": "#007a75",
+        "mergeEditor.conflict.handledFocused.border": "#007a7525",
+        "mergeEditor.conflict.handledUnfocused.border": "#007a7525",
+        "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#bb7a61",
+        "mergeEditor.conflict.unhandledFocused.border": "#bb7a61",
+        "mergeEditor.conflict.unhandledUnfocused.border": "#bb7a6188",
+        "minimap.errorHighlight": "#bd4040",
+        "notebook.cellBorderColor": "#c1c2c7",
+        "notebook.cellEditorBackground": "#cbccd1",
+        "notebook.cellStatusBarItemHoverBackground": "#d5d6db",
+        "notebook.editorBackground": "#d5d6db",
+        "notebook.focusedCellBorder": "#828594",
+        "notificationCenterHeader.background": "#dcdee3",
+        "notificationLink.foreground": "#34548a",
+        "notifications.background": "#dcdee3",
+        "notificationsErrorIcon.foreground": "#bb616b",
+        "notificationsInfoIcon.foreground": "#637dbf",
+        "notificationsWarningIcon.foreground": "#bba461",
+        "panel.background": "#cbccd1",
+        "panel.border": "#c1c2c7",
+        "panelInput.border": "#d5d6db",
+        "panelTitle.activeBorder": "#637dbf",
+        "panelTitle.activeForeground": "#4c505e",
+        "panelTitle.inactiveForeground": "#828594",
+        "peekView.border": "#c1c2c7",
+        "peekViewEditor.background": "#dcdee3",
+        "peekViewEditor.matchHighlightBackground": "#34548a22",
+        "peekViewResult.background": "#d7d9de",
+        "peekViewResult.fileForeground": "#4c505e",
+        "peekViewResult.lineForeground": "#4c505e",
+        "peekViewResult.matchHighlightBackground": "#34548a22",
+        "peekViewResult.selectionBackground": "#34548a33",
+        "peekViewResult.selectionForeground": "#4c505e",
+        "peekViewTitle.background": "#cbccd1",
+        "peekViewTitleDescription.foreground": "#4c505e",
+        "peekViewTitleLabel.foreground": "#4c505e",
+        "pickerGroup.border": "#c1c2c7",
+        "pickerGroup.foreground": "#4c505e",
+        "progressBar.background": "#34548a",
+        "sash.hoverBorder": "#828594",
+        "scrollbar.shadow": "#00000033",
+        "scrollbarSlider.activeBackground": "#90929632",
+        "scrollbarSlider.background": "#90929625",
+        "scrollbarSlider.hoverBackground": "#90929620",
+        "selection.background": "#fafbff55",
+        "settings.headerForeground": "#34548a",
+        "sideBar.background": "#cbccd1",
+        "sideBar.border": "#c1c2c7",
+        "sideBar.dropBackground": "#c1c2c7",
+        "sideBar.foreground": "#4c505e",
+        "sideBarSectionHeader.background": "#cbccd1",
+        "sideBarSectionHeader.border": "#c1c2c7",
+        "sideBarSectionHeader.foreground": "#4c505e",
+        "sideBarTitle.foreground": "#4c505e",
+        "statusBar.background": "#cbccd1",
+        "statusBar.border": "#c1c2c7",
+        "statusBar.debuggingBackground": "#d5d6db",
+        "statusBar.debuggingForeground": "#4c505e",
+        "statusBar.foreground": "#4c505e",
+        "statusBar.noFolderBackground": "#d5d6db",
+        "statusBarItem.activeBackground": "#c1c2c7",
+        "statusBarItem.hoverBackground": "#d5d6db",
+        "statusBarItem.prominentBackground": "#c1c2c7",
+        "statusBarItem.prominentHoverBackground": "#d5d6db",
+        "tab.activeBackground": "#cbccd1",
+        "tab.activeBorder": "#637dbf",
+        "tab.activeForeground": "#383b45",
+        "tab.activeModifiedBorder": "#d5d6db",
+        "tab.border": "#c1c2c7",
+        "tab.hoverForeground": "#383b45",
+        "tab.inactiveBackground": "#cbccd1",
+        "tab.inactiveForeground": "#4c505e",
+        "tab.inactiveModifiedBorder": "#d5d6db",
+        "tab.lastPinnedBorder": "#dadbe0",
+        "tab.unfocusedActiveBorder": "#9da0ab",
+        "tab.unfocusedActiveForeground": "#383b45",
+        "tab.unfocusedHoverForeground": "#383b45",
+        "tab.unfocusedInactiveForeground": "#4c505e",
+        "terminal.ansiBlack": "#0f0f14",
+        "terminal.ansiBlue": "#34548a",
+        "terminal.ansiBrightBlack": "#0f0f14",
+        "terminal.ansiBrightBlue": "#34548a",
+        "terminal.ansiBrightCyan": "#0f4b6e",
+        "terminal.ansiBrightGreen": "#33635c",
+        "terminal.ansiBrightMagenta": "#5a4a78",
+        "terminal.ansiBrightRed": "#8c4351",
+        "terminal.ansiBrightWhite": "#828594",
+        "terminal.ansiBrightYellow": "#8f5e15",
+        "terminal.ansiCyan": "#0f4b6e",
+        "terminal.ansiGreen": "#33635c",
+        "terminal.ansiMagenta": "#5a4a78",
+        "terminal.ansiRed": "#8c4351",
+        "terminal.ansiWhite": "#828594",
+        "terminal.ansiYellow": "#8f5e15",
+        "terminal.background": "#cbccd1",
+        "terminal.foreground": "#4c505e",
+        "terminal.selectionBackground": "#fafbff40",
+        "terminalCursor.foreground": "#828594",
+        "textBlockQuote.background": "#cbccd1",
+        "textCodeBlock.background": "#d5d6db",
+        "textLink.activeForeground": "#4c505e",
+        "textLink.foreground": "#34548a",
+        "textPreformat.foreground": "#33635c",
+        "textSeparator.foreground": "#828594",
+        "titleBar.activeBackground": "#cbccd1",
+        "titleBar.activeForeground": "#4c505e",
+        "titleBar.border": "#c1c2c7",
+        "titleBar.inactiveBackground": "#cbccd1",
+        "titleBar.inactiveForeground": "#4c505e",
+        "toolbar.activeBackground": "#fafbff40",
+        "toolbar.hoverBackground": "#fafbff40",
+        "tree.indentGuidesStroke": "#c1c2c7",
+        "walkThrough.embeddedEditorBackground": "#cbccd1",
+        "widget.shadow": "#ffffff00",
+        "window.activeBorder": "#cdced1",
+        "window.inactiveBorder": "#cdced1"
+    },
+    "rules": [
+        {
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.flow"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.return"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.modifier"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.block-scalar.literal"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.python"
+        },
+        {
+            "foreground": "#9699A3",
+            "token": "comment"
+        },
+        {
+            "foreground": "#9699A3",
+            "token": "comment.block.documentation"
+        },
+        {
+            "foreground": "#9699A3",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#9699A3",
+            "token": "comment.block.documentation punctuation"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "keyword.operator.assignment.jsdoc"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation variable"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation storage"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation keyword"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation support"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation markup"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "comment.block.documentation markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "meta.other.type.phpdoc.php keyword.other.type.php"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "meta.other.type.phpdoc.php support.other.namespace.php"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "keyword.other.phpdoc.php"
+        },
+        {
+            "foreground": "#7C7F87",
+            "token": "log.date"
+        },
+        {
+            "foreground": "#73767D",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#73767D",
+            "token": "comment.block.documentation storage.type"
+        },
+        {
+            "foreground": "#73767D",
+            "token": "comment.block.documentation punctuation.definition.block.tag"
+        },
+        {
+            "foreground": "#73767D",
+            "token": "comment.block.documentation entity.name.type.instance"
+        },
+        {
+            "foreground": "#965027",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#965027",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#965027",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#965027",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#965027",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#965027",
+            "token": "constant.other.caps"
+        },
+        {
+            "foreground": "#485E30",
+            "fontStyle": "",
+            "token": "string"
+        },
+        {
+            "foreground": "#485E30",
+            "fontStyle": "",
+            "token": "constant.other.symbol"
+        },
+        {
+            "foreground": "#485E30",
+            "fontStyle": "",
+            "token": "constant.other.key"
+        },
+        {
+            "foreground": "#485E30",
+            "fontStyle": "",
+            "token": "meta.attribute-selector"
+        },
+        {
+            "foreground": "#485E30",
+            "fontStyle": "",
+            "token": "string constant.character"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "constant.other.color"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
+        },
+        {
+            "foreground": "#942F2F",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#942F2F",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "meta.embedded.line.tag.smarty"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "punctuation.section.tag.twig"
+        },
+        {
+            "foreground": "#166775",
+            "token": "keyword.control.smarty"
+        },
+        {
+            "foreground": "#166775",
+            "token": "keyword.control.twig"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.constant.handlebars keyword.control"
+        },
+        {
+            "foreground": "#166775",
+            "token": "keyword.operator.comparison.twig"
+        },
+        {
+            "foreground": "#166775",
+            "token": "keyword.blade"
+        },
+        {
+            "foreground": "#166775",
+            "token": "entity.name.function.blade"
+        },
+        {
+            "foreground": "#8C4351",
+            "fontStyle": "bold",
+            "token": "keyword.operator.spread"
+        },
+        {
+            "foreground": "#8C4351",
+            "fontStyle": "bold",
+            "token": "keyword.operator.rest"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.control.as"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.other"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.operator.bitwise.shift"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "expression.embbeded.vue punctuation.definition.tag"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "text.html.twig meta.tag.inline.any.html"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.tag.template.value.twig meta.function.arguments.twig"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.definition.constant.markdown"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.support.type.property-name"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "text.html.vue-html meta.tag"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.attribute.directive"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.terminator.rule"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.definition.entity"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.other.template"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "keyword.other.substitution"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "entity.name.operator"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.property-list punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.at-rule.mixin punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "meta.at-rule.function variable.parameter.url"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.control.module"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.control.import"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.control.export"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.control.from"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.control.default"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "meta.import keyword.other"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.other.important"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "keyword.other.DML"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "storage.type.function"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.bitwise"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.ternary"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.comparison"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.relational"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.or.regexp"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "entity.name.tag support.class.component"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "meta.tag.custom entity.name.tag"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#B05467",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "meta.tag.custom punctuation.definition.tag"
+        },
+        {
+            "foreground": "#69323D",
+            "token": "meta.jsx punctuation.definition.tag"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "constant.other.php"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.other.global.safer"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.other.global.safer punctuation.definition.variable"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.other.global"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.other.global punctuation.definition.variable"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "constant.other.haskell"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "string constant.other.placeholder"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.parameter.handlebars"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.other.object"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "meta.fstring"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "meta.function-call meta.function-call.arguments"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "meta.array.literal variable"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "entity.name.type.hcl"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "string.alias.graphql"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "string.unquoted.graphql"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "string.unquoted.alias.graphql"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "meta.field.declaration.ts variable.object.property"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "meta.block entity.name.label"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "variable.other.property"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "meta.function-call variable.other.object.property"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "variable.other.object.property.cs"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.other.object.property"
+        },
+        {
+            "foreground": "#296973",
+            "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "source.cpp meta.block variable.other"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "meta.class-method.js entity.name.function.js"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "entity.name.method.js"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "variable.function.constructor"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "keyword.other.special-method"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "meta.function-call"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "meta.function-call entity.name.function"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "meta.definition.method entity.name.function"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "meta.object-literal entity.name.function"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "meta.function.parameters punctuation.definition.variable"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "meta.function.parameter variable"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.other.type.php"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "constant.escape"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.definition.variable variable.other.constant"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.definition.variable variable.other.readwrite"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "variable.declaration.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "variable.other.declaration"
+        },
+        {
+            "foreground": "#5A4A78",
+            "fontStyle": "",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#166775",
+            "token": "variable.other.readwrite.alias"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.orther.namespace.use.php"
+        },
+        {
+            "foreground": "#166775",
+            "token": "meta.use.php"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.type.sys-types"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.variable.dom"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.type.object.module"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#166775",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#166775",
+            "token": "meta.import.qualifier"
+        },
+        {
+            "foreground": "#166775",
+            "token": "variable.other.constant.object"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#166775",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.css support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.sass support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.scss support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.less support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.stylus support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.postcss support.type.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "support.type.property-name.css"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "support.type.vendored.property-name"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "support.type.map.key"
+        },
+        {
+            "foreground": "#485E30",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#485E30",
+            "token": "meta.definition.variable"
+        },
+        {
+            "foreground": "#485E30",
+            "token": "entity.other.attribute-name.class"
+        },
+        {
+            "foreground": "#485E30",
+            "token": "meta.at-rule.mixin.scss entity.name.function.scss"
+        },
+        {
+            "foreground": "#942F2F",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#166775",
+            "token": "entity.name.tag.css"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "entity.other.attribute-name.class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "entity.name.tag.reference"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "meta.property-list"
+        },
+        {
+            "foreground": "#965027",
+            "token": "meta.property-list meta.at-rule.if"
+        },
+        {
+            "foreground": "#965027",
+            "token": "meta.at-rule.return variable.parameter.url"
+        },
+        {
+            "foreground": "#965027",
+            "token": "meta.property-list meta.at-rule.else"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "meta.property-list meta.property-list"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.at-rule.include entity.name.function.scss"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "keyword.control.at-rule.include punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "meta.at-rule.extend keyword.control.at-rule.extend"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "meta.at-rule.media keyword.control.at-rule.media"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "meta.at-rule.function keyword.control.at-rule.function"
+        },
+        {
+            "foreground": "#4F4168",
+            "token": "keyword.control punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "meta.property-list meta.at-rule.include"
+        },
+        {
+            "foreground": "#965027",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "entity.name.module.js"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.import.parameter.js"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.other.class.js"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "variable.other punctuation.definition.variable"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "source.js constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "variable.language.this punctuation.definition.variable"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "keyword.other.this"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "text.html.basic entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "text.html.basic entity.other.attribute-name"
+        },
+        {
+            "foreground": "#166775",
+            "token": "text.html constant.character.entity"
+        },
+        {
+            "foreground": "#166775",
+            "token": "text.html punctuation.definition.entity"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "entity.other.attribute-name.id.html"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.sass keyword.control"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "entity.other.attribute-name.placeholder"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "meta.property-list meta.property-value"
+        },
+        {
+            "foreground": "#449DAB",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#914C54",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#3E6968",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "punctuation.definition.group"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "constant.character.escape.backslash"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#166775",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#8F5E15",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#166775",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#485E30",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.list_item.markdown"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "meta.block"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "meta.brace"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.block"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.use"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.class"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.begin.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.end.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.switch-expression.begin.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.switch-expression.end.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.section.switch-block.begin.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.section.switch-block.end.bracket"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.group.shell"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.arguments"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.dictionary"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.definition.array"
+        },
+        {
+            "foreground": "#484C61",
+            "token": "punctuation.section"
+        },
+        {
+            "foreground": "#343B58",
+            "token": "meta.embedded.block"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "meta.tag JSXNested"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "text.html"
+        },
+        {
+            "foreground": "#565A6E",
+            "token": "text.log"
+        },
+        {
+            "foreground": "#5A4A78",
+            "token": "text.html.markdown markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "#383B45",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown entity.name"
+        },
+        {
+            "foreground": "#383B45",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown entity.name"
+        },
+        {
+            "foreground": "#0F4B6E",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#34548A",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown entity.name"
+        },
+        {
+            "foreground": "#34548A",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#395B96",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown entity.name"
+        },
+        {
+            "foreground": "#395B96",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#565A6E",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown entity.name"
+        },
+        {
+            "foreground": "#565A6E",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown entity.name"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "italic",
+            "token": "markup.italic punctuation"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "bold",
+            "token": "markup.bold punctuation"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic"
+        },
+        {
+            "foreground": "#343B58",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic punctuation"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline punctuation"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "markup.quote punctuation.definition.blockquote.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "markup.underline.link"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "constant.other.reference.link.markdown"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "string.other.link.description.title.markdown"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "markup.fenced_code.block.markdown"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#4C505E",
+            "token": "variable.language.fenced.markdown"
+        },
+        {
+            "foreground": "#868891",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#C0CEFC",
+            "token": "markup.table"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#FFDB69",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#942F2F",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#8C4351",
+            "token": "entity.tag.apacheconf"
+        },
+        {
+            "foreground": "#33635C",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#34548A",
+            "token": "source.env"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/tokyo-night-storm/tokyo-night-storm-monaco.json
+++ b/themes/tokyo-night-storm/tokyo-night-storm-monaco.json
@@ -1,1684 +1,1680 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#1f2335",
-                "activityBar.border": "#1f2335",
-                "activityBar.foreground": "#7982a9",
-                "activityBar.inactiveForeground": "#41496b",
-                "activityBarBadge.background": "#3d59a1",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#7e83b233",
-                "badge.foreground": "#a9b1d6",
-                "breadcrumb.activeSelectionForeground": "#a9b1d6",
-                "breadcrumb.background": "#1f2335",
-                "breadcrumb.focusForeground": "#a9b1d6",
-                "breadcrumb.foreground": "#545c7e",
-                "breadcrumbPicker.background": "#1f2335",
-                "button.background": "#3d59a1dd",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#3d59a1aa",
-                "button.secondaryBackground": "#41496b",
-                "charts.blue": "#7aa2f7",
-                "charts.foreground": "#9aa5ce",
-                "charts.green": "#73daca",
-                "charts.lines": "#1f2335",
-                "charts.orange": "#ff9e64",
-                "charts.purple": "#9d7cd8",
-                "charts.red": "#f7768e",
-                "charts.yellow": "#e0af68",
-                "debugConsole.errorForeground": "#bb616b",
-                "debugConsole.infoForeground": "#7982a9",
-                "debugConsole.sourceForeground": "#7982a9",
-                "debugConsole.warningForeground": "#c49a5a",
-                "debugConsoleInputIcon.foreground": "#73daca",
-                "debugExceptionWidget.background": "#1b1e2e",
-                "debugExceptionWidget.border": "#963c47",
-                "debugIcon.breakpointDisabledForeground": "#545c7e",
-                "debugIcon.breakpointForeground": "#db4b4b",
-                "debugIcon.breakpointUnverifiedForeground": "#c24242",
-                "debugTokenExpression.boolean": "#ff9e64",
-                "debugTokenExpression.error": "#bb616b",
-                "debugTokenExpression.name": "#7dcfff",
-                "debugTokenExpression.number": "#ff9e64",
-                "debugTokenExpression.string": "#9ece6a",
-                "debugTokenExpression.value": "#9aa5ce",
-                "debugToolBar.background": "#1b1e2e",
-                "debugView.stateLabelBackground": "#1b1e2e",
-                "debugView.stateLabelForeground": "#7982a9",
-                "debugView.valueChangedHighlight": "#3d59a1cc",
-                "descriptionForeground": "#545c7e",
-                "diffEditor.diagonalFill": "#2c324a",
-                "diffEditor.insertedLineBackground": "#41a6b520",
-                "diffEditor.insertedTextBackground": "#41a6b520",
-                "diffEditor.removedLineBackground": "#db4b4b22",
-                "diffEditor.removedTextBackground": "#db4b4b22",
-                "diffEditorGutter.insertedLineBackground": "#41a6b525",
-                "diffEditorGutter.removedLineBackground": "#db4b4b22",
-                "diffEditorOverview.insertedForeground": "#41a6b525",
-                "diffEditorOverview.removedForeground": "#db4b4b22",
-                "dropdown.background": "#1b1e2e",
-                "dropdown.foreground": "#7982a9",
-                "dropdown.listBackground": "#1b1e2e",
-                "editor.background": "#24283b",
-                "editor.findMatchBackground": "#3d59a166",
-                "editor.findMatchBorder": "#ffdb69aa",
-                "editor.findMatchHighlightBackground": "#3d59a166",
-                "editor.findRangeHighlightBackground": "#6f7bb625",
-                "editor.focusedStackFrameHighlightBackground": "#73daca20",
-                "editor.foldBackground": "#181b294a",
-                "editor.foreground": "#a9b1d6",
-                "editor.inactiveSelectionBackground": "#6f7bb615",
-                "editor.lineHighlightBackground": "#292e42",
-                "editor.rangeHighlightBackground": "#6f7bb620",
-                "editor.selectionBackground": "#6f7bb640",
-                "editor.selectionHighlightBackground": "#6f7bb633",
-                "editor.stackFrameHighlightBackground": "#e2bd3a20",
-                "editor.wordHighlightBackground": "#6f7bb633",
-                "editor.wordHighlightStrongBackground": "#6f7bb644",
-                "editorBracketHighlight.foreground1": "#698cd6",
-                "editorBracketHighlight.foreground2": "#68b3de",
-                "editorBracketHighlight.foreground3": "#9a7ecc",
-                "editorBracketHighlight.foreground4": "#25aac2",
-                "editorBracketHighlight.foreground5": "#80a856",
-                "editorBracketHighlight.foreground6": "#cfa25f",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#db4b4b",
-                "editorBracketMatch.background": "#1f2335",
-                "editorBracketMatch.border": "#545c7e",
-                "editorBracketPairGuide.activeBackground1": "#698cd6",
-                "editorBracketPairGuide.activeBackground2": "#68b3de",
-                "editorBracketPairGuide.activeBackground3": "#9a7ecc",
-                "editorBracketPairGuide.activeBackground4": "#25aac2",
-                "editorBracketPairGuide.activeBackground5": "#80a856",
-                "editorBracketPairGuide.activeBackground6": "#cfa25f",
-                "editorCodeLens.foreground": "#565f89",
-                "editorCursor.foreground": "#c0caf5",
-                "editorError.foreground": "#db4b4b",
-                "editorGhostText.foreground": "#7582ba",
-                "editorGroup.border": "#1b1e2e",
-                "editorGroup.dropBackground": "#292e42",
-                "editorGroupHeader.border": "#1b1e2e",
-                "editorGroupHeader.noTabsBackground": "#1f2335",
-                "editorGroupHeader.tabsBackground": "#1f2335",
-                "editorGroupHeader.tabsBorder": "#1b1e2e",
-                "editorGutter.addedBackground": "#164846",
-                "editorGutter.deletedBackground": "#823c41",
-                "editorGutter.modifiedBackground": "#3d547a",
-                "editorHint.foreground": "#0da0ba",
-                "editorHoverWidget.background": "#1f2335",
-                "editorHoverWidget.border": "#1b1e2e",
-                "editorIndentGuide.activeBackground": "#3b4261",
-                "editorIndentGuide.background": "#292e42",
-                "editorInfo.foreground": "#0da0ba",
-                "editorLightBulb.foreground": "#e0af68",
-                "editorLightBulbAutoFix.foreground": "#e0af68",
-                "editorLineNumber.activeForeground": "#737aa2",
-                "editorLineNumber.foreground": "#3b4261",
-                "editorLink.activeForeground": "#a9b1d6",
-                "editorMarkerNavigation.background": "#1f2335",
-                "editorOverviewRuler.addedForeground": "#164846",
-                "editorOverviewRuler.border": "#1b1e2e",
-                "editorOverviewRuler.bracketMatchForeground": "#1b1e2e",
-                "editorOverviewRuler.deletedForeground": "#703438",
-                "editorOverviewRuler.errorForeground": "#db4b4b",
-                "editorOverviewRuler.findMatchForeground": "#a9b1d644",
-                "editorOverviewRuler.infoForeground": "#1abc9c",
-                "editorOverviewRuler.modifiedForeground": "#3d547a",
-                "editorOverviewRuler.rangeHighlightForeground": "#a9b1d644",
-                "editorOverviewRuler.selectionHighlightForeground": "#a9b1d622",
-                "editorOverviewRuler.warningForeground": "#e0af68",
-                "editorOverviewRuler.wordHighlightForeground": "#bb9af755",
-                "editorOverviewRuler.wordHighlightStrongForeground": "#bb9af766",
-                "editorPane.background": "#1f2335",
-                "editorRuler.foreground": "#1b1e2e",
-                "editorSuggestWidget.background": "#1f2335",
-                "editorSuggestWidget.border": "#1b1e2e",
-                "editorSuggestWidget.highlightForeground": "#668ac4",
-                "editorSuggestWidget.selectedBackground": "#282e44",
-                "editorWarning.foreground": "#e0af68",
-                "editorWhitespace.foreground": "#3b4261",
-                "editorWidget.background": "#1f2335",
-                "editorWidget.foreground": "#7982a9",
-                "editorWidget.resizeBorder": "#545c7e33",
-                "errorForeground": "#5a607d",
-                "extensionBadge.remoteBackground": "#3d59a1",
-                "extensionBadge.remoteForeground": "#ffffff",
-                "extensionButton.prominentBackground": "#3d59a1dd",
-                "extensionButton.prominentForeground": "#ffffff",
-                "extensionButton.prominentHoverBackground": "#3d59a1aa",
-                "focusBorder": "#545c7e33",
-                "foreground": "#7982a9",
-                "gitDecoration.addedResourceForeground": "#449dab",
-                "gitDecoration.conflictingResourceForeground": "#e0af68cc",
-                "gitDecoration.deletedResourceForeground": "#914c54",
-                "gitDecoration.ignoredResourceForeground": "#545c7e",
-                "gitDecoration.modifiedResourceForeground": "#6183bb",
-                "gitDecoration.renamedResourceForeground": "#449dab",
-                "gitDecoration.stageDeletedResourceForeground": "#914c54",
-                "gitDecoration.stageModifiedResourceForeground": "#6183bb",
-                "gitDecoration.untrackedResourceForeground": "#449dab",
-                "gitlens.gutterBackgroundColor": "#1f2335",
-                "gitlens.gutterForegroundColor": "#7982a9",
-                "gitlens.gutterUncommittedForegroundColor": "#7aa2f7",
-                "gitlens.trailingLineForegroundColor": "#7582ba",
-                "icon.foreground": "#7982a9",
-                "input.background": "#1b1e2e",
-                "input.border": "#282e44",
-                "input.foreground": "#a9b1d6",
-                "input.placeholderForeground": "#4a5272",
-                "inputOption.activeBackground": "#3d59a144",
-                "inputOption.activeForeground": "#c0caf5",
-                "inputValidation.errorBackground": "#85353e",
-                "inputValidation.errorBorder": "#963c47",
-                "inputValidation.errorForeground": "#bbc2e0",
-                "inputValidation.infoBackground": "#3d59a15c",
-                "inputValidation.infoBorder": "#3d59a1",
-                "inputValidation.infoForeground": "#bbc2e0",
-                "inputValidation.warningBackground": "#c2985b",
-                "inputValidation.warningBorder": "#e0af68",
-                "inputValidation.warningForeground": "#000000",
-                "list.activeSelectionBackground": "#2c324a",
-                "list.activeSelectionForeground": "#a9b1d6",
-                "list.deemphasizedForeground": "#7982a9",
-                "list.dropBackground": "#292e42",
-                "list.errorForeground": "#bb616b",
-                "list.focusBackground": "#292e42",
-                "list.focusForeground": "#a9b1d6",
-                "list.highlightForeground": "#668ac4",
-                "list.hoverBackground": "#1b1e2e",
-                "list.hoverForeground": "#a9b1d6",
-                "list.inactiveSelectionBackground": "#292e42",
-                "list.inactiveSelectionForeground": "#a9b1d6",
-                "list.invalidItemForeground": "#c97018",
-                "list.warningForeground": "#c49a5a",
-                "listFilterWidget.background": "#1b1e2e",
-                "listFilterWidget.noMatchesOutline": "#a6333f",
-                "listFilterWidget.outline": "#3d59a1",
-                "menu.background": "#1f2335",
-                "menu.border": "#1b1e2e",
-                "menu.foreground": "#7982a9",
-                "menu.selectionBackground": "#2f3549",
-                "menu.selectionForeground": "#c0caf5",
-                "menu.separatorBackground": "#1b1e2e",
-                "menubar.selectionBackground": "#2f3549",
-                "menubar.selectionBorder": "#1b1e2e",
-                "menubar.selectionForeground": "#c0caf5",
-                "merge.currentContentBackground": "#007a7544",
-                "merge.currentHeaderBackground": "#41a6b525",
-                "merge.incomingContentBackground": "#3d59a144",
-                "merge.incomingHeaderBackground": "#3d59a1aa",
-                "mergeEditor.change.background": "#41a6b525",
-                "mergeEditor.change.word.background": "#41a6b540",
-                "mergeEditor.conflict.handled.minimapOverViewRuler": "#449dab",
-                "mergeEditor.conflict.handledFocused.border": "#41a6b565",
-                "mergeEditor.conflict.handledUnfocused.border": "#41a6b525",
-                "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#e0af68",
-                "mergeEditor.conflict.unhandledFocused.border": "#e0af68d9",
-                "mergeEditor.conflict.unhandledUnfocused.border": "#e0af6888",
-                "minimapGutter.addedBackground": "#1c5957",
-                "minimapGutter.deletedBackground": "#944449",
-                "minimapGutter.modifiedBackground": "#3d547a",
-                "notebook.cellBorderColor": "#1b1e2e",
-                "notebook.cellEditorBackground": "#1f2335",
-                "notebook.cellStatusBarItemHoverBackground": "#2c324a",
-                "notebook.editorBackground": "#24283b",
-                "notebook.focusedCellBorder": "#29355a",
-                "notificationCenterHeader.background": "#1b1e2e",
-                "notificationLink.foreground": "#6183bb",
-                "notifications.background": "#1b1e2e",
-                "notificationsErrorIcon.foreground": "#bb616b",
-                "notificationsInfoIcon.foreground": "#0da0ba",
-                "notificationsWarningIcon.foreground": "#bba461",
-                "panel.background": "#1f2335",
-                "panel.border": "#1b1e2e",
-                "panelInput.border": "#1f2335",
-                "panelTitle.activeBorder": "#3d59a1",
-                "panelTitle.activeForeground": "#a9b1d6",
-                "panelTitle.inactiveForeground": "#7982a9",
-                "peekView.border": "#1b1e2e",
-                "peekViewEditor.background": "#1f2335",
-                "peekViewEditor.matchHighlightBackground": "#3d59a166",
-                "peekViewResult.background": "#1b1e2e",
-                "peekViewResult.fileForeground": "#7982a9",
-                "peekViewResult.lineForeground": "#a9b1d6",
-                "peekViewResult.matchHighlightBackground": "#3d59a166",
-                "peekViewResult.selectionBackground": "#3d59a133",
-                "peekViewResult.selectionForeground": "#a9b1d6",
-                "peekViewTitle.background": "#1b1e2e",
-                "peekViewTitleDescription.foreground": "#7982a9",
-                "peekViewTitleLabel.foreground": "#a9b1d6",
-                "pickerGroup.border": "#1b1e2e",
-                "pickerGroup.foreground": "#a9b1d6",
-                "progressBar.background": "#3d59a1",
-                "sash.hoverBorder": "#29355a",
-                "scrollbar.shadow": "#00000033",
-                "scrollbarSlider.activeBackground": "#9cacff22",
-                "scrollbarSlider.background": "#9cacff15",
-                "scrollbarSlider.hoverBackground": "#9cacff10",
-                "selection.background": "#6f7bb635",
-                "settings.headerForeground": "#6183bb",
-                "sideBar.background": "#1f2335",
-                "sideBar.border": "#1b1e2e",
-                "sideBar.dropBackground": "#292e42",
-                "sideBar.foreground": "#7982a9",
-                "sideBarSectionHeader.background": "#1f2335",
-                "sideBarSectionHeader.border": "#1b1e2e",
-                "sideBarSectionHeader.foreground": "#a9b1d6",
-                "sideBarTitle.foreground": "#7982a9",
-                "statusBar.background": "#1f2335",
-                "statusBar.border": "#1b1e2e",
-                "statusBar.debuggingBackground": "#1f2335",
-                "statusBar.debuggingForeground": "#7982a9",
-                "statusBar.foreground": "#7982a9",
-                "statusBar.noFolderBackground": "#1f2335",
-                "statusBarItem.activeBackground": "#1b1e2e",
-                "statusBarItem.hoverBackground": "#282e44",
-                "statusBarItem.prominentBackground": "#1b1e2e",
-                "statusBarItem.prominentHoverBackground": "#282e44",
-                "tab.activeBackground": "#1f2335",
-                "tab.activeBorder": "#3d59a1",
-                "tab.activeForeground": "#a9b1d6",
-                "tab.activeModifiedBorder": "#282d42",
-                "tab.border": "#1b1e2e",
-                "tab.hoverForeground": "#a9b1d6",
-                "tab.inactiveBackground": "#1f2335",
-                "tab.inactiveForeground": "#7982a9",
-                "tab.inactiveModifiedBorder": "#282d42",
-                "tab.lastPinnedBorder": "#2c3147",
-                "tab.unfocusedActiveBorder": "#3b4261",
-                "tab.unfocusedActiveForeground": "#a9b1d6",
-                "tab.unfocusedHoverForeground": "#a9b1d6",
-                "tab.unfocusedInactiveForeground": "#7982a9",
-                "terminal.ansiBlack": "#414868",
-                "terminal.ansiBlue": "#7aa2f7",
-                "terminal.ansiBrightBlack": "#414868",
-                "terminal.ansiBrightBlue": "#7aa2f7",
-                "terminal.ansiBrightCyan": "#7dcfff",
-                "terminal.ansiBrightGreen": "#73daca",
-                "terminal.ansiBrightMagenta": "#bb9af7",
-                "terminal.ansiBrightRed": "#f7768e",
-                "terminal.ansiBrightWhite": "#a9b1d6",
-                "terminal.ansiBrightYellow": "#e0af68",
-                "terminal.ansiCyan": "#7dcfff",
-                "terminal.ansiGreen": "#73daca",
-                "terminal.ansiMagenta": "#bb9af7",
-                "terminal.ansiRed": "#f7768e",
-                "terminal.ansiWhite": "#7982a9",
-                "terminal.ansiYellow": "#e0af68",
-                "terminal.background": "#1f2335",
-                "terminal.foreground": "#7982a9",
-                "terminal.selectionBackground": "#6f7bb640",
-                "textBlockQuote.background": "#1f2335",
-                "textCodeBlock.background": "#1f2335",
-                "textLink.activeForeground": "#7dcfff",
-                "textLink.foreground": "#668ac4",
-                "textPreformat.foreground": "#73daca",
-                "textSeparator.foreground": "#545c7e",
-                "titleBar.activeBackground": "#1f2335",
-                "titleBar.activeForeground": "#7982a9",
-                "titleBar.border": "#1b1e2e",
-                "titleBar.inactiveBackground": "#1f2335",
-                "titleBar.inactiveForeground": "#7982a9",
-                "toolbar.activeBackground": "#2c324a",
-                "toolbar.hoverBackground": "#2c324a",
-                "tree.indentGuidesStroke": "#2e344f",
-                "walkThrough.embeddedEditorBackground": "#1f2335",
-                "widget.shadow": "#ffffff00",
-                "window.activeBorder": "#0d0f17",
-                "window.inactiveBorder": "#0d0f17"
-            },
-            "rules": [
-                {
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.flow"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.return"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.modifier"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.block-scalar.literal"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.python"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "comment.block.documentation"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#565F89",
-                    "token": "comment.block.documentation punctuation"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "keyword.operator.assignment.jsdoc"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation variable"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation storage"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation keyword"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation support"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation markup"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "comment.block.documentation markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "meta.other.type.phpdoc.php keyword.other.type.php"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "meta.other.type.phpdoc.php support.other.namespace.php"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "keyword.other.phpdoc.php"
-                },
-                {
-                    "foreground": "#6A75A8",
-                    "token": "log.date"
-                },
-                {
-                    "foreground": "#7582BA",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#7582BA",
-                    "token": "comment.block.documentation storage.type"
-                },
-                {
-                    "foreground": "#7582BA",
-                    "token": "comment.block.documentation punctuation.definition.block.tag"
-                },
-                {
-                    "foreground": "#7582BA",
-                    "token": "comment.block.documentation entity.name.type.instance"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.other.caps"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "constant.other.symbol"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "constant.other.key"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "meta.attribute-selector"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "string constant.character"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "constant.other.color"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#FF5370",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#FF5370",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.embedded.line.tag.smarty"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.section.tag.twig"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "keyword.control.smarty"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "keyword.control.twig"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.constant.handlebars keyword.control"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "keyword.operator.comparison.twig"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "keyword.blade"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "entity.name.function.blade"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.spread"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.rest"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.control.as"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator.bitwise.shift"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "expression.embbeded.vue punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "text.html.twig meta.tag.inline.any.html"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.tag.template.value.twig meta.function.arguments.twig"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.constant.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.support.type.property-name"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "text.html.vue-html meta.tag"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.attribute.directive"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.terminator.rule"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other.template"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other.substitution"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "entity.name.operator"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.property-list punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.at-rule.mixin punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.at-rule.function variable.parameter.url"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.module"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.import"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.export"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.from"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.default"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.import keyword.other"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.important"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.other.DML"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type.function"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.bitwise"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.ternary"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.comparison"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.relational"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.or.regexp"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "entity.name.tag support.class.component"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag.custom entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#BA3C97",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other.php"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global.safer"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global.safer punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other.haskell"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "string constant.other.placeholder"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.parameter.handlebars"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.object"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.fstring"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.function-call meta.function-call.arguments"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.array.literal variable"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "entity.name.type.hcl"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.alias.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.unquoted.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.unquoted.alias.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.field.declaration.ts variable.object.property"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.block entity.name.label"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "variable.other.property"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.function-call variable.other.object.property"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "variable.other.object.property.cs"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.object.property"
-                },
-                {
-                    "foreground": "#41A6B5",
-                    "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.cpp meta.block variable.other"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.class-method.js entity.name.function.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "entity.name.method.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.function.constructor"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "keyword.other.special-method"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.function-call"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.function-call entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.definition.method entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.object-literal entity.name.function"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "meta.function.parameters punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "meta.function.parameter variable"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.type.php"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.escape"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.definition.variable variable.other.constant"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.definition.variable variable.other.readwrite"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "variable.declaration.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "variable.other.declaration"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "fontStyle": "",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "variable.other.readwrite.alias"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.orther.namespace.use.php"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "meta.use.php"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.type.sys-types"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.variable.dom"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.type.object.module"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "meta.import.qualifier"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "variable.other.constant.object"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.css support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.sass support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.scss support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.less support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.stylus support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.postcss support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.property-name.css"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.vendored.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.map.key"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "meta.definition.variable"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "entity.other.attribute-name.class"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "meta.at-rule.mixin.scss entity.name.function.scss"
-                },
-                {
-                    "foreground": "#FC7B7B",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "entity.name.tag.css"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.name.tag.reference"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.property-list"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.property-list meta.at-rule.if"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.at-rule.return variable.parameter.url"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.property-list meta.at-rule.else"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.property-list meta.property-list"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.include entity.name.function.scss"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.include punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.extend keyword.control.at-rule.extend"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.media keyword.control.at-rule.media"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.function keyword.control.at-rule.function"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.property-list meta.at-rule.include"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "entity.name.module.js"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.import.parameter.js"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.class.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.js constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "variable.language.this punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "keyword.other.this"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.basic entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.basic entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "text.html constant.character.entity"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.id.html"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.sass keyword.control"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.placeholder"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.property-list meta.property-value"
-                },
-                {
-                    "foreground": "#449DAB",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#914C54",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#6183BB",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#B4F9F8",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "punctuation.definition.group"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "constant.character.escape.backslash"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#2AC3DE",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.list_item.markdown"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.block"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.brace"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.block"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.use"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.class"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.switch-expression.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.switch-expression.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.section.switch-block.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.section.switch-block.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.group.shell"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.arguments"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.dictionary"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.array"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.section"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.embedded.block"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "meta.tag JSXNested"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "text.html"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "text.log"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.markdown markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown entity.name"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#61BDF2",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown entity.name"
-                },
-                {
-                    "foreground": "#61BDF2",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown entity.name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#6D91DE",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown entity.name"
-                },
-                {
-                    "foreground": "#6D91DE",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown entity.name"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown entity.name"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "italic",
-                    "token": "markup.italic punctuation"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold",
-                    "token": "markup.bold punctuation"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic punctuation"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline punctuation"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "markup.quote punctuation.definition.blockquote.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "markup.underline.link"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "constant.other.reference.link.markdown"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.other.link.description.title.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "markup.fenced_code.block.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "variable.language.fenced.markdown"
-                },
-                {
-                    "foreground": "#565F89",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#C0CEFC",
-                    "token": "markup.table"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#FFDB69",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#DB4B4B",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "entity.tag.apacheconf"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.env"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#1f2335",
+        "activityBar.border": "#1f2335",
+        "activityBar.foreground": "#7982a9",
+        "activityBar.inactiveForeground": "#41496b",
+        "activityBarBadge.background": "#3d59a1",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#7e83b233",
+        "badge.foreground": "#a9b1d6",
+        "breadcrumb.activeSelectionForeground": "#a9b1d6",
+        "breadcrumb.background": "#1f2335",
+        "breadcrumb.focusForeground": "#a9b1d6",
+        "breadcrumb.foreground": "#545c7e",
+        "breadcrumbPicker.background": "#1f2335",
+        "button.background": "#3d59a1dd",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#3d59a1aa",
+        "button.secondaryBackground": "#41496b",
+        "charts.blue": "#7aa2f7",
+        "charts.foreground": "#9aa5ce",
+        "charts.green": "#73daca",
+        "charts.lines": "#1f2335",
+        "charts.orange": "#ff9e64",
+        "charts.purple": "#9d7cd8",
+        "charts.red": "#f7768e",
+        "charts.yellow": "#e0af68",
+        "debugConsole.errorForeground": "#bb616b",
+        "debugConsole.infoForeground": "#7982a9",
+        "debugConsole.sourceForeground": "#7982a9",
+        "debugConsole.warningForeground": "#c49a5a",
+        "debugConsoleInputIcon.foreground": "#73daca",
+        "debugExceptionWidget.background": "#1b1e2e",
+        "debugExceptionWidget.border": "#963c47",
+        "debugIcon.breakpointDisabledForeground": "#545c7e",
+        "debugIcon.breakpointForeground": "#db4b4b",
+        "debugIcon.breakpointUnverifiedForeground": "#c24242",
+        "debugTokenExpression.boolean": "#ff9e64",
+        "debugTokenExpression.error": "#bb616b",
+        "debugTokenExpression.name": "#7dcfff",
+        "debugTokenExpression.number": "#ff9e64",
+        "debugTokenExpression.string": "#9ece6a",
+        "debugTokenExpression.value": "#9aa5ce",
+        "debugToolBar.background": "#1b1e2e",
+        "debugView.stateLabelBackground": "#1b1e2e",
+        "debugView.stateLabelForeground": "#7982a9",
+        "debugView.valueChangedHighlight": "#3d59a1cc",
+        "descriptionForeground": "#545c7e",
+        "diffEditor.diagonalFill": "#2c324a",
+        "diffEditor.insertedLineBackground": "#41a6b520",
+        "diffEditor.insertedTextBackground": "#41a6b520",
+        "diffEditor.removedLineBackground": "#db4b4b22",
+        "diffEditor.removedTextBackground": "#db4b4b22",
+        "diffEditorGutter.insertedLineBackground": "#41a6b525",
+        "diffEditorGutter.removedLineBackground": "#db4b4b22",
+        "diffEditorOverview.insertedForeground": "#41a6b525",
+        "diffEditorOverview.removedForeground": "#db4b4b22",
+        "dropdown.background": "#1b1e2e",
+        "dropdown.foreground": "#7982a9",
+        "dropdown.listBackground": "#1b1e2e",
+        "editor.background": "#24283b",
+        "editor.findMatchBackground": "#3d59a166",
+        "editor.findMatchBorder": "#ffdb69aa",
+        "editor.findMatchHighlightBackground": "#3d59a166",
+        "editor.findRangeHighlightBackground": "#6f7bb625",
+        "editor.focusedStackFrameHighlightBackground": "#73daca20",
+        "editor.foldBackground": "#181b294a",
+        "editor.foreground": "#a9b1d6",
+        "editor.inactiveSelectionBackground": "#6f7bb615",
+        "editor.lineHighlightBackground": "#292e42",
+        "editor.rangeHighlightBackground": "#6f7bb620",
+        "editor.selectionBackground": "#6f7bb640",
+        "editor.selectionHighlightBackground": "#6f7bb633",
+        "editor.stackFrameHighlightBackground": "#e2bd3a20",
+        "editor.wordHighlightBackground": "#6f7bb633",
+        "editor.wordHighlightStrongBackground": "#6f7bb644",
+        "editorBracketHighlight.foreground1": "#698cd6",
+        "editorBracketHighlight.foreground2": "#68b3de",
+        "editorBracketHighlight.foreground3": "#9a7ecc",
+        "editorBracketHighlight.foreground4": "#25aac2",
+        "editorBracketHighlight.foreground5": "#80a856",
+        "editorBracketHighlight.foreground6": "#cfa25f",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#db4b4b",
+        "editorBracketMatch.background": "#1f2335",
+        "editorBracketMatch.border": "#545c7e",
+        "editorBracketPairGuide.activeBackground1": "#698cd6",
+        "editorBracketPairGuide.activeBackground2": "#68b3de",
+        "editorBracketPairGuide.activeBackground3": "#9a7ecc",
+        "editorBracketPairGuide.activeBackground4": "#25aac2",
+        "editorBracketPairGuide.activeBackground5": "#80a856",
+        "editorBracketPairGuide.activeBackground6": "#cfa25f",
+        "editorCodeLens.foreground": "#565f89",
+        "editorCursor.foreground": "#c0caf5",
+        "editorError.foreground": "#db4b4b",
+        "editorGhostText.foreground": "#7582ba",
+        "editorGroup.border": "#1b1e2e",
+        "editorGroup.dropBackground": "#292e42",
+        "editorGroupHeader.border": "#1b1e2e",
+        "editorGroupHeader.noTabsBackground": "#1f2335",
+        "editorGroupHeader.tabsBackground": "#1f2335",
+        "editorGroupHeader.tabsBorder": "#1b1e2e",
+        "editorGutter.addedBackground": "#164846",
+        "editorGutter.deletedBackground": "#823c41",
+        "editorGutter.modifiedBackground": "#3d547a",
+        "editorHint.foreground": "#0da0ba",
+        "editorHoverWidget.background": "#1f2335",
+        "editorHoverWidget.border": "#1b1e2e",
+        "editorIndentGuide.activeBackground": "#3b4261",
+        "editorIndentGuide.background": "#292e42",
+        "editorInfo.foreground": "#0da0ba",
+        "editorLightBulb.foreground": "#e0af68",
+        "editorLightBulbAutoFix.foreground": "#e0af68",
+        "editorLineNumber.activeForeground": "#737aa2",
+        "editorLineNumber.foreground": "#3b4261",
+        "editorLink.activeForeground": "#a9b1d6",
+        "editorMarkerNavigation.background": "#1f2335",
+        "editorOverviewRuler.addedForeground": "#164846",
+        "editorOverviewRuler.border": "#1b1e2e",
+        "editorOverviewRuler.bracketMatchForeground": "#1b1e2e",
+        "editorOverviewRuler.deletedForeground": "#703438",
+        "editorOverviewRuler.errorForeground": "#db4b4b",
+        "editorOverviewRuler.findMatchForeground": "#a9b1d644",
+        "editorOverviewRuler.infoForeground": "#1abc9c",
+        "editorOverviewRuler.modifiedForeground": "#3d547a",
+        "editorOverviewRuler.rangeHighlightForeground": "#a9b1d644",
+        "editorOverviewRuler.selectionHighlightForeground": "#a9b1d622",
+        "editorOverviewRuler.warningForeground": "#e0af68",
+        "editorOverviewRuler.wordHighlightForeground": "#bb9af755",
+        "editorOverviewRuler.wordHighlightStrongForeground": "#bb9af766",
+        "editorPane.background": "#1f2335",
+        "editorRuler.foreground": "#1b1e2e",
+        "editorSuggestWidget.background": "#1f2335",
+        "editorSuggestWidget.border": "#1b1e2e",
+        "editorSuggestWidget.highlightForeground": "#668ac4",
+        "editorSuggestWidget.selectedBackground": "#282e44",
+        "editorWarning.foreground": "#e0af68",
+        "editorWhitespace.foreground": "#3b4261",
+        "editorWidget.background": "#1f2335",
+        "editorWidget.foreground": "#7982a9",
+        "editorWidget.resizeBorder": "#545c7e33",
+        "errorForeground": "#5a607d",
+        "extensionBadge.remoteBackground": "#3d59a1",
+        "extensionBadge.remoteForeground": "#ffffff",
+        "extensionButton.prominentBackground": "#3d59a1dd",
+        "extensionButton.prominentForeground": "#ffffff",
+        "extensionButton.prominentHoverBackground": "#3d59a1aa",
+        "focusBorder": "#545c7e33",
+        "foreground": "#7982a9",
+        "gitDecoration.addedResourceForeground": "#449dab",
+        "gitDecoration.conflictingResourceForeground": "#e0af68cc",
+        "gitDecoration.deletedResourceForeground": "#914c54",
+        "gitDecoration.ignoredResourceForeground": "#545c7e",
+        "gitDecoration.modifiedResourceForeground": "#6183bb",
+        "gitDecoration.renamedResourceForeground": "#449dab",
+        "gitDecoration.stageDeletedResourceForeground": "#914c54",
+        "gitDecoration.stageModifiedResourceForeground": "#6183bb",
+        "gitDecoration.untrackedResourceForeground": "#449dab",
+        "gitlens.gutterBackgroundColor": "#1f2335",
+        "gitlens.gutterForegroundColor": "#7982a9",
+        "gitlens.gutterUncommittedForegroundColor": "#7aa2f7",
+        "gitlens.trailingLineForegroundColor": "#7582ba",
+        "icon.foreground": "#7982a9",
+        "input.background": "#1b1e2e",
+        "input.border": "#282e44",
+        "input.foreground": "#a9b1d6",
+        "input.placeholderForeground": "#4a5272",
+        "inputOption.activeBackground": "#3d59a144",
+        "inputOption.activeForeground": "#c0caf5",
+        "inputValidation.errorBackground": "#85353e",
+        "inputValidation.errorBorder": "#963c47",
+        "inputValidation.errorForeground": "#bbc2e0",
+        "inputValidation.infoBackground": "#3d59a15c",
+        "inputValidation.infoBorder": "#3d59a1",
+        "inputValidation.infoForeground": "#bbc2e0",
+        "inputValidation.warningBackground": "#c2985b",
+        "inputValidation.warningBorder": "#e0af68",
+        "inputValidation.warningForeground": "#000000",
+        "list.activeSelectionBackground": "#2c324a",
+        "list.activeSelectionForeground": "#a9b1d6",
+        "list.deemphasizedForeground": "#7982a9",
+        "list.dropBackground": "#292e42",
+        "list.errorForeground": "#bb616b",
+        "list.focusBackground": "#292e42",
+        "list.focusForeground": "#a9b1d6",
+        "list.highlightForeground": "#668ac4",
+        "list.hoverBackground": "#1b1e2e",
+        "list.hoverForeground": "#a9b1d6",
+        "list.inactiveSelectionBackground": "#292e42",
+        "list.inactiveSelectionForeground": "#a9b1d6",
+        "list.invalidItemForeground": "#c97018",
+        "list.warningForeground": "#c49a5a",
+        "listFilterWidget.background": "#1b1e2e",
+        "listFilterWidget.noMatchesOutline": "#a6333f",
+        "listFilterWidget.outline": "#3d59a1",
+        "menu.background": "#1f2335",
+        "menu.border": "#1b1e2e",
+        "menu.foreground": "#7982a9",
+        "menu.selectionBackground": "#2f3549",
+        "menu.selectionForeground": "#c0caf5",
+        "menu.separatorBackground": "#1b1e2e",
+        "menubar.selectionBackground": "#2f3549",
+        "menubar.selectionBorder": "#1b1e2e",
+        "menubar.selectionForeground": "#c0caf5",
+        "merge.currentContentBackground": "#007a7544",
+        "merge.currentHeaderBackground": "#41a6b525",
+        "merge.incomingContentBackground": "#3d59a144",
+        "merge.incomingHeaderBackground": "#3d59a1aa",
+        "mergeEditor.change.background": "#41a6b525",
+        "mergeEditor.change.word.background": "#41a6b540",
+        "mergeEditor.conflict.handled.minimapOverViewRuler": "#449dab",
+        "mergeEditor.conflict.handledFocused.border": "#41a6b565",
+        "mergeEditor.conflict.handledUnfocused.border": "#41a6b525",
+        "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#e0af68",
+        "mergeEditor.conflict.unhandledFocused.border": "#e0af68d9",
+        "mergeEditor.conflict.unhandledUnfocused.border": "#e0af6888",
+        "minimapGutter.addedBackground": "#1c5957",
+        "minimapGutter.deletedBackground": "#944449",
+        "minimapGutter.modifiedBackground": "#3d547a",
+        "notebook.cellBorderColor": "#1b1e2e",
+        "notebook.cellEditorBackground": "#1f2335",
+        "notebook.cellStatusBarItemHoverBackground": "#2c324a",
+        "notebook.editorBackground": "#24283b",
+        "notebook.focusedCellBorder": "#29355a",
+        "notificationCenterHeader.background": "#1b1e2e",
+        "notificationLink.foreground": "#6183bb",
+        "notifications.background": "#1b1e2e",
+        "notificationsErrorIcon.foreground": "#bb616b",
+        "notificationsInfoIcon.foreground": "#0da0ba",
+        "notificationsWarningIcon.foreground": "#bba461",
+        "panel.background": "#1f2335",
+        "panel.border": "#1b1e2e",
+        "panelInput.border": "#1f2335",
+        "panelTitle.activeBorder": "#3d59a1",
+        "panelTitle.activeForeground": "#a9b1d6",
+        "panelTitle.inactiveForeground": "#7982a9",
+        "peekView.border": "#1b1e2e",
+        "peekViewEditor.background": "#1f2335",
+        "peekViewEditor.matchHighlightBackground": "#3d59a166",
+        "peekViewResult.background": "#1b1e2e",
+        "peekViewResult.fileForeground": "#7982a9",
+        "peekViewResult.lineForeground": "#a9b1d6",
+        "peekViewResult.matchHighlightBackground": "#3d59a166",
+        "peekViewResult.selectionBackground": "#3d59a133",
+        "peekViewResult.selectionForeground": "#a9b1d6",
+        "peekViewTitle.background": "#1b1e2e",
+        "peekViewTitleDescription.foreground": "#7982a9",
+        "peekViewTitleLabel.foreground": "#a9b1d6",
+        "pickerGroup.border": "#1b1e2e",
+        "pickerGroup.foreground": "#a9b1d6",
+        "progressBar.background": "#3d59a1",
+        "sash.hoverBorder": "#29355a",
+        "scrollbar.shadow": "#00000033",
+        "scrollbarSlider.activeBackground": "#9cacff22",
+        "scrollbarSlider.background": "#9cacff15",
+        "scrollbarSlider.hoverBackground": "#9cacff10",
+        "selection.background": "#6f7bb635",
+        "settings.headerForeground": "#6183bb",
+        "sideBar.background": "#1f2335",
+        "sideBar.border": "#1b1e2e",
+        "sideBar.dropBackground": "#292e42",
+        "sideBar.foreground": "#7982a9",
+        "sideBarSectionHeader.background": "#1f2335",
+        "sideBarSectionHeader.border": "#1b1e2e",
+        "sideBarSectionHeader.foreground": "#a9b1d6",
+        "sideBarTitle.foreground": "#7982a9",
+        "statusBar.background": "#1f2335",
+        "statusBar.border": "#1b1e2e",
+        "statusBar.debuggingBackground": "#1f2335",
+        "statusBar.debuggingForeground": "#7982a9",
+        "statusBar.foreground": "#7982a9",
+        "statusBar.noFolderBackground": "#1f2335",
+        "statusBarItem.activeBackground": "#1b1e2e",
+        "statusBarItem.hoverBackground": "#282e44",
+        "statusBarItem.prominentBackground": "#1b1e2e",
+        "statusBarItem.prominentHoverBackground": "#282e44",
+        "tab.activeBackground": "#1f2335",
+        "tab.activeBorder": "#3d59a1",
+        "tab.activeForeground": "#a9b1d6",
+        "tab.activeModifiedBorder": "#282d42",
+        "tab.border": "#1b1e2e",
+        "tab.hoverForeground": "#a9b1d6",
+        "tab.inactiveBackground": "#1f2335",
+        "tab.inactiveForeground": "#7982a9",
+        "tab.inactiveModifiedBorder": "#282d42",
+        "tab.lastPinnedBorder": "#2c3147",
+        "tab.unfocusedActiveBorder": "#3b4261",
+        "tab.unfocusedActiveForeground": "#a9b1d6",
+        "tab.unfocusedHoverForeground": "#a9b1d6",
+        "tab.unfocusedInactiveForeground": "#7982a9",
+        "terminal.ansiBlack": "#414868",
+        "terminal.ansiBlue": "#7aa2f7",
+        "terminal.ansiBrightBlack": "#414868",
+        "terminal.ansiBrightBlue": "#7aa2f7",
+        "terminal.ansiBrightCyan": "#7dcfff",
+        "terminal.ansiBrightGreen": "#73daca",
+        "terminal.ansiBrightMagenta": "#bb9af7",
+        "terminal.ansiBrightRed": "#f7768e",
+        "terminal.ansiBrightWhite": "#a9b1d6",
+        "terminal.ansiBrightYellow": "#e0af68",
+        "terminal.ansiCyan": "#7dcfff",
+        "terminal.ansiGreen": "#73daca",
+        "terminal.ansiMagenta": "#bb9af7",
+        "terminal.ansiRed": "#f7768e",
+        "terminal.ansiWhite": "#7982a9",
+        "terminal.ansiYellow": "#e0af68",
+        "terminal.background": "#1f2335",
+        "terminal.foreground": "#7982a9",
+        "terminal.selectionBackground": "#6f7bb640",
+        "textBlockQuote.background": "#1f2335",
+        "textCodeBlock.background": "#1f2335",
+        "textLink.activeForeground": "#7dcfff",
+        "textLink.foreground": "#668ac4",
+        "textPreformat.foreground": "#73daca",
+        "textSeparator.foreground": "#545c7e",
+        "titleBar.activeBackground": "#1f2335",
+        "titleBar.activeForeground": "#7982a9",
+        "titleBar.border": "#1b1e2e",
+        "titleBar.inactiveBackground": "#1f2335",
+        "titleBar.inactiveForeground": "#7982a9",
+        "toolbar.activeBackground": "#2c324a",
+        "toolbar.hoverBackground": "#2c324a",
+        "tree.indentGuidesStroke": "#2e344f",
+        "walkThrough.embeddedEditorBackground": "#1f2335",
+        "widget.shadow": "#ffffff00",
+        "window.activeBorder": "#0d0f17",
+        "window.inactiveBorder": "#0d0f17"
+    },
+    "rules": [
+        {
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.flow"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.return"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.modifier"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.block-scalar.literal"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.python"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "comment"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "comment.block.documentation"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#565F89",
+            "token": "comment.block.documentation punctuation"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "keyword.operator.assignment.jsdoc"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation variable"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation storage"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation keyword"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation support"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation markup"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "comment.block.documentation markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "meta.other.type.phpdoc.php keyword.other.type.php"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "meta.other.type.phpdoc.php support.other.namespace.php"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "keyword.other.phpdoc.php"
+        },
+        {
+            "foreground": "#6A75A8",
+            "token": "log.date"
+        },
+        {
+            "foreground": "#7582BA",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#7582BA",
+            "token": "comment.block.documentation storage.type"
+        },
+        {
+            "foreground": "#7582BA",
+            "token": "comment.block.documentation punctuation.definition.block.tag"
+        },
+        {
+            "foreground": "#7582BA",
+            "token": "comment.block.documentation entity.name.type.instance"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.other.caps"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "string"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "constant.other.symbol"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "constant.other.key"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "meta.attribute-selector"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "string constant.character"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "constant.other.color"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
+        },
+        {
+            "foreground": "#FF5370",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#FF5370",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.embedded.line.tag.smarty"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.section.tag.twig"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "keyword.control.smarty"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "keyword.control.twig"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.constant.handlebars keyword.control"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "keyword.operator.comparison.twig"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "keyword.blade"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "entity.name.function.blade"
+        },
+        {
+            "foreground": "#F7768E",
+            "fontStyle": "bold",
+            "token": "keyword.operator.spread"
+        },
+        {
+            "foreground": "#F7768E",
+            "fontStyle": "bold",
+            "token": "keyword.operator.rest"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.control.as"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator.bitwise.shift"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "expression.embbeded.vue punctuation.definition.tag"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "text.html.twig meta.tag.inline.any.html"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.tag.template.value.twig meta.function.arguments.twig"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.constant.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.support.type.property-name"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "text.html.vue-html meta.tag"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.attribute.directive"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.terminator.rule"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.entity"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other.template"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other.substitution"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "entity.name.operator"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.property-list punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.at-rule.mixin punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.at-rule.function variable.parameter.url"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.module"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.import"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.export"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.from"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.default"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.import keyword.other"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.important"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.other.DML"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type.function"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.bitwise"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.ternary"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.comparison"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.relational"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.or.regexp"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "entity.name.tag support.class.component"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag.custom entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#BA3C97",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other.php"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global.safer"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global.safer punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other.haskell"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "string constant.other.placeholder"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.parameter.handlebars"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.object"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.fstring"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.function-call meta.function-call.arguments"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.array.literal variable"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "entity.name.type.hcl"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.alias.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.unquoted.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.unquoted.alias.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.field.declaration.ts variable.object.property"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.block entity.name.label"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "variable.other.property"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.function-call variable.other.object.property"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "variable.other.object.property.cs"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.object.property"
+        },
+        {
+            "foreground": "#41A6B5",
+            "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.cpp meta.block variable.other"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.class-method.js entity.name.function.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "entity.name.method.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.function.constructor"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "keyword.other.special-method"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.function-call"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.function-call entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.definition.method entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.object-literal entity.name.function"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "meta.function.parameters punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "meta.function.parameter variable"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.type.php"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.escape"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.definition.variable variable.other.constant"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.definition.variable variable.other.readwrite"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "variable.declaration.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "variable.other.declaration"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "fontStyle": "",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "variable.other.readwrite.alias"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.orther.namespace.use.php"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "meta.use.php"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.type.sys-types"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.variable.dom"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.type.object.module"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "meta.import.qualifier"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "variable.other.constant.object"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.css support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.sass support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.scss support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.less support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.stylus support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.postcss support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.property-name.css"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.vendored.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.map.key"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "meta.definition.variable"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "entity.other.attribute-name.class"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "meta.at-rule.mixin.scss entity.name.function.scss"
+        },
+        {
+            "foreground": "#FC7B7B",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "entity.name.tag.css"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.name.tag.reference"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.property-list"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.property-list meta.at-rule.if"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.at-rule.return variable.parameter.url"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.property-list meta.at-rule.else"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.property-list meta.property-list"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.include entity.name.function.scss"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.include punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.extend keyword.control.at-rule.extend"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.media keyword.control.at-rule.media"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.function keyword.control.at-rule.function"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.property-list meta.at-rule.include"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "entity.name.module.js"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.import.parameter.js"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.class.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other punctuation.definition.variable"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.js constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "variable.language.this punctuation.definition.variable"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "keyword.other.this"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.basic entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.basic entity.other.attribute-name"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "text.html constant.character.entity"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.id.html"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.sass keyword.control"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.placeholder"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.property-list meta.property-value"
+        },
+        {
+            "foreground": "#449DAB",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#914C54",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#6183BB",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#B4F9F8",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "punctuation.definition.group"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "constant.character.escape.backslash"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#2AC3DE",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.list_item.markdown"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.block"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.brace"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.block"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.use"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.class"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.switch-expression.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.switch-expression.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.section.switch-block.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.section.switch-block.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.group.shell"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.arguments"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.dictionary"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.array"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.section"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.embedded.block"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "meta.tag JSXNested"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "text.html"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "text.log"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.markdown markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown entity.name"
+        },
+        {
+            "foreground": "#89DDFF",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#61BDF2",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown entity.name"
+        },
+        {
+            "foreground": "#61BDF2",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown entity.name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#6D91DE",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown entity.name"
+        },
+        {
+            "foreground": "#6D91DE",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown entity.name"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown entity.name"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "italic",
+            "token": "markup.italic punctuation"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold",
+            "token": "markup.bold punctuation"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic punctuation"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline punctuation"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "markup.quote punctuation.definition.blockquote.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "markup.underline.link"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "constant.other.reference.link.markdown"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.other.link.description.title.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "markup.fenced_code.block.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "variable.language.fenced.markdown"
+        },
+        {
+            "foreground": "#565F89",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#C0CEFC",
+            "token": "markup.table"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#FFDB69",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#DB4B4B",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "entity.tag.apacheconf"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.env"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/tokyo-night/tokyo-night-monaco.json
+++ b/themes/tokyo-night/tokyo-night-monaco.json
@@ -1,1680 +1,1676 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#16161e",
-                "activityBar.border": "#16161e",
-                "activityBar.foreground": "#787c99",
-                "activityBar.inactiveForeground": "#3b3e52",
-                "activityBarBadge.background": "#3d59a1",
-                "activityBarBadge.foreground": "#ffffff",
-                "badge.background": "#7e83b230",
-                "badge.foreground": "#acb0d0",
-                "breadcrumb.activeSelectionForeground": "#a9b1d6",
-                "breadcrumb.background": "#16161e",
-                "breadcrumb.focusForeground": "#a9b1d6",
-                "breadcrumb.foreground": "#515670",
-                "breadcrumbPicker.background": "#16161e",
-                "button.background": "#3d59a1dd",
-                "button.foreground": "#ffffff",
-                "button.hoverBackground": "#3d59a1aa",
-                "button.secondaryBackground": "#3b3e52",
-                "charts.blue": "#7aa2f7",
-                "charts.foreground": "#9aa5ce",
-                "charts.green": "#41a6b5",
-                "charts.lines": "#16161e",
-                "charts.orange": "#ff9e64",
-                "charts.purple": "#9d7cd8",
-                "charts.red": "#f7768e",
-                "charts.yellow": "#e0af68",
-                "debugConsole.errorForeground": "#bb616b",
-                "debugConsole.infoForeground": "#787c99",
-                "debugConsole.sourceForeground": "#787c99",
-                "debugConsole.warningForeground": "#c49a5a",
-                "debugConsoleInputIcon.foreground": "#73daca",
-                "debugExceptionWidget.background": "#101014",
-                "debugExceptionWidget.border": "#963c47",
-                "debugIcon.breakpointDisabledForeground": "#414761",
-                "debugIcon.breakpointForeground": "#db4b4b",
-                "debugIcon.breakpointUnverifiedForeground": "#c24242",
-                "debugTokenExpression.boolean": "#ff9e64",
-                "debugTokenExpression.error": "#bb616b",
-                "debugTokenExpression.name": "#7dcfff",
-                "debugTokenExpression.number": "#ff9e64",
-                "debugTokenExpression.string": "#9ece6a",
-                "debugTokenExpression.value": "#9aa5ce",
-                "debugToolBar.background": "#101014",
-                "debugView.stateLabelBackground": "#14141b",
-                "debugView.stateLabelForeground": "#787c99",
-                "debugView.valueChangedHighlight": "#3d59a1aa",
-                "descriptionForeground": "#515670",
-                "diffEditor.diagonalFill": "#292e42",
-                "diffEditor.insertedLineBackground": "#41a6b520",
-                "diffEditor.insertedTextBackground": "#41a6b520",
-                "diffEditor.removedLineBackground": "#db4b4b22",
-                "diffEditor.removedTextBackground": "#db4b4b22",
-                "diffEditorGutter.insertedLineBackground": "#41a6b525",
-                "diffEditorGutter.removedLineBackground": "#db4b4b22",
-                "diffEditorOverview.insertedForeground": "#41a6b525",
-                "diffEditorOverview.removedForeground": "#db4b4b22",
-                "dropdown.background": "#14141b",
-                "dropdown.foreground": "#787c99",
-                "dropdown.listBackground": "#14141b",
-                "editor.background": "#1a1b26",
-                "editor.findMatchBackground": "#3d59a166",
-                "editor.findMatchBorder": "#e0af68",
-                "editor.findMatchHighlightBackground": "#3d59a166",
-                "editor.findRangeHighlightBackground": "#515c7e33",
-                "editor.focusedStackFrameHighlightBackground": "#73daca20",
-                "editor.foldBackground": "#1111174a",
-                "editor.foreground": "#a9b1d6",
-                "editor.inactiveSelectionBackground": "#515c7e25",
-                "editor.lineHighlightBackground": "#1e202e",
-                "editor.rangeHighlightBackground": "#515c7e20",
-                "editor.selectionBackground": "#515c7e4d",
-                "editor.selectionHighlightBackground": "#515c7e44",
-                "editor.stackFrameHighlightBackground": "#e2bd3a20",
-                "editor.wordHighlightBackground": "#515c7e44",
-                "editor.wordHighlightStrongBackground": "#515c7e55",
-                "editorBracketHighlight.foreground1": "#698cd6",
-                "editorBracketHighlight.foreground2": "#68b3de",
-                "editorBracketHighlight.foreground3": "#9a7ecc",
-                "editorBracketHighlight.foreground4": "#25aac2",
-                "editorBracketHighlight.foreground5": "#80a856",
-                "editorBracketHighlight.foreground6": "#c49a5a",
-                "editorBracketHighlight.unexpectedBracket.foreground": "#db4b4b",
-                "editorBracketMatch.background": "#16161e",
-                "editorBracketMatch.border": "#42465d",
-                "editorBracketPairGuide.activeBackground1": "#698cd6",
-                "editorBracketPairGuide.activeBackground2": "#68b3de",
-                "editorBracketPairGuide.activeBackground3": "#9a7ecc",
-                "editorBracketPairGuide.activeBackground4": "#25aac2",
-                "editorBracketPairGuide.activeBackground5": "#80a856",
-                "editorBracketPairGuide.activeBackground6": "#c49a5a",
-                "editorCodeLens.foreground": "#484f70",
-                "editorCursor.foreground": "#c0caf5",
-                "editorError.foreground": "#db4b4b",
-                "editorGhostText.foreground": "#646e9c",
-                "editorGroup.border": "#101014",
-                "editorGroup.dropBackground": "#1e202e",
-                "editorGroupHeader.border": "#101014",
-                "editorGroupHeader.noTabsBackground": "#16161e",
-                "editorGroupHeader.tabsBackground": "#16161e",
-                "editorGroupHeader.tabsBorder": "#101014",
-                "editorGutter.addedBackground": "#164846",
-                "editorGutter.deletedBackground": "#823c41",
-                "editorGutter.modifiedBackground": "#394b70",
-                "editorHint.foreground": "#0da0ba",
-                "editorHoverWidget.background": "#16161e",
-                "editorHoverWidget.border": "#101014",
-                "editorIndentGuide.activeBackground": "#363b54",
-                "editorIndentGuide.background": "#1e202e",
-                "editorInfo.foreground": "#0da0ba",
-                "editorLightBulb.foreground": "#e0af68",
-                "editorLightBulbAutoFix.foreground": "#e0af68",
-                "editorLineNumber.activeForeground": "#737aa2",
-                "editorLineNumber.foreground": "#363b54",
-                "editorLink.activeForeground": "#acb0d0",
-                "editorMarkerNavigation.background": "#16161e",
-                "editorOverviewRuler.addedForeground": "#164846",
-                "editorOverviewRuler.border": "#101014",
-                "editorOverviewRuler.bracketMatchForeground": "#101014",
-                "editorOverviewRuler.deletedForeground": "#703438",
-                "editorOverviewRuler.errorForeground": "#db4b4b",
-                "editorOverviewRuler.findMatchForeground": "#a9b1d644",
-                "editorOverviewRuler.infoForeground": "#1abc9c",
-                "editorOverviewRuler.modifiedForeground": "#394b70",
-                "editorOverviewRuler.rangeHighlightForeground": "#a9b1d644",
-                "editorOverviewRuler.selectionHighlightForeground": "#a9b1d622",
-                "editorOverviewRuler.warningForeground": "#e0af68",
-                "editorOverviewRuler.wordHighlightForeground": "#bb9af755",
-                "editorOverviewRuler.wordHighlightStrongForeground": "#bb9af766",
-                "editorPane.background": "#16161e",
-                "editorRuler.foreground": "#101014",
-                "editorSuggestWidget.background": "#16161e",
-                "editorSuggestWidget.border": "#101014",
-                "editorSuggestWidget.highlightForeground": "#6183bb",
-                "editorSuggestWidget.selectedBackground": "#20222c",
-                "editorWarning.foreground": "#e0af68",
-                "editorWhitespace.foreground": "#363b54",
-                "editorWidget.background": "#16161e",
-                "editorWidget.foreground": "#787c99",
-                "editorWidget.resizeBorder": "#545c7e33",
-                "errorForeground": "#515670",
-                "extensionBadge.remoteBackground": "#3d59a1",
-                "extensionBadge.remoteForeground": "#ffffff",
-                "extensionButton.prominentBackground": "#3d59a1dd",
-                "extensionButton.prominentForeground": "#ffffff",
-                "extensionButton.prominentHoverBackground": "#3d59a1aa",
-                "focusBorder": "#545c7e33",
-                "foreground": "#787c99",
-                "gitDecoration.addedResourceForeground": "#449dab",
-                "gitDecoration.conflictingResourceForeground": "#e0af68cc",
-                "gitDecoration.deletedResourceForeground": "#914c54",
-                "gitDecoration.ignoredResourceForeground": "#515670",
-                "gitDecoration.modifiedResourceForeground": "#6183bb",
-                "gitDecoration.renamedResourceForeground": "#449dab",
-                "gitDecoration.stageDeletedResourceForeground": "#914c54",
-                "gitDecoration.stageModifiedResourceForeground": "#6183bb",
-                "gitDecoration.untrackedResourceForeground": "#449dab",
-                "gitlens.gutterBackgroundColor": "#16161e",
-                "gitlens.gutterForegroundColor": "#787c99",
-                "gitlens.gutterUncommittedForegroundColor": "#7aa2f7",
-                "gitlens.trailingLineForegroundColor": "#646e9c",
-                "icon.foreground": "#787c99",
-                "input.background": "#14141b",
-                "input.border": "#0f0f14",
-                "input.foreground": "#a9b1d6",
-                "input.placeholderForeground": "#787c998a",
-                "inputOption.activeBackground": "#3d59a144",
-                "inputOption.activeForeground": "#c0caf5",
-                "inputValidation.errorBackground": "#85353e",
-                "inputValidation.errorBorder": "#963c47",
-                "inputValidation.errorForeground": "#bbc2e0",
-                "inputValidation.infoBackground": "#3d59a15c",
-                "inputValidation.infoBorder": "#3d59a1",
-                "inputValidation.infoForeground": "#bbc2e0",
-                "inputValidation.warningBackground": "#c2985b",
-                "inputValidation.warningBorder": "#e0af68",
-                "inputValidation.warningForeground": "#000000",
-                "list.activeSelectionBackground": "#202330",
-                "list.activeSelectionForeground": "#a9b1d6",
-                "list.deemphasizedForeground": "#787c99",
-                "list.dropBackground": "#1e202e",
-                "list.errorForeground": "#bb616b",
-                "list.focusBackground": "#1c1d29",
-                "list.focusForeground": "#a9b1d6",
-                "list.highlightForeground": "#668ac4",
-                "list.hoverBackground": "#13131a",
-                "list.hoverForeground": "#a9b1d6",
-                "list.inactiveSelectionBackground": "#1c1d29",
-                "list.inactiveSelectionForeground": "#a9b1d6",
-                "list.invalidItemForeground": "#c97018",
-                "list.warningForeground": "#c49a5a",
-                "listFilterWidget.background": "#101014",
-                "listFilterWidget.noMatchesOutline": "#a6333f",
-                "listFilterWidget.outline": "#3d59a1",
-                "menu.background": "#16161e",
-                "menu.border": "#101014",
-                "menu.foreground": "#787c99",
-                "menu.selectionBackground": "#1e202e",
-                "menu.selectionForeground": "#a9b1d6",
-                "menu.separatorBackground": "#101014",
-                "menubar.selectionBackground": "#1e202e",
-                "menubar.selectionBorder": "#1b1e2e",
-                "menubar.selectionForeground": "#a9b1d6",
-                "merge.currentContentBackground": "#007a7544",
-                "merge.currentHeaderBackground": "#41a6b525",
-                "merge.incomingContentBackground": "#3d59a144",
-                "merge.incomingHeaderBackground": "#3d59a1aa",
-                "mergeEditor.change.background": "#41a6b525",
-                "mergeEditor.change.word.background": "#41a6b540",
-                "mergeEditor.conflict.handled.minimapOverViewRuler": "#449dab",
-                "mergeEditor.conflict.handledFocused.border": "#41a6b565",
-                "mergeEditor.conflict.handledUnfocused.border": "#41a6b525",
-                "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#e0af68",
-                "mergeEditor.conflict.unhandledFocused.border": "#e0af68b0",
-                "mergeEditor.conflict.unhandledUnfocused.border": "#e0af6888",
-                "minimapGutter.addedBackground": "#1c5957",
-                "minimapGutter.deletedBackground": "#944449",
-                "minimapGutter.modifiedBackground": "#425882",
-                "notebook.cellBorderColor": "#101014",
-                "notebook.cellEditorBackground": "#16161e",
-                "notebook.cellStatusBarItemHoverBackground": "#1c1d29",
-                "notebook.editorBackground": "#1a1b26",
-                "notebook.focusedCellBorder": "#29355a",
-                "notificationCenterHeader.background": "#101014",
-                "notificationLink.foreground": "#6183bb",
-                "notifications.background": "#101014",
-                "notificationsErrorIcon.foreground": "#bb616b",
-                "notificationsInfoIcon.foreground": "#0da0ba",
-                "notificationsWarningIcon.foreground": "#bba461",
-                "panel.background": "#16161e",
-                "panel.border": "#101014",
-                "panelInput.border": "#16161e",
-                "panelTitle.activeBorder": "#16161e",
-                "panelTitle.activeForeground": "#787c99",
-                "panelTitle.inactiveForeground": "#42465d",
-                "peekView.border": "#101014",
-                "peekViewEditor.background": "#16161e",
-                "peekViewEditor.matchHighlightBackground": "#3d59a166",
-                "peekViewResult.background": "#101014",
-                "peekViewResult.fileForeground": "#787c99",
-                "peekViewResult.lineForeground": "#a9b1d6",
-                "peekViewResult.matchHighlightBackground": "#3d59a166",
-                "peekViewResult.selectionBackground": "#3d59a133",
-                "peekViewResult.selectionForeground": "#a9b1d6",
-                "peekViewTitle.background": "#101014",
-                "peekViewTitleDescription.foreground": "#787c99",
-                "peekViewTitleLabel.foreground": "#a9b1d6",
-                "pickerGroup.border": "#101014",
-                "pickerGroup.foreground": "#a9b1d6",
-                "progressBar.background": "#3d59a1",
-                "sash.hoverBorder": "#29355a",
-                "scrollbar.shadow": "#00000033",
-                "scrollbarSlider.activeBackground": "#868bc422",
-                "scrollbarSlider.background": "#868bc415",
-                "scrollbarSlider.hoverBackground": "#868bc410",
-                "selection.background": "#515c7e40",
-                "settings.headerForeground": "#6183bb",
-                "sideBar.background": "#16161e",
-                "sideBar.border": "#101014",
-                "sideBar.dropBackground": "#1e202e",
-                "sideBar.foreground": "#787c99",
-                "sideBarSectionHeader.background": "#16161e",
-                "sideBarSectionHeader.border": "#101014",
-                "sideBarSectionHeader.foreground": "#a9b1d6",
-                "sideBarTitle.foreground": "#787c99",
-                "statusBar.background": "#16161e",
-                "statusBar.border": "#101014",
-                "statusBar.debuggingBackground": "#16161e",
-                "statusBar.debuggingForeground": "#787c99",
-                "statusBar.foreground": "#787c99",
-                "statusBar.noFolderBackground": "#16161e",
-                "statusBarItem.activeBackground": "#101014",
-                "statusBarItem.hoverBackground": "#20222c",
-                "statusBarItem.prominentBackground": "#101014",
-                "statusBarItem.prominentHoverBackground": "#20222c",
-                "tab.activeBackground": "#16161e",
-                "tab.activeBorder": "#3d59a1",
-                "tab.activeForeground": "#a9b1d6",
-                "tab.activeModifiedBorder": "#1a1b26",
-                "tab.border": "#101014",
-                "tab.hoverForeground": "#a9b1d6",
-                "tab.inactiveBackground": "#16161e",
-                "tab.inactiveForeground": "#787c99",
-                "tab.inactiveModifiedBorder": "#1f202e",
-                "tab.lastPinnedBorder": "#222333",
-                "tab.unfocusedActiveBorder": "#1f202e",
-                "tab.unfocusedActiveForeground": "#a9b1d6",
-                "tab.unfocusedHoverForeground": "#a9b1d6",
-                "tab.unfocusedInactiveForeground": "#787c99",
-                "terminal.ansiBlack": "#363b54",
-                "terminal.ansiBlue": "#7aa2f7",
-                "terminal.ansiBrightBlack": "#363b54",
-                "terminal.ansiBrightBlue": "#7aa2f7",
-                "terminal.ansiBrightCyan": "#7dcfff",
-                "terminal.ansiBrightGreen": "#41a6b5",
-                "terminal.ansiBrightMagenta": "#bb9af7",
-                "terminal.ansiBrightRed": "#f7768e",
-                "terminal.ansiBrightWhite": "#acb0d0",
-                "terminal.ansiBrightYellow": "#e0af68",
-                "terminal.ansiCyan": "#7dcfff",
-                "terminal.ansiGreen": "#41a6b5",
-                "terminal.ansiMagenta": "#bb9af7",
-                "terminal.ansiRed": "#f7768e",
-                "terminal.ansiWhite": "#787c99",
-                "terminal.ansiYellow": "#e0af68",
-                "terminal.background": "#16161e",
-                "terminal.foreground": "#787c99",
-                "terminal.selectionBackground": "#515c7e4d",
-                "textBlockQuote.background": "#16161e",
-                "textCodeBlock.background": "#16161e",
-                "textLink.activeForeground": "#7dcfff",
-                "textLink.foreground": "#6183bb",
-                "textPreformat.foreground": "#9699a8",
-                "textSeparator.foreground": "#363b54",
-                "titleBar.activeBackground": "#16161e",
-                "titleBar.activeForeground": "#787c99",
-                "titleBar.border": "#101014",
-                "titleBar.inactiveBackground": "#16161e",
-                "titleBar.inactiveForeground": "#787c99",
-                "toolbar.activeBackground": "#202330",
-                "toolbar.hoverBackground": "#202330",
-                "tree.indentGuidesStroke": "#2b2b3b",
-                "walkThrough.embeddedEditorBackground": "#16161e",
-                "widget.shadow": "#ffffff00",
-                "window.activeBorder": "#0d0f17",
-                "window.inactiveBorder": "#0d0f17"
-            },
-            "rules": [
-                {
-                    "fontStyle": "italic",
-                    "token": "comment"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.flow"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "keyword.control.return"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "storage.modifier"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.block-scalar.literal"
-                },
-                {
-                    "fontStyle": "",
-                    "token": "keyword.control.flow.python"
-                },
-                {
-                    "foreground": "#444B6A",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#444B6A",
-                    "token": "comment.block.documentation"
-                },
-                {
-                    "foreground": "#444B6A",
-                    "token": "punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#444B6A",
-                    "token": "comment.block.documentation punctuation"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "keyword.operator.assignment.jsdoc"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation variable"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation storage"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation keyword"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation support"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation markup"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "comment.block.documentation markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "meta.other.type.phpdoc.php keyword.other.type.php"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "meta.other.type.phpdoc.php support.other.namespace.php"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "keyword.other.phpdoc.php"
-                },
-                {
-                    "foreground": "#5A638C",
-                    "token": "log.date"
-                },
-                {
-                    "foreground": "#646E9C",
-                    "token": "meta.other.type.phpdoc.php support.class"
-                },
-                {
-                    "foreground": "#646E9C",
-                    "token": "comment.block.documentation storage.type"
-                },
-                {
-                    "foreground": "#646E9C",
-                    "token": "comment.block.documentation punctuation.definition.block.tag"
-                },
-                {
-                    "foreground": "#646E9C",
-                    "token": "comment.block.documentation entity.name.type.instance"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "support.constant"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "constant.other.caps"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "constant.other.symbol"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "constant.other.key"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "meta.attribute-selector"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "fontStyle": "",
-                    "token": "string constant.character"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "constant.other.color"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#FF5370",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#FF5370",
-                    "token": "invalid.illegal"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.var.expr storage.type"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.definition.template-expression"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.embedded.line.tag.smarty"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "punctuation.section.tag.twig"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "keyword.control.smarty"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "keyword.control.twig"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.constant.handlebars keyword.control"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "keyword.operator.comparison.twig"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "keyword.blade"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "entity.name.function.blade"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.spread"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.rest"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.control.as"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator.bitwise.shift"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "expression.embbeded.vue punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "text.html.twig meta.tag.inline.any.html"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.tag.template.value.twig meta.function.arguments.twig"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.directive.vue punctuation.separator.key-value.html"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.constant.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.string"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.support.type.property-name"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "text.html.vue-html meta.tag"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.attribute.directive"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.terminator.rule"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "punctuation.separator.inheritance.php"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other.template"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.other.substitution"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "entity.name.operator"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.property-list punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.at-rule.mixin punctuation.separator.key-value"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "meta.at-rule.function variable.parameter.url"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.module"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.import"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.export"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.from"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.control.default"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.import keyword.other"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.important"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "keyword.other.DML"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type.function"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.bitwise"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.ternary"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.comparison"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.relational"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.operator.or.regexp"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "entity.name.tag support.class.component"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag.custom entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
-                },
-                {
-                    "foreground": "#DE5971",
-                    "token": "meta.tag"
-                },
-                {
-                    "foreground": "#BA3C97",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other.php"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global.safer"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global.safer punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.other.global punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "string constant.other.placeholder"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.parameter.handlebars"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.object"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.fstring"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.function-call meta.function-call.arguments"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.array.literal variable"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "entity.name.type.hcl"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.alias.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.unquoted.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.unquoted.alias.graphql"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.field.declaration.ts variable.object.property"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.block entity.name.label"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "variable.other.property"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.variable.property"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "support.variable.property.dom"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "meta.function-call variable.other.object.property"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.object.property"
-                },
-                {
-                    "foreground": "#41A6B5",
-                    "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.cpp meta.block variable.other"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "support.other.variable"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.class-method.js entity.name.function.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "entity.name.method.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.function.constructor"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "keyword.other.special-method"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.function-call"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.function-call entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "variable.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.definition.method entity.name.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "meta.object-literal entity.name.function"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.parameter.function.language.special"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "variable.parameter"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "meta.function.parameters punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "meta.function.parameter variable"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.type.php"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "storage.type.php"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.escape"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.definition.variable variable.other.constant"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.definition.variable variable.other.readwrite"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "variable.declaration.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "variable.other.declaration"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "fontStyle": "",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "variable.other.readwrite.alias"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.orther.namespace.use.php"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "meta.use.php"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.other.namespace.php"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.type.sys-types"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.variable.dom"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.type.object.module"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "meta.import.qualifier"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "variable.other.constant.object"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "entity.name"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.css support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.sass support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.scss support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.less support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.stylus support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.postcss support.type.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.property-name.css"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.vendored.property-name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "support.type.map.key"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "meta.definition.variable"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "entity.other.attribute-name.class"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "meta.at-rule.mixin.scss entity.name.function.scss"
-                },
-                {
-                    "foreground": "#FC7B7B",
-                    "token": "entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "entity.name.tag.css"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.other.attribute-name.class punctuation.definition.entity"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "entity.name.tag.reference"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.property-list"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.property-list meta.at-rule.if"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.at-rule.return variable.parameter.url"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "meta.property-list meta.at-rule.else"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.property-list meta.property-list"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.include entity.name.function.scss"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.include punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.include keyword.control.at-rule.include"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.extend keyword.control.at-rule.extend"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.media keyword.control.at-rule.media"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "meta.at-rule.function keyword.control.at-rule.function"
-                },
-                {
-                    "foreground": "#9D7CD8",
-                    "token": "keyword.control punctuation.definition.keyword"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.property-list meta.at-rule.include"
-                },
-                {
-                    "foreground": "#FF9E64",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "entity.name.module.js"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.import.parameter.js"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other.class.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "variable.other punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.js constant.other.object.key.js string.unquoted.label.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "variable.language.this punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "keyword.other.this"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.basic entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.basic entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "text.html constant.character.entity"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.id.html"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.directive.vue entity.other.attribute-name.html"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.sass keyword.control"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.pseudo-class"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.pseudo-element"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "entity.other.attribute-name.placeholder"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "meta.property-list meta.property-value"
-                },
-                {
-                    "foreground": "#449DAB",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#914C54",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#6183BB",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#B4F9F8",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "punctuation.definition.group"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "constant.character.escape.backslash"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "tag.decorator.js entity.name.tag.js"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "tag.decorator.js punctuation.definition.tag.js"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#7DCFFF",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#E0AF68",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#9ECE6A",
-                    "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.list_item.markdown"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.block"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "meta.brace"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.block"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.use"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.class"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.switch-expression.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.switch-expression.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.section.switch-block.begin.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.section.switch-block.end.bracket"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.group.shell"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.parameters"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.arguments"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.dictionary"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.definition.array"
-                },
-                {
-                    "foreground": "#9ABDF5",
-                    "token": "punctuation.section"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "token": "meta.embedded.block"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "meta.tag JSXNested"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "meta.jsx.children"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "text.html"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "token": "text.log"
-                },
-                {
-                    "foreground": "#BB9AF7",
-                    "token": "text.html.markdown markup.inline.raw.markdown"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown entity.name"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "fontStyle": "bold",
-                    "token": "heading.1.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#61BDF2",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown entity.name"
-                },
-                {
-                    "foreground": "#61BDF2",
-                    "fontStyle": "bold",
-                    "token": "heading.2.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown entity.name"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "fontStyle": "bold",
-                    "token": "heading.3.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#6D91DE",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown entity.name"
-                },
-                {
-                    "foreground": "#6D91DE",
-                    "fontStyle": "bold",
-                    "token": "heading.4.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown entity.name"
-                },
-                {
-                    "foreground": "#9AA5CE",
-                    "fontStyle": "bold",
-                    "token": "heading.5.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown entity.name"
-                },
-                {
-                    "foreground": "#747CA1",
-                    "fontStyle": "bold",
-                    "token": "heading.6.markdown punctuation.definition.heading.markdown"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "italic",
-                    "token": "markup.italic punctuation"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold",
-                    "token": "markup.bold punctuation"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic"
-                },
-                {
-                    "foreground": "#C0CAF5",
-                    "fontStyle": "bold italic",
-                    "token": "markup.bold markup.italic punctuation"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline punctuation"
-                },
-                {
-                    "foreground": "#4E5579",
-                    "token": "markup.quote punctuation.definition.blockquote.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.quote"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.other.link"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "markup.underline.link"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "constant.other.reference.link.markdown"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "string.other.link.description.title.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "markup.fenced_code.block.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "markup.inline.raw.string.markdown"
-                },
-                {
-                    "foreground": "#89DDFF",
-                    "token": "variable.language.fenced.markdown"
-                },
-                {
-                    "foreground": "#444B6A",
-                    "fontStyle": "bold",
-                    "token": "meta.separator"
-                },
-                {
-                    "foreground": "#C0CEFC",
-                    "token": "markup.table"
-                },
-                {
-                    "foreground": "#0DB9D7",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#FFDB69",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#DB4B4B",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                },
-                {
-                    "foreground": "#F7768E",
-                    "token": "entity.tag.apacheconf"
-                },
-                {
-                    "foreground": "#73DACA",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#7AA2F7",
-                    "token": "source.env"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#16161e",
+        "activityBar.border": "#16161e",
+        "activityBar.foreground": "#787c99",
+        "activityBar.inactiveForeground": "#3b3e52",
+        "activityBarBadge.background": "#3d59a1",
+        "activityBarBadge.foreground": "#ffffff",
+        "badge.background": "#7e83b230",
+        "badge.foreground": "#acb0d0",
+        "breadcrumb.activeSelectionForeground": "#a9b1d6",
+        "breadcrumb.background": "#16161e",
+        "breadcrumb.focusForeground": "#a9b1d6",
+        "breadcrumb.foreground": "#515670",
+        "breadcrumbPicker.background": "#16161e",
+        "button.background": "#3d59a1dd",
+        "button.foreground": "#ffffff",
+        "button.hoverBackground": "#3d59a1aa",
+        "button.secondaryBackground": "#3b3e52",
+        "charts.blue": "#7aa2f7",
+        "charts.foreground": "#9aa5ce",
+        "charts.green": "#41a6b5",
+        "charts.lines": "#16161e",
+        "charts.orange": "#ff9e64",
+        "charts.purple": "#9d7cd8",
+        "charts.red": "#f7768e",
+        "charts.yellow": "#e0af68",
+        "debugConsole.errorForeground": "#bb616b",
+        "debugConsole.infoForeground": "#787c99",
+        "debugConsole.sourceForeground": "#787c99",
+        "debugConsole.warningForeground": "#c49a5a",
+        "debugConsoleInputIcon.foreground": "#73daca",
+        "debugExceptionWidget.background": "#101014",
+        "debugExceptionWidget.border": "#963c47",
+        "debugIcon.breakpointDisabledForeground": "#414761",
+        "debugIcon.breakpointForeground": "#db4b4b",
+        "debugIcon.breakpointUnverifiedForeground": "#c24242",
+        "debugTokenExpression.boolean": "#ff9e64",
+        "debugTokenExpression.error": "#bb616b",
+        "debugTokenExpression.name": "#7dcfff",
+        "debugTokenExpression.number": "#ff9e64",
+        "debugTokenExpression.string": "#9ece6a",
+        "debugTokenExpression.value": "#9aa5ce",
+        "debugToolBar.background": "#101014",
+        "debugView.stateLabelBackground": "#14141b",
+        "debugView.stateLabelForeground": "#787c99",
+        "debugView.valueChangedHighlight": "#3d59a1aa",
+        "descriptionForeground": "#515670",
+        "diffEditor.diagonalFill": "#292e42",
+        "diffEditor.insertedLineBackground": "#41a6b520",
+        "diffEditor.insertedTextBackground": "#41a6b520",
+        "diffEditor.removedLineBackground": "#db4b4b22",
+        "diffEditor.removedTextBackground": "#db4b4b22",
+        "diffEditorGutter.insertedLineBackground": "#41a6b525",
+        "diffEditorGutter.removedLineBackground": "#db4b4b22",
+        "diffEditorOverview.insertedForeground": "#41a6b525",
+        "diffEditorOverview.removedForeground": "#db4b4b22",
+        "dropdown.background": "#14141b",
+        "dropdown.foreground": "#787c99",
+        "dropdown.listBackground": "#14141b",
+        "editor.background": "#1a1b26",
+        "editor.findMatchBackground": "#3d59a166",
+        "editor.findMatchBorder": "#e0af68",
+        "editor.findMatchHighlightBackground": "#3d59a166",
+        "editor.findRangeHighlightBackground": "#515c7e33",
+        "editor.focusedStackFrameHighlightBackground": "#73daca20",
+        "editor.foldBackground": "#1111174a",
+        "editor.foreground": "#a9b1d6",
+        "editor.inactiveSelectionBackground": "#515c7e25",
+        "editor.lineHighlightBackground": "#1e202e",
+        "editor.rangeHighlightBackground": "#515c7e20",
+        "editor.selectionBackground": "#515c7e4d",
+        "editor.selectionHighlightBackground": "#515c7e44",
+        "editor.stackFrameHighlightBackground": "#e2bd3a20",
+        "editor.wordHighlightBackground": "#515c7e44",
+        "editor.wordHighlightStrongBackground": "#515c7e55",
+        "editorBracketHighlight.foreground1": "#698cd6",
+        "editorBracketHighlight.foreground2": "#68b3de",
+        "editorBracketHighlight.foreground3": "#9a7ecc",
+        "editorBracketHighlight.foreground4": "#25aac2",
+        "editorBracketHighlight.foreground5": "#80a856",
+        "editorBracketHighlight.foreground6": "#c49a5a",
+        "editorBracketHighlight.unexpectedBracket.foreground": "#db4b4b",
+        "editorBracketMatch.background": "#16161e",
+        "editorBracketMatch.border": "#42465d",
+        "editorBracketPairGuide.activeBackground1": "#698cd6",
+        "editorBracketPairGuide.activeBackground2": "#68b3de",
+        "editorBracketPairGuide.activeBackground3": "#9a7ecc",
+        "editorBracketPairGuide.activeBackground4": "#25aac2",
+        "editorBracketPairGuide.activeBackground5": "#80a856",
+        "editorBracketPairGuide.activeBackground6": "#c49a5a",
+        "editorCodeLens.foreground": "#484f70",
+        "editorCursor.foreground": "#c0caf5",
+        "editorError.foreground": "#db4b4b",
+        "editorGhostText.foreground": "#646e9c",
+        "editorGroup.border": "#101014",
+        "editorGroup.dropBackground": "#1e202e",
+        "editorGroupHeader.border": "#101014",
+        "editorGroupHeader.noTabsBackground": "#16161e",
+        "editorGroupHeader.tabsBackground": "#16161e",
+        "editorGroupHeader.tabsBorder": "#101014",
+        "editorGutter.addedBackground": "#164846",
+        "editorGutter.deletedBackground": "#823c41",
+        "editorGutter.modifiedBackground": "#394b70",
+        "editorHint.foreground": "#0da0ba",
+        "editorHoverWidget.background": "#16161e",
+        "editorHoverWidget.border": "#101014",
+        "editorIndentGuide.activeBackground": "#363b54",
+        "editorIndentGuide.background": "#1e202e",
+        "editorInfo.foreground": "#0da0ba",
+        "editorLightBulb.foreground": "#e0af68",
+        "editorLightBulbAutoFix.foreground": "#e0af68",
+        "editorLineNumber.activeForeground": "#737aa2",
+        "editorLineNumber.foreground": "#363b54",
+        "editorLink.activeForeground": "#acb0d0",
+        "editorMarkerNavigation.background": "#16161e",
+        "editorOverviewRuler.addedForeground": "#164846",
+        "editorOverviewRuler.border": "#101014",
+        "editorOverviewRuler.bracketMatchForeground": "#101014",
+        "editorOverviewRuler.deletedForeground": "#703438",
+        "editorOverviewRuler.errorForeground": "#db4b4b",
+        "editorOverviewRuler.findMatchForeground": "#a9b1d644",
+        "editorOverviewRuler.infoForeground": "#1abc9c",
+        "editorOverviewRuler.modifiedForeground": "#394b70",
+        "editorOverviewRuler.rangeHighlightForeground": "#a9b1d644",
+        "editorOverviewRuler.selectionHighlightForeground": "#a9b1d622",
+        "editorOverviewRuler.warningForeground": "#e0af68",
+        "editorOverviewRuler.wordHighlightForeground": "#bb9af755",
+        "editorOverviewRuler.wordHighlightStrongForeground": "#bb9af766",
+        "editorPane.background": "#16161e",
+        "editorRuler.foreground": "#101014",
+        "editorSuggestWidget.background": "#16161e",
+        "editorSuggestWidget.border": "#101014",
+        "editorSuggestWidget.highlightForeground": "#6183bb",
+        "editorSuggestWidget.selectedBackground": "#20222c",
+        "editorWarning.foreground": "#e0af68",
+        "editorWhitespace.foreground": "#363b54",
+        "editorWidget.background": "#16161e",
+        "editorWidget.foreground": "#787c99",
+        "editorWidget.resizeBorder": "#545c7e33",
+        "errorForeground": "#515670",
+        "extensionBadge.remoteBackground": "#3d59a1",
+        "extensionBadge.remoteForeground": "#ffffff",
+        "extensionButton.prominentBackground": "#3d59a1dd",
+        "extensionButton.prominentForeground": "#ffffff",
+        "extensionButton.prominentHoverBackground": "#3d59a1aa",
+        "focusBorder": "#545c7e33",
+        "foreground": "#787c99",
+        "gitDecoration.addedResourceForeground": "#449dab",
+        "gitDecoration.conflictingResourceForeground": "#e0af68cc",
+        "gitDecoration.deletedResourceForeground": "#914c54",
+        "gitDecoration.ignoredResourceForeground": "#515670",
+        "gitDecoration.modifiedResourceForeground": "#6183bb",
+        "gitDecoration.renamedResourceForeground": "#449dab",
+        "gitDecoration.stageDeletedResourceForeground": "#914c54",
+        "gitDecoration.stageModifiedResourceForeground": "#6183bb",
+        "gitDecoration.untrackedResourceForeground": "#449dab",
+        "gitlens.gutterBackgroundColor": "#16161e",
+        "gitlens.gutterForegroundColor": "#787c99",
+        "gitlens.gutterUncommittedForegroundColor": "#7aa2f7",
+        "gitlens.trailingLineForegroundColor": "#646e9c",
+        "icon.foreground": "#787c99",
+        "input.background": "#14141b",
+        "input.border": "#0f0f14",
+        "input.foreground": "#a9b1d6",
+        "input.placeholderForeground": "#787c998a",
+        "inputOption.activeBackground": "#3d59a144",
+        "inputOption.activeForeground": "#c0caf5",
+        "inputValidation.errorBackground": "#85353e",
+        "inputValidation.errorBorder": "#963c47",
+        "inputValidation.errorForeground": "#bbc2e0",
+        "inputValidation.infoBackground": "#3d59a15c",
+        "inputValidation.infoBorder": "#3d59a1",
+        "inputValidation.infoForeground": "#bbc2e0",
+        "inputValidation.warningBackground": "#c2985b",
+        "inputValidation.warningBorder": "#e0af68",
+        "inputValidation.warningForeground": "#000000",
+        "list.activeSelectionBackground": "#202330",
+        "list.activeSelectionForeground": "#a9b1d6",
+        "list.deemphasizedForeground": "#787c99",
+        "list.dropBackground": "#1e202e",
+        "list.errorForeground": "#bb616b",
+        "list.focusBackground": "#1c1d29",
+        "list.focusForeground": "#a9b1d6",
+        "list.highlightForeground": "#668ac4",
+        "list.hoverBackground": "#13131a",
+        "list.hoverForeground": "#a9b1d6",
+        "list.inactiveSelectionBackground": "#1c1d29",
+        "list.inactiveSelectionForeground": "#a9b1d6",
+        "list.invalidItemForeground": "#c97018",
+        "list.warningForeground": "#c49a5a",
+        "listFilterWidget.background": "#101014",
+        "listFilterWidget.noMatchesOutline": "#a6333f",
+        "listFilterWidget.outline": "#3d59a1",
+        "menu.background": "#16161e",
+        "menu.border": "#101014",
+        "menu.foreground": "#787c99",
+        "menu.selectionBackground": "#1e202e",
+        "menu.selectionForeground": "#a9b1d6",
+        "menu.separatorBackground": "#101014",
+        "menubar.selectionBackground": "#1e202e",
+        "menubar.selectionBorder": "#1b1e2e",
+        "menubar.selectionForeground": "#a9b1d6",
+        "merge.currentContentBackground": "#007a7544",
+        "merge.currentHeaderBackground": "#41a6b525",
+        "merge.incomingContentBackground": "#3d59a144",
+        "merge.incomingHeaderBackground": "#3d59a1aa",
+        "mergeEditor.change.background": "#41a6b525",
+        "mergeEditor.change.word.background": "#41a6b540",
+        "mergeEditor.conflict.handled.minimapOverViewRuler": "#449dab",
+        "mergeEditor.conflict.handledFocused.border": "#41a6b565",
+        "mergeEditor.conflict.handledUnfocused.border": "#41a6b525",
+        "mergeEditor.conflict.unhandled.minimapOverViewRuler": "#e0af68",
+        "mergeEditor.conflict.unhandledFocused.border": "#e0af68b0",
+        "mergeEditor.conflict.unhandledUnfocused.border": "#e0af6888",
+        "minimapGutter.addedBackground": "#1c5957",
+        "minimapGutter.deletedBackground": "#944449",
+        "minimapGutter.modifiedBackground": "#425882",
+        "notebook.cellBorderColor": "#101014",
+        "notebook.cellEditorBackground": "#16161e",
+        "notebook.cellStatusBarItemHoverBackground": "#1c1d29",
+        "notebook.editorBackground": "#1a1b26",
+        "notebook.focusedCellBorder": "#29355a",
+        "notificationCenterHeader.background": "#101014",
+        "notificationLink.foreground": "#6183bb",
+        "notifications.background": "#101014",
+        "notificationsErrorIcon.foreground": "#bb616b",
+        "notificationsInfoIcon.foreground": "#0da0ba",
+        "notificationsWarningIcon.foreground": "#bba461",
+        "panel.background": "#16161e",
+        "panel.border": "#101014",
+        "panelInput.border": "#16161e",
+        "panelTitle.activeBorder": "#16161e",
+        "panelTitle.activeForeground": "#787c99",
+        "panelTitle.inactiveForeground": "#42465d",
+        "peekView.border": "#101014",
+        "peekViewEditor.background": "#16161e",
+        "peekViewEditor.matchHighlightBackground": "#3d59a166",
+        "peekViewResult.background": "#101014",
+        "peekViewResult.fileForeground": "#787c99",
+        "peekViewResult.lineForeground": "#a9b1d6",
+        "peekViewResult.matchHighlightBackground": "#3d59a166",
+        "peekViewResult.selectionBackground": "#3d59a133",
+        "peekViewResult.selectionForeground": "#a9b1d6",
+        "peekViewTitle.background": "#101014",
+        "peekViewTitleDescription.foreground": "#787c99",
+        "peekViewTitleLabel.foreground": "#a9b1d6",
+        "pickerGroup.border": "#101014",
+        "pickerGroup.foreground": "#a9b1d6",
+        "progressBar.background": "#3d59a1",
+        "sash.hoverBorder": "#29355a",
+        "scrollbar.shadow": "#00000033",
+        "scrollbarSlider.activeBackground": "#868bc422",
+        "scrollbarSlider.background": "#868bc415",
+        "scrollbarSlider.hoverBackground": "#868bc410",
+        "selection.background": "#515c7e40",
+        "settings.headerForeground": "#6183bb",
+        "sideBar.background": "#16161e",
+        "sideBar.border": "#101014",
+        "sideBar.dropBackground": "#1e202e",
+        "sideBar.foreground": "#787c99",
+        "sideBarSectionHeader.background": "#16161e",
+        "sideBarSectionHeader.border": "#101014",
+        "sideBarSectionHeader.foreground": "#a9b1d6",
+        "sideBarTitle.foreground": "#787c99",
+        "statusBar.background": "#16161e",
+        "statusBar.border": "#101014",
+        "statusBar.debuggingBackground": "#16161e",
+        "statusBar.debuggingForeground": "#787c99",
+        "statusBar.foreground": "#787c99",
+        "statusBar.noFolderBackground": "#16161e",
+        "statusBarItem.activeBackground": "#101014",
+        "statusBarItem.hoverBackground": "#20222c",
+        "statusBarItem.prominentBackground": "#101014",
+        "statusBarItem.prominentHoverBackground": "#20222c",
+        "tab.activeBackground": "#16161e",
+        "tab.activeBorder": "#3d59a1",
+        "tab.activeForeground": "#a9b1d6",
+        "tab.activeModifiedBorder": "#1a1b26",
+        "tab.border": "#101014",
+        "tab.hoverForeground": "#a9b1d6",
+        "tab.inactiveBackground": "#16161e",
+        "tab.inactiveForeground": "#787c99",
+        "tab.inactiveModifiedBorder": "#1f202e",
+        "tab.lastPinnedBorder": "#222333",
+        "tab.unfocusedActiveBorder": "#1f202e",
+        "tab.unfocusedActiveForeground": "#a9b1d6",
+        "tab.unfocusedHoverForeground": "#a9b1d6",
+        "tab.unfocusedInactiveForeground": "#787c99",
+        "terminal.ansiBlack": "#363b54",
+        "terminal.ansiBlue": "#7aa2f7",
+        "terminal.ansiBrightBlack": "#363b54",
+        "terminal.ansiBrightBlue": "#7aa2f7",
+        "terminal.ansiBrightCyan": "#7dcfff",
+        "terminal.ansiBrightGreen": "#41a6b5",
+        "terminal.ansiBrightMagenta": "#bb9af7",
+        "terminal.ansiBrightRed": "#f7768e",
+        "terminal.ansiBrightWhite": "#acb0d0",
+        "terminal.ansiBrightYellow": "#e0af68",
+        "terminal.ansiCyan": "#7dcfff",
+        "terminal.ansiGreen": "#41a6b5",
+        "terminal.ansiMagenta": "#bb9af7",
+        "terminal.ansiRed": "#f7768e",
+        "terminal.ansiWhite": "#787c99",
+        "terminal.ansiYellow": "#e0af68",
+        "terminal.background": "#16161e",
+        "terminal.foreground": "#787c99",
+        "terminal.selectionBackground": "#515c7e4d",
+        "textBlockQuote.background": "#16161e",
+        "textCodeBlock.background": "#16161e",
+        "textLink.activeForeground": "#7dcfff",
+        "textLink.foreground": "#6183bb",
+        "textPreformat.foreground": "#9699a8",
+        "textSeparator.foreground": "#363b54",
+        "titleBar.activeBackground": "#16161e",
+        "titleBar.activeForeground": "#787c99",
+        "titleBar.border": "#101014",
+        "titleBar.inactiveBackground": "#16161e",
+        "titleBar.inactiveForeground": "#787c99",
+        "toolbar.activeBackground": "#202330",
+        "toolbar.hoverBackground": "#202330",
+        "tree.indentGuidesStroke": "#2b2b3b",
+        "walkThrough.embeddedEditorBackground": "#16161e",
+        "widget.shadow": "#ffffff00",
+        "window.activeBorder": "#0d0f17",
+        "window.inactiveBorder": "#0d0f17"
+    },
+    "rules": [
+        {
+            "fontStyle": "italic",
+            "token": "comment"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.flow"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "keyword.control.return"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "storage.modifier"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.block-scalar.literal"
+        },
+        {
+            "fontStyle": "",
+            "token": "keyword.control.flow.python"
+        },
+        {
+            "foreground": "#444B6A",
+            "token": "comment"
+        },
+        {
+            "foreground": "#444B6A",
+            "token": "comment.block.documentation"
+        },
+        {
+            "foreground": "#444B6A",
+            "token": "punctuation.definition.comment"
+        },
+        {
+            "foreground": "#444B6A",
+            "token": "comment.block.documentation punctuation"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "keyword.operator.assignment.jsdoc"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation variable"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation storage"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation keyword"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation support"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation markup"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "comment.block.documentation markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "meta.other.type.phpdoc.php keyword.other.type.php"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "meta.other.type.phpdoc.php support.other.namespace.php"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "meta.other.type.phpdoc.php punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "keyword.other.phpdoc.php"
+        },
+        {
+            "foreground": "#5A638C",
+            "token": "log.date"
+        },
+        {
+            "foreground": "#646E9C",
+            "token": "meta.other.type.phpdoc.php support.class"
+        },
+        {
+            "foreground": "#646E9C",
+            "token": "comment.block.documentation storage.type"
+        },
+        {
+            "foreground": "#646E9C",
+            "token": "comment.block.documentation punctuation.definition.block.tag"
+        },
+        {
+            "foreground": "#646E9C",
+            "token": "comment.block.documentation entity.name.type.instance"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "punctuation.definition.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "support.constant"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "constant.other.caps"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "string"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "constant.other.symbol"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "constant.other.key"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "meta.attribute-selector"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "fontStyle": "",
+            "token": "string constant.character"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "constant.other.color"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "constant.other.color.rgb-value.hex punctuation.definition.constant"
+        },
+        {
+            "foreground": "#FF5370",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#FF5370",
+            "token": "invalid.illegal"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "invalid.deprecated"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.var.expr storage.type"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.definition.template-expression"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.embedded.line.tag.smarty"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "punctuation.section.tag.twig"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "keyword.control.smarty"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "keyword.control.twig"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.constant.handlebars keyword.control"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "keyword.operator.comparison.twig"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "keyword.blade"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "entity.name.function.blade"
+        },
+        {
+            "foreground": "#F7768E",
+            "fontStyle": "bold",
+            "token": "keyword.operator.spread"
+        },
+        {
+            "foreground": "#F7768E",
+            "fontStyle": "bold",
+            "token": "keyword.operator.rest"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.control.as"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator.bitwise.shift"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "expression.embbeded.vue punctuation.definition.tag"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "text.html.twig meta.tag.inline.any.html"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.tag.template.value.twig meta.function.arguments.twig"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.directive.vue punctuation.separator.key-value.html"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.constant.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.string"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.support.type.property-name"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "text.html.vue-html meta.tag"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.attribute.directive"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.terminator.rule"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.definition.entity"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "punctuation.separator.inheritance.php"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other.template"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.other.substitution"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "entity.name.operator"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.property-list punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.at-rule.mixin punctuation.separator.key-value"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "meta.at-rule.function variable.parameter.url"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.module"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.import"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.export"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.from"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.control.default"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.import keyword.other"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.important"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "keyword.other.DML"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type.function"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.bitwise"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.ternary"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.comparison"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.relational"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.operator.or.regexp"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "entity.name.tag support.class.component"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag.custom entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag.other.unrecognized.html.derivative entity.name.tag"
+        },
+        {
+            "foreground": "#DE5971",
+            "token": "meta.tag"
+        },
+        {
+            "foreground": "#BA3C97",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other.php"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global.safer"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global.safer punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.other.global punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "string constant.other.placeholder"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.parameter.handlebars"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.object"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.fstring"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.function-call meta.function-call.arguments"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.array.literal variable"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "entity.name.type.hcl"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.alias.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.unquoted.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.unquoted.alias.graphql"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.field.declaration.ts variable.object.property"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.block entity.name.label"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "variable.other.property"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.variable.property"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "support.variable.property.dom"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "meta.function-call variable.other.object.property"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.object.property"
+        },
+        {
+            "foreground": "#41A6B5",
+            "token": "meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.cpp meta.block variable.other"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "support.other.variable"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.class-method.js entity.name.function.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "entity.name.method.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.function.constructor"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "keyword.other.special-method"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.function-call"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.function-call entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "variable.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.definition.method entity.name.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "meta.object-literal entity.name.function"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.parameter.function.language.special"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "variable.parameter"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "meta.function.parameters punctuation.definition.variable"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "meta.function.parameter variable"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.type.php"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "storage.type.php"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.escape"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.definition.variable variable.other.constant"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.definition.variable variable.other.readwrite"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "variable.declaration.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.mapping.key.hcl variable.other.readwrite.hcl"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "variable.other.declaration"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "fontStyle": "",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "variable.other.readwrite.alias"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.orther.namespace.use.php"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "meta.use.php"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.other.namespace.php"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.type.sys-types"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.variable.dom"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.type.object.module"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "meta.import.qualifier"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "variable.other.constant.object"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "entity.name"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.css support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.sass support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.scss support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.less support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.stylus support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.postcss support.type.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.property-name.css"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.vendored.property-name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "support.type.map.key"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "meta.definition.variable"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "entity.other.attribute-name.class"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "meta.at-rule.mixin.scss entity.name.function.scss"
+        },
+        {
+            "foreground": "#FC7B7B",
+            "token": "entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "entity.name.tag.css"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.pseudo-class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.pseudo-element punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.other.attribute-name.class punctuation.definition.entity"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "entity.name.tag.reference"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.property-list"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.property-list meta.at-rule.if"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.at-rule.return variable.parameter.url"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "meta.property-list meta.at-rule.else"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "entity.other.attribute-name.parent-selector-suffix punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.property-list meta.property-list"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.include entity.name.function.scss"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.include punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.mixin punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.include keyword.control.at-rule.include"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control.at-rule.extend punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.extend keyword.control.at-rule.extend"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "entity.other.attribute-name.placeholder.css punctuation.definition.entity.css"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.media keyword.control.at-rule.media"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.mixin keyword.control.at-rule.mixin"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "meta.at-rule.function keyword.control.at-rule.function"
+        },
+        {
+            "foreground": "#9D7CD8",
+            "token": "keyword.control punctuation.definition.keyword"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.property-list meta.at-rule.include"
+        },
+        {
+            "foreground": "#FF9E64",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "entity.name.module.js"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.import.parameter.js"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other.class.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "variable.other punctuation.definition.variable"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.js constant.other.object.key.js string.unquoted.label.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "variable.language.this punctuation.definition.variable"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "keyword.other.this"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.basic entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.basic entity.other.attribute-name"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "text.html constant.character.entity"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.id.html"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.directive.vue entity.other.attribute-name.html"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.sass keyword.control"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.pseudo-class"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.pseudo-element"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "entity.other.attribute-name.placeholder"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "meta.property-list meta.property-value"
+        },
+        {
+            "foreground": "#449DAB",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#914C54",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#6183BB",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#B4F9F8",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "punctuation.definition.group"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "constant.character.escape.backslash"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "tag.decorator.js entity.name.tag.js"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "tag.decorator.js punctuation.definition.tag.js"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#7DCFFF",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#E0AF68",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#9ECE6A",
+            "token": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.list_item.markdown"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.block"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "meta.brace"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.block"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.use"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.class"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.switch-expression.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.switch-expression.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.section.switch-block.begin.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.section.switch-block.end.bracket"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.group.shell"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.parameters"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.arguments"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.dictionary"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.definition.array"
+        },
+        {
+            "foreground": "#9ABDF5",
+            "token": "punctuation.section"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "token": "meta.embedded.block"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "meta.tag JSXNested"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "meta.jsx.children"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "text.html"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "token": "text.log"
+        },
+        {
+            "foreground": "#BB9AF7",
+            "token": "text.html.markdown markup.inline.raw.markdown"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown entity.name"
+        },
+        {
+            "foreground": "#89DDFF",
+            "fontStyle": "bold",
+            "token": "heading.1.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#61BDF2",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown entity.name"
+        },
+        {
+            "foreground": "#61BDF2",
+            "fontStyle": "bold",
+            "token": "heading.2.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown entity.name"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "fontStyle": "bold",
+            "token": "heading.3.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#6D91DE",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown entity.name"
+        },
+        {
+            "foreground": "#6D91DE",
+            "fontStyle": "bold",
+            "token": "heading.4.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown entity.name"
+        },
+        {
+            "foreground": "#9AA5CE",
+            "fontStyle": "bold",
+            "token": "heading.5.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown entity.name"
+        },
+        {
+            "foreground": "#747CA1",
+            "fontStyle": "bold",
+            "token": "heading.6.markdown punctuation.definition.heading.markdown"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "italic",
+            "token": "markup.italic punctuation"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold",
+            "token": "markup.bold punctuation"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic"
+        },
+        {
+            "foreground": "#C0CAF5",
+            "fontStyle": "bold italic",
+            "token": "markup.bold markup.italic punctuation"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline punctuation"
+        },
+        {
+            "foreground": "#4E5579",
+            "token": "markup.quote punctuation.definition.blockquote.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.quote"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.other.link"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "markup.underline.link"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "constant.other.reference.link.markdown"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "string.other.link.description.title.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "markup.fenced_code.block.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "markup.inline.raw.string.markdown"
+        },
+        {
+            "foreground": "#89DDFF",
+            "token": "variable.language.fenced.markdown"
+        },
+        {
+            "foreground": "#444B6A",
+            "fontStyle": "bold",
+            "token": "meta.separator"
+        },
+        {
+            "foreground": "#C0CEFC",
+            "token": "markup.table"
+        },
+        {
+            "foreground": "#0DB9D7",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#FFDB69",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#DB4B4B",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
+        },
+        {
+            "foreground": "#F7768E",
+            "token": "entity.tag.apacheconf"
+        },
+        {
+            "foreground": "#73DACA",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#7AA2F7",
+            "token": "source.env"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/totallyinformation/totallyinformation-monaco.json
+++ b/themes/totallyinformation/totallyinformation-monaco.json
@@ -1,714 +1,710 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "editor.background": "#1f1f1f",
-                "editor.findMatchBackground": "#9e6a03",
-                "editor.foreground": "#cccccc",
-                "editor.inactiveSelectionBackground": "#3a3d41",
-                "editor.selectionHighlightBackground": "#add6ff26",
-                "editorGroup.border": "#ffffff17",
-                "editorGroupHeader.tabsBackground": "#181818",
-                "editorGroupHeader.tabsBorder": "#ffffff15",
-                "editorGutter.addedBackground": "#2ea043",
-                "editorGutter.deletedBackground": "#f85149",
-                "editorGutter.modifiedBackground": "#0078d4",
-                "editorIndentGuide.activeBackground": "#707070",
-                "editorIndentGuide.background": "#404040",
-                "editorInlayHint.background": "#8b949e1b",
-                "editorInlayHint.typeBackground": "#8b949e1b",
-                "editorLineNumber.activeForeground": "#cccccc",
-                "editorLineNumber.foreground": "#6e7681",
-                "editorOverviewRuler.border": "#010409",
-                "editorWidget.background": "#1f1f1f"
-            },
-            "rules": [
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "meta.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "source.groovy.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "string meta.image.inline.markdown"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "emphasis"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "strong"
-                },
-                {
-                    "foreground": "#000080",
-                    "token": "header"
-                },
-                {
-                    "foreground": "#6A9955",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.operator.plus.exponent"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.operator.minus.exponent"
-                },
-                {
-                    "foreground": "#646695",
-                    "token": "constant.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.name.tag.css"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.class.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.class.mixin.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.id.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.parent-selector.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.pseudo-class.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.pseudo-element.css"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "source.css.less entity.other.attribute-name.id"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "entity.other.attribute-name.scss"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "invalid"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "markup.underline"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "fontStyle": "bold",
-                    "token": "markup.heading"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "strikethrough",
-                    "token": "markup.strikethrough"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#6A9955",
-                    "token": "punctuation.definition.quote.begin.markdown"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "punctuation.definition.list.begin.markdown"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "markup.inline.raw"
-                },
-                {
-                    "foreground": "#808080",
-                    "token": "punctuation.definition.tag"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "meta.preprocessor"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "entity.name.function.preprocessor"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "meta.preprocessor.string"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "meta.preprocessor.numeric"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.structure.dictionary.key.python"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "meta.diff.header"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage.type"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.noexcept"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "meta.embedded.assembly"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string.tag"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "string.value"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "string.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.definition.template-expression.begin"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.definition.template-expression.end"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "meta.template.expression"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.type.vendored.property-name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.type.property-name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.css"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.scss"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable.other.less"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "source.coffee.embedded"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "keyword.operator"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.new"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.expression"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.cast"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.sizeof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.alignof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.typeid"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.alignas"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.instanceof"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.logical.python"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "keyword.operator.wordlike"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "keyword.other.unit"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.function.git-rebase"
-                },
-                {
-                    "foreground": "#B5CEA8",
-                    "token": "constant.sha.git-rebase"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "storage.modifier.import.java"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "variable.language.wildcard.java"
-                },
-                {
-                    "foreground": "#D4D4D4",
-                    "token": "storage.modifier.package.java"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "variable.language"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "entity.name.function"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "support.function"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "support.constant.handlebars"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "source.powershell variable.other.member"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "entity.name.operator.custom-literal"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.class"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.type"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.namespace"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.other.attribute"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.scope-resolution"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.name.class"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.numeric.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.byte.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.boolean.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.string.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.uintptr.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.error.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.rune.go"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.modifier.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.variable.cs"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.annotation.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.object.array.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.array.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.token.java"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.annotation.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.parameters.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.generic.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.object.array.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.array.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "storage.type.primitive.groovy"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "meta.type.cast.expr"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "meta.type.new.expr"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.math"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.dom"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "support.constant.json"
-                },
-                {
-                    "foreground": "#4EC9B0",
-                    "token": "entity.other.inherited-class"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.control"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "source.cpp keyword.operator.new"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.operator.delete"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.other.using"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "keyword.other.operator"
-                },
-                {
-                    "foreground": "#C586C0",
-                    "token": "entity.name.operator"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.definition.variable.name"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "support.variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "entity.name.variable"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "constant.other.placeholder"
-                },
-                {
-                    "foreground": "#4FC1FF",
-                    "token": "variable.other.constant"
-                },
-                {
-                    "foreground": "#4FC1FF",
-                    "token": "variable.other.enummember"
-                },
-                {
-                    "foreground": "#9CDCFE",
-                    "token": "meta.object-literal.key"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.property-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.font-name"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.media-type"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.media"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "constant.other.color.rgb-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "constant.other.rgb-value"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.constant.color"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.group.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.group.assertion.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.definition.character-class.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.character.set.begin.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "punctuation.character.set.end.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "keyword.operator.negation.regexp"
-                },
-                {
-                    "foreground": "#CE9178",
-                    "token": "support.other.parenthesis.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.character.character-class.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.other.character-class.set.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.other.character-class.regexp"
-                },
-                {
-                    "foreground": "#D16969",
-                    "token": "constant.character.set.regexp"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "keyword.operator.or.regexp"
-                },
-                {
-                    "foreground": "#DCDCAA",
-                    "token": "keyword.control.anchor.regexp"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "keyword.operator.quantifier.regexp"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#569CD6",
-                    "token": "constant.other.option"
-                },
-                {
-                    "foreground": "#D7BA7D",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#C8C8C8",
-                    "token": "entity.name.label"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "editor.background": "#1f1f1f",
+        "editor.findMatchBackground": "#9e6a03",
+        "editor.foreground": "#cccccc",
+        "editor.inactiveSelectionBackground": "#3a3d41",
+        "editor.selectionHighlightBackground": "#add6ff26",
+        "editorGroup.border": "#ffffff17",
+        "editorGroupHeader.tabsBackground": "#181818",
+        "editorGroupHeader.tabsBorder": "#ffffff15",
+        "editorGutter.addedBackground": "#2ea043",
+        "editorGutter.deletedBackground": "#f85149",
+        "editorGutter.modifiedBackground": "#0078d4",
+        "editorIndentGuide.activeBackground": "#707070",
+        "editorIndentGuide.background": "#404040",
+        "editorInlayHint.background": "#8b949e1b",
+        "editorInlayHint.typeBackground": "#8b949e1b",
+        "editorLineNumber.activeForeground": "#cccccc",
+        "editorLineNumber.foreground": "#6e7681",
+        "editorOverviewRuler.border": "#010409",
+        "editorWidget.background": "#1f1f1f"
+    },
+    "rules": [
+        {
+            "foreground": "#D4D4D4",
+            "token": "meta.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "source.groovy.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "string meta.image.inline.markdown"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "emphasis"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "strong"
+        },
+        {
+            "foreground": "#000080",
+            "token": "header"
+        },
+        {
+            "foreground": "#6A9955",
+            "token": "comment"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.operator.plus.exponent"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.operator.minus.exponent"
+        },
+        {
+            "foreground": "#646695",
+            "token": "constant.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.name.tag.css"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "entity.other.attribute-name"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.class.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.class.mixin.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.id.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.parent-selector.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.pseudo-class.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.pseudo-element.css"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "source.css.less entity.other.attribute-name.id"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "entity.other.attribute-name.scss"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "invalid"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "markup.underline"
+        },
+        {
+            "foreground": "#569CD6",
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "foreground": "#569CD6",
+            "fontStyle": "bold",
+            "token": "markup.heading"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "strikethrough",
+            "token": "markup.strikethrough"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#6A9955",
+            "token": "punctuation.definition.quote.begin.markdown"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "punctuation.definition.list.begin.markdown"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "markup.inline.raw"
+        },
+        {
+            "foreground": "#808080",
+            "token": "punctuation.definition.tag"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "meta.preprocessor"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "entity.name.function.preprocessor"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "meta.preprocessor.string"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "meta.preprocessor.numeric"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.structure.dictionary.key.python"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "meta.diff.header"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage.type"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.noexcept"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "meta.embedded.assembly"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string.tag"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "string.value"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "string.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.definition.template-expression.begin"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.definition.template-expression.end"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "meta.template.expression"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.type.vendored.property-name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.type.property-name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.css"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.scss"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable.other.less"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "source.coffee.embedded"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "keyword.operator"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.new"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.expression"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.cast"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.sizeof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.alignof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.typeid"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.alignas"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.instanceof"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.logical.python"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "keyword.operator.wordlike"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "keyword.other.unit"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.function.git-rebase"
+        },
+        {
+            "foreground": "#B5CEA8",
+            "token": "constant.sha.git-rebase"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "storage.modifier.import.java"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "variable.language.wildcard.java"
+        },
+        {
+            "foreground": "#D4D4D4",
+            "token": "storage.modifier.package.java"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "variable.language"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "entity.name.function"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "support.function"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "support.constant.handlebars"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "source.powershell variable.other.member"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "entity.name.operator.custom-literal"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.class"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.type"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.namespace"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.other.attribute"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.scope-resolution"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.name.class"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.numeric.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.byte.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.boolean.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.string.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.uintptr.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.error.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.rune.go"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.modifier.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.variable.cs"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.annotation.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.object.array.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.array.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.token.java"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.annotation.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.parameters.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.generic.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.object.array.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.array.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "storage.type.primitive.groovy"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "meta.type.cast.expr"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "meta.type.new.expr"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.math"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.dom"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "support.constant.json"
+        },
+        {
+            "foreground": "#4EC9B0",
+            "token": "entity.other.inherited-class"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.control"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "source.cpp keyword.operator.new"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.operator.delete"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.other.using"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "keyword.other.operator"
+        },
+        {
+            "foreground": "#C586C0",
+            "token": "entity.name.operator"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.definition.variable.name"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "support.variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "entity.name.variable"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "constant.other.placeholder"
+        },
+        {
+            "foreground": "#4FC1FF",
+            "token": "variable.other.constant"
+        },
+        {
+            "foreground": "#4FC1FF",
+            "token": "variable.other.enummember"
+        },
+        {
+            "foreground": "#9CDCFE",
+            "token": "meta.object-literal.key"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.property-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.font-name"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.media-type"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.media"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "constant.other.color.rgb-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "constant.other.rgb-value"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.constant.color"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.group.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.group.assertion.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.definition.character-class.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.character.set.begin.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "punctuation.character.set.end.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "keyword.operator.negation.regexp"
+        },
+        {
+            "foreground": "#CE9178",
+            "token": "support.other.parenthesis.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.character.character-class.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.other.character-class.set.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.other.character-class.regexp"
+        },
+        {
+            "foreground": "#D16969",
+            "token": "constant.character.set.regexp"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "keyword.operator.or.regexp"
+        },
+        {
+            "foreground": "#DCDCAA",
+            "token": "keyword.control.anchor.regexp"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "keyword.operator.quantifier.regexp"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#569CD6",
+            "token": "constant.other.option"
+        },
+        {
+            "foreground": "#D7BA7D",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#C8C8C8",
+            "token": "entity.name.label"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }

--- a/themes/zenburn/zenburn-monaco.json
+++ b/themes/zenburn/zenburn-monaco.json
@@ -1,1046 +1,1042 @@
 {
-    "monacoOptions": {
-        "theme": {
-            "inherit": true,
-            "base": "vs-dark",
-            "colors": {
-                "activityBar.background": "#313633",
-                "activityBarBadge.background": "#7f9f7f",
-                "activityBarBadge.foreground": "#313633",
-                "badge.foreground": "#313633",
-                "breadcrumb.focusForeground": "#9e8f68",
-                "breadcrumbPicker.background": "#3f3f3f",
-                "button.background": "#87ae86",
-                "button.foreground": "#373737",
-                "editor.background": "#3f3f3f",
-                "editor.foreground": "#dedede",
-                "editor.lineHighlightBackground": "#303030",
-                "editor.selectionBackground": "#8383839c",
-                "editorBracketHighlight.foreground1": "#cc9393",
-                "editorBracketHighlight.foreground2": "#8cd0d3",
-                "editorBracketHighlight.foreground3": "#f0dfaf",
-                "editorCursor.foreground": "#8cd0d3",
-                "editorError.foreground": "#cc9393",
-                "editorGutter.addedBackground": "#87ae86",
-                "editorGutter.deletedBackground": "#cc9393",
-                "editorGutter.modifiedBackground": "#e7c4a1",
-                "editorInfo.foreground": "#8cd0d388",
-                "editorLineNumber.activeForeground": "#9e8f68",
-                "editorLineNumber.foreground": "#90907e",
-                "editorSuggestWidget.background": "#3f3f3f",
-                "editorSuggestWidget.focusHighlightForeground": "#87ae86",
-                "editorSuggestWidget.foreground": "#dedede",
-                "editorSuggestWidget.highlightForeground": "#8cd0d3",
-                "editorSuggestWidget.selectedBackground": "#242424",
-                "editorSuggestWidget.selectedForeground": "#dedede",
-                "editorSuggestWidget.selectedIconForeground": "#87ae86",
-                "editorSuggestWidgetStatus.foreground": "#dedede",
-                "editorWarning.foreground": "#e7c4a1",
-                "editorWhitespace.foreground": "#a5a5a552",
-                "focusBorder": "#8cd0d344",
-                "gitDecoration.addedResourceForeground": "#87ae86",
-                "gitDecoration.conflictingResourceForeground": "#cc9393",
-                "gitDecoration.deletedResourceForeground": "#cc9393",
-                "gitDecoration.ignoredResourceForeground": "#7f9f7f",
-                "gitDecoration.modifiedResourceForeground": "#e7c4a1",
-                "gitDecoration.submoduleResourceForeground": "#e7c4a1",
-                "gitDecoration.untrackedResourceForeground": "#87ae86",
-                "list.highlightForeground": "#87ae86",
-                "quickInput.background": "#3f3f3f",
-                "quickInput.foreground": "#dedede",
-                "quickInputList.focusBackground": "#555555",
-                "quickInputList.focusForeground": "#dedede",
-                "quickInputList.focusIconForeground": "#3f3f3f",
-                "selection.background": "#8383839c",
-                "sideBar.background": "#3a3a3a",
-                "statusBar.background": "#2e3330",
-                "statusBar.foreground": "#87ae86",
-                "statusBar.noFolderBackground": "#2e3330",
-                "tab.activeForeground": "#dcdccc",
-                "tab.inactiveBackground": "#353535",
-                "terminal.ansiBlue": "#8cd0d3",
-                "terminal.ansiBrightBlue": "#8cd0d3",
-                "terminal.ansiBrightCyan": "#8cd0d3",
-                "terminal.ansiBrightGreen": "#7f9f7f",
-                "terminal.ansiBrightMagenta": "#dca3a3",
-                "terminal.ansiBrightRed": "#ecbcbc",
-                "terminal.ansiBrightYellow": "#f0dfaf",
-                "terminal.ansiCyan": "#8cd0d3",
-                "terminal.ansiGreen": "#7f9f7f",
-                "terminal.ansiMagenta": "#dca3a3",
-                "terminal.ansiRed": "#ecbcbc",
-                "terminal.ansiYellow": "#f0dfaf",
-                "terminal.foreground": "#dcdccc",
-                "terminal.selectionBackground": "#686868aa",
-                "textLink.activeForeground": "#82a282",
-                "textLink.foreground": "#8cd0d3"
-            },
-            "rules": [
-                {
-                    "foreground": "#7F9F7F",
-                    "token": "comment"
-                },
-                {
-                    "foreground": "#7F9F7F",
-                    "token": " punctuation.definition.comment"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": "constant.language"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " support.constant"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " constant.other.color"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " entity.name.type.variant.ocaml"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.rust variable.language.rust"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " support.type.rust"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.elixir constant.other.symbol.elixir"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.elixir constant.other.symbol.elixir punctuation.definition.constant.elixir"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.elixir variable.language.elixir"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.elixir constant.other.keywords.elixir"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.ruby constant.other.symbol"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.ruby punctuation.definition.constant"
-                },
-                {
-                    "foreground": "#CC9393",
-                    "token": "string"
-                },
-                {
-                    "foreground": "#CC9393",
-                    "token": " punctuation.definition.string.begin"
-                },
-                {
-                    "foreground": "#CC9393",
-                    "token": " punctuation.definition.string.end"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": "constant.character"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.scss keyword.operator.ampersand"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "fontStyle": "bold",
-                    "token": " source.css keyword.operator.ampersand"
-                },
-                {
-                    "foreground": "#8CD0D3",
-                    "token": "constant.numeric"
-                },
-                {
-                    "foreground": "#8CD0D3",
-                    "token": " storage.type.numeric"
-                },
-                {
-                    "foreground": "#8CD0D3",
-                    "token": " source.scss keyword.other.unit"
-                },
-                {
-                    "foreground": "#8CD0D3",
-                    "token": " source.css keyword.other.unit"
-                },
-                {
-                    "foreground": "#DCA3A3",
-                    "token": "constant.language.boolean"
-                },
-                {
-                    "foreground": "#C0BED1",
-                    "token": "meta.number.float.decimal constant.numeric"
-                },
-                {
-                    "foreground": "#C0BED1",
-                    "token": " punctuation.separator.decimal"
-                },
-                {
-                    "foreground": "#C0BED1",
-                    "token": " markup.underline.link"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": "source.scss variable.declaration"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " source.scss punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " source.css variable.declaration"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " source.css punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " support.class.js"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " keyword.operator.word.new.js"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " variable.other.php"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " variable.parameter.php"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " variable.language.php"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " meta.function.type-declaration.haskell entity.name.function.haskell"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " source.haskell meta.name.haskell"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " entity.name.type.fsharp"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " punctuation.definition.variable.ruby"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "token": " variable.other.readwrite.instance.ruby"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": "keyword.declaration.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.scss support.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.css support.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.c"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.preprocessor.c"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.c++"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.preprocessor.c++"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.python"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " variable.function.python support.function.builtin.python"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.class.python"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " variable.annotation.python"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " meta.class.js entity.name.function.constructor.js"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": "support.function.classobj.php"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " storage.type.function.php"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " meta.function-call.php support.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.cs"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.rust meta.function.rust entity.name.function.rust"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " support.function.rust"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.clojure"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " entity.name.function.elm"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.elixir meta.function.public.elixir entity.name.function.public.elixir"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.java entity.name.function.java"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.sql support.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " source.ruby entity.name.function"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " meta.definition.method.ts entity.name.function.ts"
-                },
-                {
-                    "foreground": "#EFEF8F",
-                    "token": " meta.definition.method.js entity.name.function.js"
-                },
-                {
-                    "foreground": "#F0DFAF",
-                    "fontStyle": "bold",
-                    "token": "keyword.control.conditional"
-                },
-                {
-                    "foreground": "#FFD7A7",
-                    "fontStyle": "bold",
-                    "token": "keyword.control.loop"
-                },
-                {
-                    "foreground": "#FFD7A7",
-                    "fontStyle": "bold",
-                    "token": " source.scss keyword.control.flow.sass"
-                },
-                {
-                    "foreground": "#DFCFAF",
-                    "token": "keyword.control.conditional.case"
-                },
-                {
-                    "foreground": "#DFCFAF",
-                    "token": " keyword.control.conditional.default"
-                },
-                {
-                    "foreground": "#DFCFAF",
-                    "token": " source.json meta.mapping.key.json string.quoted.double.json"
-                },
-                {
-                    "foreground": "#DFCFAF",
-                    "token": " source.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json"
-                },
-                {
-                    "foreground": "#DFCFAF",
-                    "token": " source.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json"
-                },
-                {
-                    "foreground": "#F0EFD0",
-                    "token": "punctuation.definition"
-                },
-                {
-                    "foreground": "#F0EFD0",
-                    "token": " punctuation.section"
-                },
-                {
-                    "foreground": "#F0EFD0",
-                    "token": " punctuation.separator"
-                },
-                {
-                    "foreground": "#F0EFD0",
-                    "token": " punctuation.terminator - punctuation.definition.numeric.base - keyword.operator"
-                },
-                {
-                    "foreground": "#F0DFAF",
-                    "fontStyle": "bold",
-                    "token": "keyword"
-                },
-                {
-                    "foreground": "#F0DFAF",
-                    "fontStyle": "bold",
-                    "token": " constant.other.keyword.clojure - keyword.operator - keyword.operator.word - keyword.control.flow.return.js - keyword.operator.logical"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": "entity.name.tag"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " punctuation.definition.list_item"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " source.shell.bash support.function"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.flow.return.js"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.declaration.function.python"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.flow.assert.python"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.operator.new.cs - keyword.control.import"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.default"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.export"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.from"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.as"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " source.sql keyword.other"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "fontStyle": "bold",
-                    "token": " source.sql keyword.operator.assignment"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": "keyword.control.exception.try"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.exception.catch"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " text.html.basic entity.name.tag.script"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " source.cs keyword.control.trycatch"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": "source.scss entity.other.pseudo-class"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.shell.bash punctuation.definition.variable"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.shell.bash variable.other.readwrite"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.scss meta.function-call.sass variable.function.sass keyword.control.at-rule.sass"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " entity.other.pseudo-class.css"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " entity.other.pseudo-element.css"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " keyword.control.directive.css punctuation.definition.keyword.css"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " keyword.control.directive.css"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " comment.block.documentation.phpdoc.php keyword.other.phpdoc.php"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.haskell meta.preprocessor.c"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.haskell punctuation.definition.preprocessor.c"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.haskell meta.preprocessor.haskell"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": "keyword.control.import.include"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.at-rule.import.scss"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.at-rule.import.scss punctuation.definition.keyword.scss"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.scss meta.function-call.sass variable.function.sass punctuation.definition.keyword.sass"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.import.js"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.default.js"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.export.js"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.from.js"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.as.js"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.import.python"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.import.from.python"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.other.use.php"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " meta.module-reference.ocaml"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " support.other.module.ocaml"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " entity.name.type.module.ocaml"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.import.haskell"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " namespace.open.fsharp keyword.fsharp"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.fsharp keyword.control.directive.fsharp"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.cs keyword.control.import.cs"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.go keyword.other.import.go"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.rust meta.path.rust"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " meta.declaration.module.elm keyword.other.elm"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " meta.import.elm keyword.other.elm"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.elm meta.import.elm keyword.import.elm"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.java meta.package-declaration.java keyword.other.package.java"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " source.java meta.import.java keyword.control.import.java"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": "keyword.control.import.define"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " meta.preprocessor.macro.c entity.name.constant.preprocessor.c"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " meta.preprocessor.macro.c++ entity.name.constant.preprocessor.c++"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " storage.modifier.def.clojure"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " meta.module.elixir keyword.control.module.elixir"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.ruby keyword.declaration.class"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.ruby keyword.declaration.function"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": " source.ruby keyword.control.block.end"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "fontStyle": "bold",
-                    "token": "support.macro.rust"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "fontStyle": "bold",
-                    "token": " source.ruby keyword.other.special-method"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": "keyword.control.import.c"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " meta.preprocessor.c"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " keyword.control.import.c++"
-                },
-                {
-                    "foreground": "#DFAF8F",
-                    "fontStyle": "bold",
-                    "token": " meta.preprocessor.c++"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": "entity.name.type"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " support.type"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " entity.other.attribute-name"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " storage.type"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " support.class.builtin"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " source.scss entity.other"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " constant.other.haskell"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " source.haskell meta.import.haskell support.other.module.haskell"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " source.haskell meta.declaration.module.haskell entity.name.namespace.haskell"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " abstract.definition.fsharp entity.name.type.fsharp"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " source.elixir entity.name.type"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " source.java support.class.java"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " entity.name.class.ruby"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " entity.other.inherited-class.ruby"
-                },
-                {
-                    "foreground": "#DFDFBF",
-                    "fontStyle": "bold",
-                    "token": " support.class.ruby"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": "storage.modifier"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " support.type.property-name"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " abstract.definition.fsharp keyword.fsharp"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " keyword.declaration"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " storage.type.js"
-                },
-                {
-                    "foreground": "#C3BF9F",
-                    "fontStyle": "bold",
-                    "token": " storage.type.ts"
-                },
-                {
-                    "foreground": "#EFEFAF",
-                    "fontStyle": "bold",
-                    "token": "keyword.declaration.enum"
-                },
-                {
-                    "foreground": "#EFEFAF",
-                    "fontStyle": "bold",
-                    "token": " keyword.declaration.struct"
-                },
-                {
-                    "foreground": "#EFEFAF",
-                    "fontStyle": "bold",
-                    "token": " keyword.declaration.union"
-                },
-                {
-                    "foreground": "#EFEFAF",
-                    "fontStyle": "bold",
-                    "token": " variable.language.this.js"
-                },
-                {
-                    "foreground": "#EFEFAF",
-                    "fontStyle": "bold",
-                    "token": " keyword.declaration.type.haskell"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": "constant.character.escape"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " punctuation.section.interpolation"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " source.scss keyword.other.important"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " source.css keyword.other.important"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " source.scss support.type"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " source.css support.type"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " text.html.basic punctuation.definition.entity.html"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " text.html.basic constant.character.entity.named"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " text.html.basic punctuation.terminator.entity.html"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " entity.other.custom-property.css"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": " variable.function.clojure"
-                },
-                {
-                    "foreground": "#82A282",
-                    "fontStyle": "bold",
-                    "token": "variable.annotation"
-                },
-                {
-                    "foreground": "#8F8F8F",
-                    "token": "markup.heading punctuation.definition.heading"
-                },
-                {
-                    "foreground": "#8F8F8F",
-                    "token": " punctuation.definition.raw.begin"
-                },
-                {
-                    "foreground": "#8F8F8F",
-                    "token": " punctuation.definition.raw.end"
-                },
-                {
-                    "foreground": "#8F8F8F",
-                    "token": " punctuation.section.embedded.begin.php"
-                },
-                {
-                    "foreground": "#8F8F8F",
-                    "token": " punctuation.section.embedded.end.php"
-                },
-                {
-                    "foreground": "#EFEFEF",
-                    "fontStyle": "bold",
-                    "token": "entity.name.section.markdown"
-                },
-                {
-                    "foreground": "#DEDEDE",
-                    "fontStyle": "bold",
-                    "token": "keyword.operator.logical"
-                },
-                {
-                    "foreground": "#DEDEDE",
-                    "token": "constant.language.import-export-all.js"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid"
-                },
-                {
-                    "foreground": "#FFFFFF",
-                    "token": "invalid.deprecated"
-                },
-                {
-                    "fontStyle": "bold",
-                    "token": "markup.bold"
-                },
-                {
-                    "fontStyle": "italic",
-                    "token": "markup.italic"
-                },
-                {
-                    "fontStyle": "underline",
-                    "token": "meta.link.inline.description.markdown"
-                },
-                {
-                    "fontStyle": "bold italic",
-                    "token": "markup.italic markup.bold | markup.bold markup.italic"
-                },
-                {
-                    "fontStyle": "bold underline",
-                    "token": "markup.underline markup.bold | markup.bold markup.underline"
-                },
-                {
-                    "fontStyle": "italic underline",
-                    "token": "markup.underline markup.italic | markup.italic markup.underline"
-                },
-                {
-                    "fontStyle": "bold italic underline",
-                    "token": "markup.bold markup.italic markup.underline | markup.bold markup.underline markup.italic | markup.italic markup.bold markup.underline | markup.italic markup.underline markup.bold | markup.underline markup.bold markup.italic | markup.underline markup.italic markup.bold"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "token": "meta.diff"
-                },
-                {
-                    "foreground": "#E3CEAB",
-                    "token": " meta.diff.header"
-                },
-                {
-                    "foreground": "#CFBFAF",
-                    "token": "markup.deleted"
-                },
-                {
-                    "foreground": "#EFDCBC",
-                    "fontStyle": "bold",
-                    "token": "markup.inserted"
-                },
-                {
-                    "foreground": "#FFCFAF",
-                    "token": "markup.changed"
-                },
-                {
-                    "foreground": "#CC9393",
-                    "token": "message.error"
-                },
-                {
-                    "foreground": "#6796E6",
-                    "token": "token.info-token"
-                },
-                {
-                    "foreground": "#CD9731",
-                    "token": "token.warn-token"
-                },
-                {
-                    "foreground": "#F44747",
-                    "token": "token.error-token"
-                },
-                {
-                    "foreground": "#B267E6",
-                    "token": "token.debug-token"
-                }
-            ],
-            "encodedTokensColors": []
+    "inherit": true,
+    "base": "vs-dark",
+    "colors": {
+        "activityBar.background": "#313633",
+        "activityBarBadge.background": "#7f9f7f",
+        "activityBarBadge.foreground": "#313633",
+        "badge.foreground": "#313633",
+        "breadcrumb.focusForeground": "#9e8f68",
+        "breadcrumbPicker.background": "#3f3f3f",
+        "button.background": "#87ae86",
+        "button.foreground": "#373737",
+        "editor.background": "#3f3f3f",
+        "editor.foreground": "#dedede",
+        "editor.lineHighlightBackground": "#303030",
+        "editor.selectionBackground": "#8383839c",
+        "editorBracketHighlight.foreground1": "#cc9393",
+        "editorBracketHighlight.foreground2": "#8cd0d3",
+        "editorBracketHighlight.foreground3": "#f0dfaf",
+        "editorCursor.foreground": "#8cd0d3",
+        "editorError.foreground": "#cc9393",
+        "editorGutter.addedBackground": "#87ae86",
+        "editorGutter.deletedBackground": "#cc9393",
+        "editorGutter.modifiedBackground": "#e7c4a1",
+        "editorInfo.foreground": "#8cd0d388",
+        "editorLineNumber.activeForeground": "#9e8f68",
+        "editorLineNumber.foreground": "#90907e",
+        "editorSuggestWidget.background": "#3f3f3f",
+        "editorSuggestWidget.focusHighlightForeground": "#87ae86",
+        "editorSuggestWidget.foreground": "#dedede",
+        "editorSuggestWidget.highlightForeground": "#8cd0d3",
+        "editorSuggestWidget.selectedBackground": "#242424",
+        "editorSuggestWidget.selectedForeground": "#dedede",
+        "editorSuggestWidget.selectedIconForeground": "#87ae86",
+        "editorSuggestWidgetStatus.foreground": "#dedede",
+        "editorWarning.foreground": "#e7c4a1",
+        "editorWhitespace.foreground": "#a5a5a552",
+        "focusBorder": "#8cd0d344",
+        "gitDecoration.addedResourceForeground": "#87ae86",
+        "gitDecoration.conflictingResourceForeground": "#cc9393",
+        "gitDecoration.deletedResourceForeground": "#cc9393",
+        "gitDecoration.ignoredResourceForeground": "#7f9f7f",
+        "gitDecoration.modifiedResourceForeground": "#e7c4a1",
+        "gitDecoration.submoduleResourceForeground": "#e7c4a1",
+        "gitDecoration.untrackedResourceForeground": "#87ae86",
+        "list.highlightForeground": "#87ae86",
+        "quickInput.background": "#3f3f3f",
+        "quickInput.foreground": "#dedede",
+        "quickInputList.focusBackground": "#555555",
+        "quickInputList.focusForeground": "#dedede",
+        "quickInputList.focusIconForeground": "#3f3f3f",
+        "selection.background": "#8383839c",
+        "sideBar.background": "#3a3a3a",
+        "statusBar.background": "#2e3330",
+        "statusBar.foreground": "#87ae86",
+        "statusBar.noFolderBackground": "#2e3330",
+        "tab.activeForeground": "#dcdccc",
+        "tab.inactiveBackground": "#353535",
+        "terminal.ansiBlue": "#8cd0d3",
+        "terminal.ansiBrightBlue": "#8cd0d3",
+        "terminal.ansiBrightCyan": "#8cd0d3",
+        "terminal.ansiBrightGreen": "#7f9f7f",
+        "terminal.ansiBrightMagenta": "#dca3a3",
+        "terminal.ansiBrightRed": "#ecbcbc",
+        "terminal.ansiBrightYellow": "#f0dfaf",
+        "terminal.ansiCyan": "#8cd0d3",
+        "terminal.ansiGreen": "#7f9f7f",
+        "terminal.ansiMagenta": "#dca3a3",
+        "terminal.ansiRed": "#ecbcbc",
+        "terminal.ansiYellow": "#f0dfaf",
+        "terminal.foreground": "#dcdccc",
+        "terminal.selectionBackground": "#686868aa",
+        "textLink.activeForeground": "#82a282",
+        "textLink.foreground": "#8cd0d3"
+    },
+    "rules": [
+        {
+            "foreground": "#7F9F7F",
+            "token": "comment"
+        },
+        {
+            "foreground": "#7F9F7F",
+            "token": " punctuation.definition.comment"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": "constant.language"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " support.constant"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " constant.other.color"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " entity.name.type.variant.ocaml"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.rust variable.language.rust"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " support.type.rust"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.elixir constant.other.symbol.elixir"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.elixir constant.other.symbol.elixir punctuation.definition.constant.elixir"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.elixir variable.language.elixir"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.elixir constant.other.keywords.elixir"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.ruby constant.other.symbol"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.ruby punctuation.definition.constant"
+        },
+        {
+            "foreground": "#CC9393",
+            "token": "string"
+        },
+        {
+            "foreground": "#CC9393",
+            "token": " punctuation.definition.string.begin"
+        },
+        {
+            "foreground": "#CC9393",
+            "token": " punctuation.definition.string.end"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": "constant.character"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.scss keyword.operator.ampersand"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "fontStyle": "bold",
+            "token": " source.css keyword.operator.ampersand"
+        },
+        {
+            "foreground": "#8CD0D3",
+            "token": "constant.numeric"
+        },
+        {
+            "foreground": "#8CD0D3",
+            "token": " storage.type.numeric"
+        },
+        {
+            "foreground": "#8CD0D3",
+            "token": " source.scss keyword.other.unit"
+        },
+        {
+            "foreground": "#8CD0D3",
+            "token": " source.css keyword.other.unit"
+        },
+        {
+            "foreground": "#DCA3A3",
+            "token": "constant.language.boolean"
+        },
+        {
+            "foreground": "#C0BED1",
+            "token": "meta.number.float.decimal constant.numeric"
+        },
+        {
+            "foreground": "#C0BED1",
+            "token": " punctuation.separator.decimal"
+        },
+        {
+            "foreground": "#C0BED1",
+            "token": " markup.underline.link"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": "source.scss variable.declaration"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " source.scss punctuation.definition.variable"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " source.css variable.declaration"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " source.css punctuation.definition.variable"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " support.class.js"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " keyword.operator.word.new.js"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " variable.other.php"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " variable.parameter.php"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " variable.language.php"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " meta.function.type-declaration.haskell entity.name.function.haskell"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " source.haskell meta.name.haskell"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " entity.name.type.fsharp"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " punctuation.definition.variable.ruby"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "token": " variable.other.readwrite.instance.ruby"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": "keyword.declaration.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.scss support.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.css support.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.c"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.preprocessor.c"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.c++"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.preprocessor.c++"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.python"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " variable.function.python support.function.builtin.python"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.class.python"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " variable.annotation.python"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " meta.class.js entity.name.function.constructor.js"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": "support.function.classobj.php"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " storage.type.function.php"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " meta.function-call.php support.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.cs"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.rust meta.function.rust entity.name.function.rust"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " support.function.rust"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.clojure"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " entity.name.function.elm"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.elixir meta.function.public.elixir entity.name.function.public.elixir"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.java entity.name.function.java"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.sql support.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " source.ruby entity.name.function"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " meta.definition.method.ts entity.name.function.ts"
+        },
+        {
+            "foreground": "#EFEF8F",
+            "token": " meta.definition.method.js entity.name.function.js"
+        },
+        {
+            "foreground": "#F0DFAF",
+            "fontStyle": "bold",
+            "token": "keyword.control.conditional"
+        },
+        {
+            "foreground": "#FFD7A7",
+            "fontStyle": "bold",
+            "token": "keyword.control.loop"
+        },
+        {
+            "foreground": "#FFD7A7",
+            "fontStyle": "bold",
+            "token": " source.scss keyword.control.flow.sass"
+        },
+        {
+            "foreground": "#DFCFAF",
+            "token": "keyword.control.conditional.case"
+        },
+        {
+            "foreground": "#DFCFAF",
+            "token": " keyword.control.conditional.default"
+        },
+        {
+            "foreground": "#DFCFAF",
+            "token": " source.json meta.mapping.key.json string.quoted.double.json"
+        },
+        {
+            "foreground": "#DFCFAF",
+            "token": " source.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json"
+        },
+        {
+            "foreground": "#DFCFAF",
+            "token": " source.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json"
+        },
+        {
+            "foreground": "#F0EFD0",
+            "token": "punctuation.definition"
+        },
+        {
+            "foreground": "#F0EFD0",
+            "token": " punctuation.section"
+        },
+        {
+            "foreground": "#F0EFD0",
+            "token": " punctuation.separator"
+        },
+        {
+            "foreground": "#F0EFD0",
+            "token": " punctuation.terminator - punctuation.definition.numeric.base - keyword.operator"
+        },
+        {
+            "foreground": "#F0DFAF",
+            "fontStyle": "bold",
+            "token": "keyword"
+        },
+        {
+            "foreground": "#F0DFAF",
+            "fontStyle": "bold",
+            "token": " constant.other.keyword.clojure - keyword.operator - keyword.operator.word - keyword.control.flow.return.js - keyword.operator.logical"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": "entity.name.tag"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " punctuation.definition.list_item"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " source.shell.bash support.function"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.flow.return.js"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.declaration.function.python"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.flow.assert.python"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.operator.new.cs - keyword.control.import"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.default"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.export"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.from"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " keyword.control.as"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " source.sql keyword.other"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "fontStyle": "bold",
+            "token": " source.sql keyword.operator.assignment"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": "keyword.control.exception.try"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " keyword.control.exception.catch"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " text.html.basic entity.name.tag.script"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " source.cs keyword.control.trycatch"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": "source.scss entity.other.pseudo-class"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.shell.bash punctuation.definition.variable"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.shell.bash variable.other.readwrite"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.scss meta.function-call.sass variable.function.sass keyword.control.at-rule.sass"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " entity.other.pseudo-class.css"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " entity.other.pseudo-element.css"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " keyword.control.directive.css punctuation.definition.keyword.css"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " keyword.control.directive.css"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " comment.block.documentation.phpdoc.php keyword.other.phpdoc.php"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.haskell meta.preprocessor.c"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.haskell punctuation.definition.preprocessor.c"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.haskell meta.preprocessor.haskell"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": "keyword.control.import.include"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.at-rule.import.scss"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.at-rule.import.scss punctuation.definition.keyword.scss"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.scss meta.function-call.sass variable.function.sass punctuation.definition.keyword.sass"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.import.js"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.default.js"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.export.js"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.from.js"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.as.js"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.import.python"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.import.from.python"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.other.use.php"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " meta.module-reference.ocaml"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " support.other.module.ocaml"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " entity.name.type.module.ocaml"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.import.haskell"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " namespace.open.fsharp keyword.fsharp"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.fsharp keyword.control.directive.fsharp"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.cs keyword.control.import.cs"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.go keyword.other.import.go"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.rust meta.path.rust"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " meta.declaration.module.elm keyword.other.elm"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " meta.import.elm keyword.other.elm"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.elm meta.import.elm keyword.import.elm"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.java meta.package-declaration.java keyword.other.package.java"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " source.java meta.import.java keyword.control.import.java"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": "keyword.control.import.define"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " meta.preprocessor.macro.c entity.name.constant.preprocessor.c"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " meta.preprocessor.macro.c++ entity.name.constant.preprocessor.c++"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " storage.modifier.def.clojure"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " meta.module.elixir keyword.control.module.elixir"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.ruby keyword.declaration.class"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.ruby keyword.declaration.function"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": " source.ruby keyword.control.block.end"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "fontStyle": "bold",
+            "token": "support.macro.rust"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "fontStyle": "bold",
+            "token": " source.ruby keyword.other.special-method"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": "keyword.control.import.c"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " meta.preprocessor.c"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " keyword.control.import.c++"
+        },
+        {
+            "foreground": "#DFAF8F",
+            "fontStyle": "bold",
+            "token": " meta.preprocessor.c++"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": "entity.name.type"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " support.type"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " entity.other.attribute-name"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " storage.type"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " support.class.builtin"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " source.scss entity.other"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " constant.other.haskell"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " source.haskell meta.import.haskell support.other.module.haskell"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " source.haskell meta.declaration.module.haskell entity.name.namespace.haskell"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " abstract.definition.fsharp entity.name.type.fsharp"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " source.elixir entity.name.type"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " source.java support.class.java"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " entity.name.class.ruby"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " entity.other.inherited-class.ruby"
+        },
+        {
+            "foreground": "#DFDFBF",
+            "fontStyle": "bold",
+            "token": " support.class.ruby"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": "storage.modifier"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " support.type.property-name"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " abstract.definition.fsharp keyword.fsharp"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " keyword.declaration"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " storage.type.js"
+        },
+        {
+            "foreground": "#C3BF9F",
+            "fontStyle": "bold",
+            "token": " storage.type.ts"
+        },
+        {
+            "foreground": "#EFEFAF",
+            "fontStyle": "bold",
+            "token": "keyword.declaration.enum"
+        },
+        {
+            "foreground": "#EFEFAF",
+            "fontStyle": "bold",
+            "token": " keyword.declaration.struct"
+        },
+        {
+            "foreground": "#EFEFAF",
+            "fontStyle": "bold",
+            "token": " keyword.declaration.union"
+        },
+        {
+            "foreground": "#EFEFAF",
+            "fontStyle": "bold",
+            "token": " variable.language.this.js"
+        },
+        {
+            "foreground": "#EFEFAF",
+            "fontStyle": "bold",
+            "token": " keyword.declaration.type.haskell"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": "constant.character.escape"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " punctuation.section.interpolation"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " source.scss keyword.other.important"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " source.css keyword.other.important"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " source.scss support.type"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " source.css support.type"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " text.html.basic punctuation.definition.entity.html"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " text.html.basic constant.character.entity.named"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " text.html.basic punctuation.terminator.entity.html"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " entity.other.custom-property.css"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": " variable.function.clojure"
+        },
+        {
+            "foreground": "#82A282",
+            "fontStyle": "bold",
+            "token": "variable.annotation"
+        },
+        {
+            "foreground": "#8F8F8F",
+            "token": "markup.heading punctuation.definition.heading"
+        },
+        {
+            "foreground": "#8F8F8F",
+            "token": " punctuation.definition.raw.begin"
+        },
+        {
+            "foreground": "#8F8F8F",
+            "token": " punctuation.definition.raw.end"
+        },
+        {
+            "foreground": "#8F8F8F",
+            "token": " punctuation.section.embedded.begin.php"
+        },
+        {
+            "foreground": "#8F8F8F",
+            "token": " punctuation.section.embedded.end.php"
+        },
+        {
+            "foreground": "#EFEFEF",
+            "fontStyle": "bold",
+            "token": "entity.name.section.markdown"
+        },
+        {
+            "foreground": "#DEDEDE",
+            "fontStyle": "bold",
+            "token": "keyword.operator.logical"
+        },
+        {
+            "foreground": "#DEDEDE",
+            "token": "constant.language.import-export-all.js"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid"
+        },
+        {
+            "foreground": "#FFFFFF",
+            "token": "invalid.deprecated"
+        },
+        {
+            "fontStyle": "bold",
+            "token": "markup.bold"
+        },
+        {
+            "fontStyle": "italic",
+            "token": "markup.italic"
+        },
+        {
+            "fontStyle": "underline",
+            "token": "meta.link.inline.description.markdown"
+        },
+        {
+            "fontStyle": "bold italic",
+            "token": "markup.italic markup.bold | markup.bold markup.italic"
+        },
+        {
+            "fontStyle": "bold underline",
+            "token": "markup.underline markup.bold | markup.bold markup.underline"
+        },
+        {
+            "fontStyle": "italic underline",
+            "token": "markup.underline markup.italic | markup.italic markup.underline"
+        },
+        {
+            "fontStyle": "bold italic underline",
+            "token": "markup.bold markup.italic markup.underline | markup.bold markup.underline markup.italic | markup.italic markup.bold markup.underline | markup.italic markup.underline markup.bold | markup.underline markup.bold markup.italic | markup.underline markup.italic markup.bold"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "token": "meta.diff"
+        },
+        {
+            "foreground": "#E3CEAB",
+            "token": " meta.diff.header"
+        },
+        {
+            "foreground": "#CFBFAF",
+            "token": "markup.deleted"
+        },
+        {
+            "foreground": "#EFDCBC",
+            "fontStyle": "bold",
+            "token": "markup.inserted"
+        },
+        {
+            "foreground": "#FFCFAF",
+            "token": "markup.changed"
+        },
+        {
+            "foreground": "#CC9393",
+            "token": "message.error"
+        },
+        {
+            "foreground": "#6796E6",
+            "token": "token.info-token"
+        },
+        {
+            "foreground": "#CD9731",
+            "token": "token.warn-token"
+        },
+        {
+            "foreground": "#F44747",
+            "token": "token.error-token"
+        },
+        {
+            "foreground": "#B267E6",
+            "token": "token.debug-token"
         }
-    }
+    ],
+    "encodedTokensColors": []
 }


### PR DESCRIPTION
Since we only configure the `theme` setting, there is no need to configure the whole `monacoOptions` object in every single theme.