### PR TITLE
Check out the default branch when cloning

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -18,7 +18,7 @@
     }
 
     await runner(
-        'git clone --depth=1 --no-tags --branch dev https://github.com/node-red/node-red.git',
+        'git clone --depth=1 --no-tags https://github.com/node-red/node-red.git',
         rootDir,
         'Cloning Node-RED repository'
     )


### PR DESCRIPTION
The `--branch dev` option was included by mistake in #587.