### PR TITLE
Set minimum node version to 18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
             "node-red-contrib-themes": "themes.js"
         }
     },
+    "engines": {
+        "node": ">=18.5"
+    },
     "files": [
         "/themes",
         "/themes.js"


### PR DESCRIPTION
Match Node-RED's [minimum node version](https://github.com/node-red/node-red/blob/73dd2e117f42fefcfdc9b6c5e7e37b9b7db6247e/package.json#L127-L129).

This setting was removed in #632. That shouldn't have been done.

As per the Node-RED Flow Library Scorecard:

> Within the `engines` section of the package.json file you SHOULD declare the minimum version of Node that your package works on. This SHOULD satisfy the current minimum supported version of the latest Node-RED release.

<img width="960" height="540" alt="SCR-20260514-hqqy" src="https://github.com/user-attachments/assets/4642be7b-e00a-4fae-bdf8-36db535a5983" />
