### PR TITLE
Don't use spaces in label names

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_theme_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_theme_request.yml
@@ -1,6 +1,6 @@
 name: "Theme request"
 description: "Suggest a new theme"
-labels: ['theme request']
+labels: ['theme-request']
 body:
   - type: markdown
     attributes:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,16 +12,16 @@ template: |
 categories:
   - title: "🚨 Breaking changes"
     labels:
-      - "breaking change"
+      - "breaking-change"
   - title: "✨ New themes"
     labels:
-      - "new theme"
+      - "new-theme"
   - title: "🐛 Bug fixes"
     labels:
       - "bugfix"
   - title: "🎨 Theme updates"
     labels:
-      - "theme updates"
+      - "theme-updates"
   - title: "🚀 Enhancements"
     labels:
       - "enhancement"
@@ -40,11 +40,11 @@ version-resolver:
   major:
     labels:
       - "major"
-      - "breaking change"
+      - "breaking-change"
   minor:
     labels:
       - "minor"
-      - "new theme"
+      - "new-theme"
   patch:
     labels:
       - "patch"

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -19,6 +19,6 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: >-
-            breaking change, bugfix, documentation, enhancement, new theme,
-            dependencies, maintenance, theme updates, skip-changelog, no-stale
+            breaking-change, bugfix, documentation, enhancement, new-theme,
+            dependencies, maintenance, theme-updates, skip-changelog, no-stale
           disable-reviews: true


### PR DESCRIPTION
Replace spaces in label names with a '-'. ~Spaces in label names seem to cause issues with the Release Drafter Version Resolver.~