### PR TITLE
Do not specify minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,6 @@
             "node-red-contrib-themes": "themes.js"
         }
     },
-    "engines": {
-        "node": ">=18"
-    },
     "files": [
         "/themes",
         "/themes.js"


### PR DESCRIPTION
There is no need to specify a minimum node version since we already specify a minimum Node-RED version, and the Node-RED project specifies the minimum node version compatible with it.