### PR TITLE
Add a replacer to fix Renovate's link

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -50,3 +50,7 @@ version-resolver:
 
 exclude-labels:
   - "skip-changelog"
+
+replacers:
+  - search: /renovate$/
+    replace: renovatebot


### PR DESCRIPTION
Add a rule to replace `@renovate` with `@renovatebot`.

- `@renovate` points to a non-existent user profile.

- `@renovatebot` points to Renovate's organization page on GitHub.

Used `@dependabot` as a reference.