### PR TITLE
Replace fs.watch with chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "homepage": "https://github.com/node-red-contrib-themes/theme-collection#readme",
     "devDependencies": {
+        "chokidar": "3.6.0",
         "command-line-args": "5.2.1",
         "csso": "5.0.5",
         "fs-extra": "11.2.0",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -2,7 +2,8 @@
 const commandLineArgs = require('command-line-args')
 const options = commandLineArgs([{ name: 'themeName', type: String, defaultOption: true }])
 const path = require('path')
-const { existsSync, readFileSync, watch, writeFileSync } = require('fs')
+const { existsSync, readFileSync, writeFileSync } = require('fs')
+const watch = require('chokidar').watch
 const { exec } = require('child_process')
 const { minify } = require('csso')
 const nodemon = require('nodemon')
@@ -28,30 +29,21 @@ if (options.themeName && !existsSync(themePath)) {
     process.exit(2)
 }
 
-watch(path.join(themePath, 'theme.scss'), () => {
-    exec(`node ${rootPath}/scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
-})
+watch([path.join(themePath, 'theme.scss')])
+    .on('add', () => { buildTheme() })
+    .on('change', () => { buildTheme() })
 
-watch(path.join(themePath, 'theme-custom.css'), () => {
-    const themeCustomCss = readFileSync(path.join(themePath, 'theme-custom.css'), 'utf-8')
-    const minifiedCss = minify(themeCustomCss).css
+watch([path.join(themePath, 'theme-custom.css')])
+    .on('add', () => { buildCustomTheme() })
+    .on('change', () => { buildCustomTheme() })
 
-    writeFileSync(path.join(themePath, `${themeName}-custom.min.css`), minifiedCss)
-})
+watch([path.join(themePath, 'theme-mermaid.json')])
+    .on('add', () => { buildThememermaidOptions() })
+    .on('change', () => { buildThememermaidOptions() })
 
-watch(path.join(themePath, 'theme-mermaid.json'), () => {
-    const mermaidOptions = JSON.parse(readFileSync(path.join(themePath, 'theme-mermaid.json'), 'utf-8'))
-    const minifiedMermaidOptions = JSON.stringify(mermaidOptions)
-
-    writeFileSync(path.join(themePath, `${themeName}-mermaid.min.json`), minifiedMermaidOptions)
-})
-
-watch(path.join(themePath, 'theme-monaco.json'), () => {
-    const monacoOptions = JSON.parse(readFileSync(path.join(themePath, 'theme-monaco.json'), 'utf-8'))
-    const minifiedMonacoOptions = JSON.stringify(monacoOptions)
-
-    writeFileSync(path.join(themePath, `${themeName}-monaco.min.json`), minifiedMonacoOptions)
-})
+watch([path.join(themePath, 'theme-monaco.json')])
+    .on('add', () => { buildThememonacoOptions() })
+    .on('change', () => { buildThememonacoOptions() })
 
 nodemon({
     exec: `${rootPath}/node-red/packages/node_modules/node-red/red.js --port 41880 --userDir ${rootPath}/.node-red --define credentialSecret=false --define editorTheme.projects.enabled=true --define editorTheme.theme=${options.themeName} theme-dev-project`,
@@ -62,6 +54,31 @@ nodemon({
     ],
     restartable: false
 })
+
+function buildTheme() {
+    exec(`node ${rootPath}/scripts/build-theme.js --in=${buildIn} --out=${buildOut} --src=${buildSrc}`)
+}
+
+function buildCustomTheme() {
+    const themeCustomCss = readFileSync(path.join(themePath, 'theme-custom.css'), 'utf-8')
+    const minifiedCss = minify(themeCustomCss).css
+
+    writeFileSync(path.join(themePath, `${themeName}-custom.min.css`), minifiedCss)
+}
+
+function buildThememermaidOptions() {
+    const mermaidOptions = JSON.parse(readFileSync(path.join(themePath, 'theme-mermaid.json'), 'utf-8'))
+    const minifiedMermaidOptions = JSON.stringify(mermaidOptions)
+
+    writeFileSync(path.join(themePath, `${themeName}-mermaid.min.json`), minifiedMermaidOptions)
+}
+
+function buildThememonacoOptions() {
+    const monacoOptions = JSON.parse(readFileSync(path.join(themePath, 'theme-monaco.json'), 'utf-8'))
+    const minifiedMonacoOptions = JSON.stringify(monacoOptions)
+
+    writeFileSync(path.join(themePath, `${themeName}-monaco.min.json`), minifiedMonacoOptions)
+}
 
 function showUsageAndExit(exitCode) {
     console.log('')


### PR DESCRIPTION
This excerpt from the [chokidar documentation](https://github.com/paulmillr/chokidar) explains the reasoning behind this change.

> ## Why?
> 
> Node.js `fs.watch`:
> 
> * Doesn't report filenames on MacOS.
> * Doesn't report events at all when using editors like Sublime on MacOS.
> * Often reports events twice.
> * Emits most changes as `rename`.
> * Does not provide an easy way to recursively watch file trees.
> * Does not support recursive watching on Linux.
> 
> Node.js `fs.watchFile`:
> 
> * Almost as bad at event handling.
> * Also does not provide any recursive watching.
> * Results in high CPU utilization.
> 
> Chokidar resolves these problems.