### PR TITLE
Do not include null values ​​in Monaco themes

### DIFF
--- a/lib/build-theme.js
+++ b/lib/build-theme.js
@@ -227,9 +227,9 @@ async function buildTheme(themeName) {
 
         if (typeof monacoTheme === 'object') {
             for (const entry of Object.entries(monacoTheme.colors)) {
-                const [key, value] = entry;
-                if (!monacoExposedColors.includes(key)) {
-                    delete monacoTheme.colors[key];
+                const [key, value] = entry
+                if (!monacoExposedColors.includes(key) || entry[1] === null) {
+                    delete monacoTheme.colors[key]
                 }
             }
         }


### PR DESCRIPTION
Do not include properties with `null` values when building Monaco themes. This should prevent issues like #456 from happening again.