### PR TITLE
Update Sass files to the module system

### DIFF
--- a/src/template/theme.scss
+++ b/src/template/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ad1625;
 $text-color-link: #0088cc;
 
 $primary-border-color: #bbbbbb;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/aurora/theme.scss
+++ b/src/themes/aurora/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -17,12 +19,12 @@ $shadow: rgba(0, 0, 0, 0.2);
 // Main body text
 $primary-text-color: #ececec;
 // UI control label text
-$secondary-text-color: scale-color($primary-text-color, $lightness: -38%);
-$secondary-text-color-focus: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-hover: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-active: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-selected: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-inactive: scale-color($primary-text-color, $lightness: -17.5%);
+$secondary-text-color: color.scale($primary-text-color, $lightness: -38%);
+$secondary-text-color-focus: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-hover: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-active: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-selected: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-inactive: color.scale($primary-text-color, $lightness: -17.5%);
 $secondary-text-color-disabled: rgba($primary-text-color, 0.4);
 $secondary-text-color-disabled-active: rgba($primary-text-color, 0.5);
 $secondary-text-color-disabled-inactive: rgba($primary-text-color, 0.4);
@@ -39,8 +41,8 @@ $text-color-code: #aaaaaa;
 $text-color-link: #bbbb77;
 
 $primary-border-color: #3f3d4d;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/cobalt2/theme.scss
+++ b/src/themes/cobalt2/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ffc600;
 $text-color-link: #0088ff;
 
 $primary-border-color: #1f4662;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/dark/theme.scss
+++ b/src/themes/dark/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d0d0d0;
 $text-color-link: #4daafc;
 
 $primary-border-color: #2b2b2b;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/dracula/theme.scss
+++ b/src/themes/dracula/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #3d3e46;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/espresso-libre/theme.scss
+++ b/src/themes/espresso-libre/theme.scss
@@ -1,34 +1,36 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
 
