### PR TITLE
Add upstream reference to git push command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "create-theme": "node ./scripts/create-theme.js",
         "build": "node ./scripts/build.js",
         "version": "git checkout -b release/$npm_package_version && npm run build && git add -A",
-        "postversion": "git push && git push --tags && git checkout master"
+        "postversion": "git push -u origin release/$npm_package_version && git push --tags && git checkout master"
     },
     "author": "Mauricio Bonani @mbonani",
     "funding": {


### PR DESCRIPTION
If the upstream reference option is not set, `git push` can result in an error like the one below.

```
git push

fatal: The current branch release/3.1.10 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin release/3.1.10
```