### PR TITLE
Text color tweaks on the OLED theme

### DIFF
--- a/src/themes/oled/theme.scss
+++ b/src/themes/oled/theme.scss
@@ -15,28 +15,28 @@ $tertiary-background: scale-color($secondary-background, $lightness: 3%);
 $shadow: rgba(0, 0, 0, 0.2);
 
 // Main body text
-$primary-text-color: #dedede;
+$primary-text-color: #cccccc;
 // UI control label text
-$secondary-text-color: #c7c7c7;
-$secondary-text-color-focus: #dedede;
-$secondary-text-color-hover: #dedede;
-$secondary-text-color-active: #dedede;
-$secondary-text-color-selected: #dedede;
-$secondary-text-color-inactive: #dedede;
+$secondary-text-color: #c5c5c5;
+$secondary-text-color-focus: #ffffff;
+$secondary-text-color-hover: #ffffff;
+$secondary-text-color-active: #ffffff;
+$secondary-text-color-selected: #ffffff;
+$secondary-text-color-inactive: #ffffff80;
 $secondary-text-color-disabled: rgba($primary-text-color, 0.4);
 $secondary-text-color-disabled-active: rgba($primary-text-color, 0.5);
 $secondary-text-color-disabled-inactive: rgba($primary-text-color, 0.4);
 
 // Sub label text
-$tertiary-text-color: scale-color($secondary-text-color, $lightness: -26%);
+$tertiary-text-color: #969896;
 // Heading text
-$header-text-color: #dedede;
+$header-text-color: #cccccc;
 
-$text-color-error: #f53d3d;
-$text-color-warning: #f5d63d;
-$text-color-success: #5cf53d;
-$text-color-code: #f53d3d;
-$text-color-link: #3d99f5;
+$text-color-error: #f48771;
+$text-color-warning: #cca700;
+$text-color-success: #0dbc79;
+$text-color-code: #d7ba7d;
+$text-color-link: #3794ff;
 
 $primary-border-color: #2a2a2a;
 $secondary-border-color: #1a1a1a;
@@ -47,28 +47,28 @@ $border-color-warning: #ffcf70;
 $border-color-success: #4b8400;
 
 $form-background: $secondary-background;
-$form-placeholder-color: $tertiary-text-color;
+$form-placeholder-color: #cccccc80;
 $form-text-color: $primary-text-color;
 $form-text-color-disabled: $secondary-text-color-disabled;
 $form-input-focus-color: rgba(85, 150, 230, 0.8);
 $form-input-border-color: $tertiary-border-color;
 $form-input-border-selected-color: $tertiary-text-color;
-$form-input-border-error-color: rgb(214, 97, 95);
+$form-input-border-error-color: #be1100;
 $form-input-background: $secondary-background;
 $form-input-background-disabled: $secondary-background-disabled;
 $form-button-background: $secondary-background-selected;
 
 $form-tips-background: $primary-background;
 
-$text-editor-color: #dedede;
+$text-editor-color: $primary-text-color;
 $text-editor-background: $secondary-background;
 $text-editor-color-disabled: $secondary-text-color-inactive;
 $text-editor-background-disabled: $secondary-background-disabled;
-$text-editor-gutter-background: #1a1a1a;
-$text-editor-gutter-color: #dedede;
-$text-editor-gutter-active-line-background: #2a2a2a;
+$text-editor-gutter-background: $secondary-background;
+$text-editor-gutter-color: #858585;
+$text-editor-gutter-active-line-background: $secondary-background-selected;
 $text-editor-active-line-background: #2a2a2a;
-$text-editor-selection-background: #424242;
+$text-editor-selection-background: #2e2e2e99;
 
 $event-log-background: $secondary-background;
 $event-log-color: $primary-text-color;
@@ -132,17 +132,17 @@ $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;
 $diff-state-color: $primary-text-color;
 $diff-state-prefix-color: $secondary-text-color;
-$diff-state-added: #5cf53d;
-$diff-state-deleted: #f53d3d;
-$diff-state-changed: #f5993d;
+$diff-state-added: #81b88b;
+$diff-state-deleted: #c74e39;
+$diff-state-changed: #e2c08d;
 $diff-state-changed-background: $secondary-background;
 $diff-state-unchanged: $primary-text-color;
 $diff-state-unchanged-background: $primary-background;
 
 $diff-state-conflicted: purple;
 $diff-state-moved: #3f81b3;
-$diff-state-conflict: #9b45ce;
-$diff-state-conflict-background: #ffdad4;
+$diff-state-conflict: #e4676b;
+$diff-state-conflict-background: #ffea0047;
 
 $diff-state-added-background: #9bb95533;
 $diff-state-added-border: rgba($diff-state-added-background, 0.1);
@@ -257,13 +257,13 @@ $debug-message-background: $secondary-background;
 $debug-message-background-hover: $secondary-background-hover;
 
 $debug-message-text-color: $primary-text-color;
-$debug-message-text-color-meta: #f5993d;
-$debug-message-text-color-object-key: #b83df5;
-$debug-message-text-color-msg-type-other: #3d99f5;
-$debug-message-text-color-msg-type-string: #f53d3d;
-$debug-message-text-color-msg-type-null: #808080;
-$debug-message-text-color-msg-type-meta: #808080;
-$debug-message-text-color-msg-type-number: #3d99f5;
+$debug-message-text-color-meta: #7aa6da;
+$debug-message-text-color-object-key: #cccccc;
+$debug-message-text-color-msg-type-other: #4e94ce;
+$debug-message-text-color-msg-type-string: #ce9178;
+$debug-message-text-color-msg-type-null: #cccccc;
+$debug-message-text-color-msg-type-meta: #c586c0;
+$debug-message-text-color-msg-type-number: #b5cea8;
 
 $debug-message-border: $primary-background;
 $debug-message-border-hover: $secondary-background-hover;


### PR DESCRIPTION
Use the text colors from the `tomorrow-night-bright` theme for VSCode on the OLED theme.