-$primary-background: scale-color(#2a211c, $lightness: -20%);
+$primary-background: color.scale(#2a211c, $lightness: -20%);
 
 $secondary-background: #2a211c;
-$secondary-background-selected: scale-color($secondary-background, $lightness: -24%);
-$secondary-background-inactive: scale-color($secondary-background, $lightness: -24%);
+$secondary-background-selected: color.scale($secondary-background, $lightness: -24%);
+$secondary-background-inactive: color.scale($secondary-background, $lightness: -24%);
 $secondary-background-hover: #3a312c;
-$secondary-background-disabled: scale-color($secondary-background, $lightness: -8%);
+$secondary-background-disabled: color.scale($secondary-background, $lightness: -8%);
 
-$tertiary-background: scale-color($secondary-background, $lightness: -20%);
+$tertiary-background: color.scale($secondary-background, $lightness: -20%);
 
 $shadow: rgba(0, 0, 0, 0.2);
 
 // Main body text
 $primary-text-color: #bdae9d;
 // UI control label text
-$secondary-text-color: scale-color($primary-text-color, $lightness: -38%);
-$secondary-text-color-focus: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-hover: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-active: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-selected: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-inactive: scale-color($primary-text-color, $lightness: -17.5%);
+$secondary-text-color: color.scale($primary-text-color, $lightness: -38%);
+$secondary-text-color-focus: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-hover: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-active: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-selected: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-inactive: color.scale($primary-text-color, $lightness: -17.5%);
 $secondary-text-color-disabled: rgba($primary-text-color, 0.4);
 $secondary-text-color-disabled-active: rgba($primary-text-color, 0.5);
 $secondary-text-color-disabled-inactive: rgba($primary-text-color, 0.4);
 
 // Sub label text
-$tertiary-text-color: scale-color($primary-text-color, $lightness: -51%);
+$tertiary-text-color: color.scale($primary-text-color, $lightness: -51%);
 // Heading text
 $header-text-color: #bdae9d;
 
@@ -39,8 +41,8 @@ $text-color-code: #888888;
 $text-color-link: #43a8ed;
 
 $primary-border-color: #3a312c;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/github-dark-default/theme.scss
+++ b/src/themes/github-dark-default/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #7d8590;
 $text-color-link: #2f81f7;
 
 $primary-border-color: #30363d;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/github-dark-dimmed/theme.scss
+++ b/src/themes/github-dark-dimmed/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #768390;
 $text-color-link: #539bf5;
 
 $primary-border-color: #444c56;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/github-dark/theme.scss
+++ b/src/themes/github-dark/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d1d5da;
 $text-color-link: #79b8ff;
 
 $primary-border-color: #1b1f23;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/midnight-red/theme.scss
+++ b/src/themes/midnight-red/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;

--- a/src/themes/monoindustrial/theme.scss
+++ b/src/themes/monoindustrial/theme.scss
@@ -1,28 +1,30 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
 
-$primary-background: scale-color(#222c28, $lightness: -20%);
+$primary-background: color.scale(#222c28, $lightness: -20%);
 
 $secondary-background: #222c28;
-$secondary-background-selected: scale-color($secondary-background, $lightness: 10%);
-$secondary-background-inactive: scale-color($secondary-background, $lightness: -12%);
-$secondary-background-hover: scale-color($secondary-background, $lightness: 5%);
-$secondary-background-disabled: scale-color($secondary-background, $lightness: -4%);
+$secondary-background-selected: color.scale($secondary-background, $lightness: 10%);
+$secondary-background-inactive: color.scale($secondary-background, $lightness: -12%);
+$secondary-background-hover: color.scale($secondary-background, $lightness: 5%);
+$secondary-background-disabled: color.scale($secondary-background, $lightness: -4%);
 
-$tertiary-background: scale-color($secondary-background, $lightness: -10%);
+$tertiary-background: color.scale($secondary-background, $lightness: -10%);
 
 $shadow: rgba(0, 0, 0, 0.2);
 
 // Main body text
 $primary-text-color: #fff;
 // UI control label text
-$secondary-text-color: scale-color($primary-text-color, $lightness: -38%);
-$secondary-text-color-focus: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-hover: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-active: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-selected: scale-color($primary-text-color, $lightness: -17.5%);
-$secondary-text-color-inactive: scale-color($primary-text-color, $lightness: -17.5%);
+$secondary-text-color: color.scale($primary-text-color, $lightness: -38%);
+$secondary-text-color-focus: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-hover: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-active: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-selected: color.scale($primary-text-color, $lightness: -17.5%);
+$secondary-text-color-inactive: color.scale($primary-text-color, $lightness: -17.5%);
 $secondary-text-color-disabled: rgba($primary-text-color, 0.4);
 $secondary-text-color-disabled-active: rgba($primary-text-color, 0.5);
 $secondary-text-color-disabled-inactive: rgba($primary-text-color, 0.4);
@@ -39,8 +41,8 @@ $text-color-code: #ad1625;
 $text-color-link: #0088cc;
 
 $primary-border-color: #171d1b;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/monokai-dimmed/theme.scss
+++ b/src/themes/monokai-dimmed/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #414141;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/monokai/theme.scss
+++ b/src/themes/monokai/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #414339;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/night-owl/theme.scss
+++ b/src/themes/night-owl/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #272b3b;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-azureus/theme.scss
+++ b/src/themes/noctis-azureus/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ffc180;
 $text-color-link: #49ace9;
 
 $primary-border-color: #1a425b;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-bordo/theme.scss
+++ b/src/themes/noctis-bordo/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ffc180;
 $text-color-link: #f18eb0;
 
 $primary-border-color: #593a46;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-minimus/theme.scss
+++ b/src/themes/noctis-minimus/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #dfc09f;
 $text-color-link: #5998c0;
 
 $primary-border-color: #334652;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-obscuro/theme.scss
+++ b/src/themes/noctis-obscuro/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
 $primary-border-color: #243f42;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-sereno/theme.scss
+++ b/src/themes/noctis-sereno/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
 $primary-border-color: #29484c;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-uva/theme.scss
+++ b/src/themes/noctis-uva/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ffc180;
 $text-color-link: #998ef1;
 
 $primary-border-color: #473856;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis-viola/theme.scss
+++ b/src/themes/noctis-viola/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #ffc180;
 $text-color-link: #bf8ef1;
 
 $primary-border-color: #473856;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/noctis/theme.scss
+++ b/src/themes/noctis/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
 $primary-border-color: #29484c;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/oceanic-next/theme.scss
+++ b/src/themes/oceanic-next/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #2b3b44;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/oled/theme.scss
+++ b/src/themes/oled/theme.scss
@@ -1,16 +1,18 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
 
-$primary-background: scale-color(#000, $lightness: 5%);
+$primary-background: color.scale(#000, $lightness: 5%);
 
 $secondary-background: #000;
 $secondary-background-selected: #161616;
-$secondary-background-inactive: scale-color($secondary-background, $lightness: 6%);
+$secondary-background-inactive: color.scale($secondary-background, $lightness: 6%);
 $secondary-background-hover: #323232;
 $secondary-background-disabled: $secondary-background;
 
-$tertiary-background: scale-color($secondary-background, $lightness: 3%);
+$tertiary-background: color.scale($secondary-background, $lightness: 3%);
 
 $shadow: rgba(0, 0, 0, 0.2);
 
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #2a2a2a;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/one-dark-pro-darker/theme.scss
+++ b/src/themes/one-dark-pro-darker/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d19a66;
 $text-color-link: #61afef;
 
 $primary-border-color: #3e4452;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/one-dark-pro/theme.scss
+++ b/src/themes/one-dark-pro/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d19a66;
 $text-color-link: #61afef;
 
 $primary-border-color: #3e4452;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/railscasts-extended/theme.scss
+++ b/src/themes/railscasts-extended/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -17,8 +19,8 @@ $shadow: rgba(0, 0, 0, 0.2);
 // Main body text
 $primary-text-color: #e6e1dc;
 // UI control label text
-$secondary-text-color: scale-color($primary-text-color, $lightness: -20%);
-$secondary-text-color-focus: scale-color($secondary-text-color, $lightness: 50%);
+$secondary-text-color: color.scale($primary-text-color, $lightness: -20%);
+$secondary-text-color-focus: color.scale($secondary-text-color, $lightness: 50%);
 $secondary-text-color-hover: $secondary-text-color-focus;
 $secondary-text-color-active: $secondary-text-color-focus;
 $secondary-text-color-selected: $secondary-text-color-focus;
@@ -39,8 +41,8 @@ $text-color-code: $primary-text-color;
 $text-color-link: #6e9cbe;
 
 $primary-border-color: #202020;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/selenized-dark/theme.scss
+++ b/src/themes/selenized-dark/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
 $primary-border-color: #285058;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/selenized-light/theme.scss
+++ b/src/themes/selenized-light/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #a31515;
 $text-color-link: #006ab1;
 
 $primary-border-color: #dad2c0;
-$secondary-border-color: scale-color($primary-border-color, $lightness: 14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: 7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/solarized-dark/theme.scss
+++ b/src/themes/solarized-dark/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #dc322f;
 $text-color-link: #268bd2;
 
 $primary-border-color: #2c4d57;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/solarized-light/theme.scss
+++ b/src/themes/solarized-light/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #dc322f;
 $text-color-link: #268bd2;
 
 $primary-border-color: #ddd6c1;
-$secondary-border-color: scale-color($primary-border-color, $lightness: 14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: 7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/tokyo-night-light/theme.scss
+++ b/src/themes/tokyo-night-light/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #33635c;
 $text-color-link: #2959aa;
 
 $primary-border-color: #c1c2c7;
-$secondary-border-color: scale-color($primary-border-color, $lightness: 14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: 7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/tokyo-night-storm/theme.scss
+++ b/src/themes/tokyo-night-storm/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #73daca;
 $text-color-link: #668ac4;
 
 $primary-border-color: #2d324a;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/tokyo-night/theme.scss
+++ b/src/themes/tokyo-night/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #9699a8;
 $text-color-link: #6183bb;
 
 $primary-border-color: #232433;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;

--- a/src/themes/totallyinformation/theme.scss
+++ b/src/themes/totallyinformation/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;

--- a/src/themes/zenburn/theme.scss
+++ b/src/themes/zenburn/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $primary-font: "Helvetica Neue", Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, "DejaVu Sans Mono", Courier, monospace;
@@ -39,8 +41,8 @@ $text-color-code: #d7ba7d;
 $text-color-link: #8cd0d3;
 
 $primary-border-color: #565656;
-$secondary-border-color: scale-color($primary-border-color, $lightness: -5%);
-$tertiary-border-color: scale-color($primary-border-color, $lightness: -2.5%);
+$secondary-border-color: color.scale($primary-border-color, $lightness: -5%);
+$tertiary-border-color: color.scale($primary-border-color, $lightness: -2.5%);
 
 $border-color-error: #df2935;
 $border-color-warning: #ffcf70;


### PR DESCRIPTION
The Sass global built-in rules were deprecated in [Dart Sass 1.80.0](https://github.com/sass/dart-sass/releases/tag/1.80.0).

This is generating large deprecation warning messages.

```log
Deprecation Warning: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.scale instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
42 │ $secondary-border-color: scale-color($primary-border-color, $lightness: -14%);
   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    /var/folders/v5/jgdt5brs0h527rjtssr6dw580000gn/T/dark-36EQJU/colors.scss 42:26             @import
    /var/folders/v5/jgdt5brs0h527rjtssr6dw580000gn/T/dark-36EQJU/style-custom-theme.scss 17:9  root stylesheet

Deprecation Warning: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.scale instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
43 │ $tertiary-border-color: scale-color($primary-border-color, $lightness: -7%);
   │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    /var/folders/v5/jgdt5brs0h527rjtssr6dw580000gn/T/dark-36EQJU/colors.scss 43:25             @import
    /var/folders/v5/jgdt5brs0h527rjtssr6dw580000gn/T/dark-36EQJU/style-custom-theme.scss 17:9  root stylesheet
```

To fix that, we're migrating all the Sass files to the Sass module system introduced in [Dart Sass 1.23.0](https://github.com/sass/dart-sass/releases/tag/1.23.0).