### PR TITLE
Fix theme name validation

### DIFF
--- a/lib/create-theme.js
+++ b/lib/create-theme.js
@@ -3,16 +3,14 @@ const commandLineArgs = require('command-line-args')
 const options = commandLineArgs([{ name: 'themeName', type: String, defaultOption: true }])
 const path = require('path')
 const fs = require('fs-extra')
-const rootDir = path.resolve(path.join(__dirname, '..'))
 const themeName = options.themeName
-const themeSourceDir = path.join(rootDir, 'src/themes', themeName)
 
 if (!themeName) {
     error('Missing argument: theme-name')
     showUsageAndExit(1)
 }
 
-if (!/^(?=.{3,})[a-zA-Z0-9]+(?!-{2,})[a-zA-Z0-9-]*[a-zA-Z0-9]+$/.test(themeName)) {
+if (!/(?=^.{3,}$)(?:^[a-zA-Z0-9]+(([a-zA-Z0-9]*|-)[a-zA-Z0-9]+)+$)/.test(themeName)) {
     log('')
     error('Theme name not valid')
     log('')
@@ -24,6 +22,9 @@ if (!/^(?=.{3,})[a-zA-Z0-9]+(?!-{2,})[a-zA-Z0-9-]*[a-zA-Z0-9]+$/.test(themeName)
     log(`- Consecutive non-alphanumeric chars are also forbidden`)
     showUsageAndExit(1)
 }
+
+const rootDir = path.resolve(path.join(__dirname, '..'))
+const themeSourceDir = path.join(rootDir, 'src/themes', themeName)
 
 if (fs.existsSync(themeSourceDir)) {
     log('')


### PR DESCRIPTION
There was a problem with the regex used to validate theme names. It allowed the creation of themes with names that do not fully comply with the rules listed in the [documentation](https://github.com/node-red-contrib-themes/theme-collection/blob/dev/DEVELOPMENT.md#creating-a-new-theme).