### PR TITLE
Don't push to the default branch when preparing a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "dev": "node ./scripts/dev.js",
         "create-theme": "node ./scripts/create-theme.js",
         "build": "node ./scripts/build.js",
-        "version": "npm run build && git add -A",
-        "postversion": "git push && git push --tags"
+        "version": "git checkout -b release/$npm_package_version && npm run build && git add -A",
+        "postversion": "git push && git push --tags && git checkout master"
     },
     "author": "Mauricio Bonani @mbonani",
     "funding": {


### PR DESCRIPTION
Always create a new branch when preparing a release, and use that branch to create a pull request instead of pushing directly to the default branch.