### PR TITLE
Remove autolabeler file matcher

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -55,8 +55,6 @@ exclude-labels:
 
 autolabeler:
   - label: "skip-changelog"
-    files:
-      - "package.json"
     branch:
       - "/release\/.+/"
   - label: "new-theme"


### PR DESCRIPTION
From https://github.com/release-drafter/release-drafter?tab=readme-ov-file#autolabeler

> Matchers are evaluated independently; the label will be set if at least one of the matchers meets the criteria.

With the removal of this 'files' matcher, autolabeler no longer adds a label to pull requests containing any changes in the `package.json` file.