### PR TITLE
Customize the scrollbar colors

### DIFF
--- a/src/common/common.css
+++ b/src/common/common.css
@@ -11,3 +11,8 @@
 :root {
   accent-color: var(--red-ui-form-text-color);
 }
+
+/* Custom scrollbar colors */
+:root {
+  scrollbar-color: var(--red-ui-secondary-text-color-disabled) var(--red-ui-secondary-background);
+}


### PR DESCRIPTION
Bring back the custom scrollbar colors feature.

Safari doesn't support that, but it already has custom scrollbars.