### PR TITLE
Follow the user's OS color scheme preference

### DIFF
--- a/lib/build-theme.js
+++ b/lib/build-theme.js
@@ -13,11 +13,11 @@ async function buildTheme(themeName) {
         fs.mkdirSync(themeDir, { recursive: true })
     }
 
-    await buildCss(themeName)
+    await buildCSS(themeName)
     await buildMermaidTheme(themeName)
     await buildMonacoTheme(themeName)
 
-    async function buildCss(themeName) {
+    async function buildCSS(themeName) {
         const sassDir = path.join(rootDir, 'node-red/packages/node_modules/@node-red/editor-client/src/sass/')
         const tmpDir = os.tmpdir()
         const workingDir = fs.mkdtempSync(path.join(`${tmpDir}${path.sep}`, `${themeName}-`))
@@ -27,13 +27,14 @@ async function buildTheme(themeName) {
         fs.copyFileSync(path.join(themeSourceDir, 'theme.scss'), path.join(workingDir, 'colors.scss'))
 
         const compiledSass = sass.compile(path.join(workingDir, 'style-custom-theme.scss')).css
+        const commonCSS = fs.readFileSync(path.join(rootDir, 'src/common/common.css'), 'utf-8')
         const themeCustomCSS = fs.readFileSync(path.join(themeSourceDir, 'theme-custom.css'), 'utf-8')
-        const result = ''.concat(compiledSass, themeCustomCSS)
-        const minifiedCss = minify(result).css
+        const result = ''.concat(compiledSass, commonCSS, themeCustomCSS)
+        const minifiedCSS = minify(result).css
         const nrVersion = require(path.join(rootDir, 'node-red/package.json')).version
         const now = new Date().toISOString()
         const header = `/*\n* Theme '${themeName}' generated with Node-RED ${nrVersion} on ${now}\n*/`
-        const output = ''.concat(header, '\n', minifiedCss)
+        const output = ''.concat(header, '\n', minifiedCSS)
 
         fs.writeFileSync(path.join(themeDir, `${themeName}.min.css`), output)
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -18,9 +18,10 @@
     const rootDir = path.resolve(path.join(__dirname, '..'))
     const themeSourceDir = path.join(rootDir, 'src/themes', themeName)
     const sass = path.join(themeSourceDir, 'theme.scss')
-    const customCss = path.join(themeSourceDir, 'theme-custom.css')
+    const customCSS = path.join(themeSourceDir, 'theme-custom.css')
     const mermaidTheme = path.join(themeSourceDir, 'theme-mermaid.json')
     const monacoTheme = path.join(themeSourceDir, 'theme-monaco.json')
+    const commonCss = path.join(rootDir, 'src/common/common.css')
 
     if (!fs.existsSync(themeSourceDir)) {
         error(`Theme path is not valid. Could not find '${themeSourceDir}'`)
@@ -34,7 +35,7 @@
 
     await buildTheme(themeName)
 
-    watch([sass, customCss, mermaidTheme, monacoTheme])
+    watch([sass, customCSS, mermaidTheme, monacoTheme, commonCss])
         .on('change', () => { buildTheme(themeName) })
 
     nodemon({

--- a/src/common/common.css
+++ b/src/common/common.css
@@ -1,0 +1,7 @@
+/** Style customizations common to all themes **/
+
+/* color-scheme */
+/* Follows the user's color scheme preference on their operating system */
+:root {
+  color-scheme: light dark;
+}


### PR DESCRIPTION
Use the `color-scheme` CSS property to follow the user's OS color scheme preference.

For example, this is what the color picker looks like in light and dark mode.

<table>
<tr>
 <td>Browser
 <td>Light
 <td>Dark
<tr>
 <td>Chrome
 <td><img width="235" alt="SCR-20240313-jmmj" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/ae3b7cd2-7ce7-4885-a6e4-24a2fb5d3473">
 <td><img width="236" alt="SCR-20240313-jmjc" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/9598b778-2754-49b8-a3a4-5339ffa29328">
<tr>
 <td>Firefox
 <td><img width="225" alt="SCR-20240313-jndt" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/54fde156-ba76-4957-83b5-a4f0f2c8ad00">
 <td><img width="226" alt="SCR-20240313-jnck" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/41dbaef6-16e6-4648-90b8-b43b8bffce7f">
<tr>
 <td>Safari
 <td><img width="180" alt="SCR-20240313-jmvv" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/e6e9e632-636b-42fe-9aca-3ab9c3aee91d">
 <td><img width="181" alt="SCR-20240313-jmug" src="https://github.com/node-red-contrib-themes/theme-collection/assets/29807944/6c347313-7b26-403d-bafa-db45a92397fe">
</table>