### PR TITLE
Fix selected and hover background colors

### DIFF
--- a/src/themes/solarized-dark/theme.scss
+++ b/src/themes/solarized-dark/theme.scss
@@ -5,9 +5,9 @@ $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
 $primary-background: #002b36;
 
 $secondary-background: #073642;
-$secondary-background-selected: #005a6f;
+$secondary-background-selected: #002b36;
 $secondary-background-inactive: #002b36;
-$secondary-background-hover: #033f4e;
+$secondary-background-hover: #002b36;
 $secondary-background-disabled: #002b36;
 
 $tertiary-background: #002b36;

--- a/src/themes/solarized-light/theme.scss
+++ b/src/themes/solarized-light/theme.scss
@@ -5,9 +5,9 @@ $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
 $primary-background: #eee8d5;
 
 $secondary-background: #fdf6e3;
-$secondary-background-selected: #dfca88;
+$secondary-background-selected: #eee8d5;
 $secondary-background-inactive: #eee8d5;
-$secondary-background-hover: #f5ebcc;
+$secondary-background-hover: #eee8d5;
 $secondary-background-disabled: #eee8d5;
 
 $tertiary-background: #eee8d5;


### PR DESCRIPTION
In #421, some undesired changes were made to the selected and hover background colors in Solarized themes. Those colors are not part of the [Solarized palette](https://ethanschoonover.com/solarized/).

This PR fixes that by using the colors listed in the official palette.

Closes #472.