### PR TITLE
Set the accent color for user-interface controls

### DIFF
--- a/src/common/common.css
+++ b/src/common/common.css
@@ -5,3 +5,9 @@
 :root {
   color-scheme: light dark;
 }
+
+/* Accent color */
+/* Specifies the accent color for user-interface controls like: <input type="checkbox">, <input type="radio">, <input type="range"> and <progress> */
+:root {
+  accent-color: var(--red-ui-form-text-color);
+}


### PR DESCRIPTION
The accent-color property specifies the accent color for user-interface controls like \<input type="checkbox"\>, \<input type="radio"\>, \<input type="range"\>, and \<progress\>.