### PR TITLE
Install via the Palette Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of themes for [Node-RED][node-red].
 ## Table of Contents
 
 - [Installation](#installation)
+  - [Install via the Palette Manager](#install-via-the-palette-manager)
   - [Install with npm](#install-with-npm)
 - [Theme list](#theme-list)
 - [Usage](#usage)
@@ -21,6 +22,10 @@ A collection of themes for [Node-RED][node-red].
 - [License](#license)
 
 ## Installation
+
+### Install via the Palette Manager
+
+Search for @node-red-contrib-themes/theme-collection
 
 ### Install with npm
 


### PR DESCRIPTION
Excerpt from Node-RED 4.0.0-beta.2 release notes:

> The Palette Manager now lists what plugins you have installed alongside the regular node modules you have. Previously, it only listed modules that include palette nodes.