### PR TITLE
Disable telemetry in the development environment

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -45,6 +45,7 @@
             --userDir .node-red \
             --define credentialSecret=false \
             --define editorTheme.projects.enabled=true \
+            --no-telemetry \
             --define editorTheme.theme=${themeName} theme-dev-project`,
         ext: 'min.css,min.json',
         watch: [`themes/${themeName}/`],


### PR DESCRIPTION
To avoid polluting the telemetry database.