### PR TITLE
Align variables with recent Node-RED changes

### DIFF
--- a/src/template/theme.scss
+++ b/src/template/theme.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-
 $primary-font: 'Helvetica Neue', Arial, Helvetica, sans-serif;
 $primary-font-size: 14px;
 $monospace-font: Menlo, Consolas, 'DejaVu Sans Mono', Courier, monospace;
@@ -14,7 +12,7 @@ $secondary-background-disabled: #f9f9f9;
 
 $tertiary-background: #f7f7f7;
 
-$shadow: rgba(0, 0, 0, 0.1);
+$shadow: rgba(0, 0, 0, 0.2);
 
 // Main body text
 $primary-text-color: #202020;
@@ -25,9 +23,9 @@ $secondary-text-color-hover: #666;
 $secondary-text-color-active: #666;
 $secondary-text-color-selected: #666;
 $secondary-text-color-inactive: #666;
-$secondary-text-color-disabled: rgba($primary-text-color, 0.4);
-$secondary-text-color-disabled-active: rgba($primary-text-color, 0.5);
-$secondary-text-color-disabled-inactive: rgba($primary-text-color, 0.4);
+$secondary-text-color-disabled: #bbb;
+$secondary-text-color-disabled-active: #999;
+$secondary-text-color-disabled-inactive: #aaa;
 
 // Sub label text
 $tertiary-text-color: #696969;
@@ -40,9 +38,16 @@ $text-color-success: #218358;
 $text-color-code: #ad1625;
 $text-color-link: #0d74ce;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #d9d9d9;
-$secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
-$tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
+$secondary-border-color: #e8e8e8;
+$tertiary-border-color: #cecece;
 
 $border-color-error: #df2935;
 $border-color-warning: #e79a00;
@@ -102,7 +107,7 @@ $palette-header-background: $primary-background;
 $palette-header-color: $header-text-color;
 $palette-content-background: $secondary-background;
 
-$scrollbar-handle-background: $primary-text-color;
+$scrollbar-handle-background: #a0a0a0;
 
 $workspace-button-background: $secondary-background;
 $workspace-button-background-hover: $secondary-background-hover;
@@ -125,11 +130,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;
@@ -173,11 +182,11 @@ $menuCaret: $tertiary-text-color;
 
 $view-navigator-background: rgba($primary-background, 0.8);
 
-$view-lasso-stroke: #ff7f0e;
+$view-lasso-stroke: #0d74ce;
 $view-lasso-fill: rgba(20, 125, 255, 0.1);
 
 $view-background: $secondary-background;
-$view-grid-color: #ffffff0f;
+$view-grid-color: #00000011;
 
 $node-label-color: #333;
 $node-port-label-color: #646464;
@@ -213,8 +222,8 @@ $node-status-colors: (
     grey: #d3d3d3
 );
 
-$node-selected-color: #ff7f0e;
-$port-selected-color: #ff7f0e;
+$node-selected-color: #0090ff;
+$port-selected-color: #0090ff;
 
 $link-color: #999;
 $link-link-color: #aaa;
@@ -248,8 +257,8 @@ $deploy-button-border-color: $header-button-border;
 $deploy-button-background: #bb0000;
 $deploy-button-background-hover: #a21212;
 $deploy-button-background-active: #7a0e0e;
-$deploy-button-background-disabled: #444;
-$deploy-button-background-disabled-hover: #555;
+$deploy-button-background-disabled: #ddd;
+$deploy-button-background-disabled-hover: #d3d3d3;
 
 $vcCommitShaColor: #5eb1ef;
 
@@ -284,8 +293,8 @@ $group-default-stroke: $primary-border-color;
 $group-default-stroke-opacity: 1;
 $group-default-label-color: $primary-text-color;
 
-$tourGuide-border: #c56c6c;
-$tourGuide-heading-color: #c56c6c;
+$tourGuide-border: #9e3232;
+$tourGuide-heading-color: #9e3232;
 
 $grip-color: rgba($primary-text-color, 0.5);
 

--- a/src/themes/aurora/theme.scss
+++ b/src/themes/aurora/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #c5e400;
 $text-color-code: #aaaaaa;
 $text-color-link: #bbbb77;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #3f3d4d;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/cobalt2/theme.scss
+++ b/src/themes/cobalt2/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #3ad900;
 $text-color-code: #ffc600;
 $text-color-link: #0088ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #0d3a58;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/dark-modern/theme.scss
+++ b/src/themes/dark-modern/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #0dbc79;
 $text-color-code: #d0d0d0;
 $text-color-link: #4daafc;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #2b2b2b;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/dracula/theme.scss
+++ b/src/themes/dracula/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #50fa7b;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #ffffff1a;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/espresso-libre/theme.scss
+++ b/src/themes/espresso-libre/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #049b0a;
 $text-color-code: #888888;
 $text-color-link: #43a8ed;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #3a312c;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/github-dark-default/theme.scss
+++ b/src/themes/github-dark-default/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #3fb950;
 $text-color-code: #7d8590;
 $text-color-link: #2f81f7;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #30363d;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/github-dark-dimmed/theme.scss
+++ b/src/themes/github-dark-dimmed/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #57ab5a;
 $text-color-code: #768390;
 $text-color-link: #539bf5;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #444c56;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/github-dark/theme.scss
+++ b/src/themes/github-dark/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #34d058;
 $text-color-code: #d1d5da;
 $text-color-link: #79b8ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #1b1f23;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/midnight-red/theme.scss
+++ b/src/themes/midnight-red/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #39e949;
 $text-color-code: #f4b400;
 $text-color-link: #4285f4;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #2e333a;
 $secondary-border-color: #2c3138;
 $tertiary-border-color: #2d3239;
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/monoindustrial/theme.scss
+++ b/src/themes/monoindustrial/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #3a3;
 $text-color-code: #ad1625;
 $text-color-link: #0088cc;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #171d1b;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/monokai-dimmed/theme.scss
+++ b/src/themes/monokai-dimmed/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #86b42b;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #414141;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/monokai/theme.scss
+++ b/src/themes/monokai/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #86b42b;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #414339;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/night-owl/theme.scss
+++ b/src/themes/night-owl/theme.scss
@@ -41,6 +41,13 @@ $text-color-success: #22da6e;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #272b3b;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -126,11 +133,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-azureus/theme.scss
+++ b/src/themes/noctis-azureus/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #ffc180;
 $text-color-link: #49ace9;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #0f1315;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-bordo/theme.scss
+++ b/src/themes/noctis-bordo/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #ffc180;
 $text-color-link: #f18eb0;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #1f191b;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-minimus/theme.scss
+++ b/src/themes/noctis-minimus/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #72c09f;
 $text-color-code: #dfc09f;
 $text-color-link: #5998c0;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #101213;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-obscuro/theme.scss
+++ b/src/themes/noctis-obscuro/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #0f1415;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-sereno/theme.scss
+++ b/src/themes/noctis-sereno/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #0f1415;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-uva/theme.scss
+++ b/src/themes/noctis-uva/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #ffc180;
 $text-color-link: #998ef1;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #171523;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis-viola/theme.scss
+++ b/src/themes/noctis-viola/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #ffc180;
 $text-color-link: #bf8ef1;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #1c1226;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/noctis/theme.scss
+++ b/src/themes/noctis/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #49e9a6;
 $text-color-code: #e4b781;
 $text-color-link: #40d4e7;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #0f1415;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/oceanic-next/theme.scss
+++ b/src/themes/oceanic-next/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #99c794;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #343d46;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/oled/theme.scss
+++ b/src/themes/oled/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #0dbc79;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #2a2a2a;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/one-dark-pro-darker/theme.scss
+++ b/src/themes/one-dark-pro-darker/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #8cc265;
 $text-color-code: #d19a66;
 $text-color-link: #61afef;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #373c44;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/one-dark-pro/theme.scss
+++ b/src/themes/one-dark-pro/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #8cc265;
 $text-color-code: #d19a66;
 $text-color-link: #61afef;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #3c4049;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/railscasts-extended/theme.scss
+++ b/src/themes/railscasts-extended/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #519f50;
 $text-color-code: $primary-text-color;
 $text-color-link: #6e9cbe;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #202020;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/selenized-dark/theme.scss
+++ b/src/themes/selenized-dark/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #80b83c;
 $text-color-code: #d7ba7d;
 $text-color-link: #3794ff;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #285058;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/selenized-light/theme.scss
+++ b/src/themes/selenized-light/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #539100;
 $text-color-code: #a31515;
 $text-color-link: #006ab1;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #d3d3d3;
 $secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/solarized-dark/theme.scss
+++ b/src/themes/solarized-dark/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #859900;
 $text-color-code: #dc322f;
 $text-color-link: #268bd2;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #2c4d57;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/solarized-light/theme.scss
+++ b/src/themes/solarized-light/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #859900;
 $text-color-code: #dc322f;
 $text-color-link: #268bd2;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #ddd6c1;
 $secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/tokyo-night-light/theme.scss
+++ b/src/themes/tokyo-night-light/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #33635c;
 $text-color-code: #33635c;
 $text-color-link: #2959aa;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #c1c2c7;
 $secondary-border-color: color.scale($primary-border-color, $lightness: 14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: 7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/tokyo-night-storm/theme.scss
+++ b/src/themes/tokyo-night-storm/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #73daca;
 $text-color-code: #73daca;
 $text-color-link: #668ac4;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #1b1e2e;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/tokyo-night/theme.scss
+++ b/src/themes/tokyo-night/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #73daca;
 $text-color-code: #9699a8;
 $text-color-link: #6183bb;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #232433;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/totallyinformation/theme.scss
+++ b/src/themes/totallyinformation/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #3a3;
 $text-color-code: #ad1625;
 $text-color-link: #0088cc;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: hsl(40, 7%, 60%);
 $secondary-border-color: hsl(40, 7%, 62.5%);
 $tertiary-border-color: hsl(40, 7%, 61.25%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/zenburn/theme.scss
+++ b/src/themes/zenburn/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #7f9f7f;
 $text-color-code: #d7ba7d;
 $text-color-link: #8cd0d3;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #565656;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -5%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -2.5%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;

--- a/src/themes/zendesk-garden/theme.scss
+++ b/src/themes/zendesk-garden/theme.scss
@@ -40,6 +40,13 @@ $text-color-success: #94c1b0;
 $text-color-code: #919ca5;
 $text-color-link: #2694d6;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #3a5bc7;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 $primary-border-color: #39434b;
 $secondary-border-color: color.scale($primary-border-color, $lightness: -14%);
 $tertiary-border-color: color.scale($primary-border-color, $lightness: -7%);
@@ -125,11 +132,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0, 0, 0, 0.35);
 
-$popover-background: $secondary-background-hover;
-$popover-border: $popover-background;
+$popover-background: $primary-background;
+$popover-border: $primary-border-color;
 $popover-color: $primary-text-color;
 $popover-button-border-color: $primary-border-color;
 $popover-button-border-color-hover: $secondary-text-color-hover;
+
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: $secondary-background;


### PR DESCRIPTION
Align with changes from the following PRs:

[Add support for GH style blockquote alerts
](https://github.com/node-red/node-red/pull/5733)

[Standardize popover colors](https://github.com/node-red/node-red/pull/5738)

[Tidy up popover appearance](https://github.com/node-red/node-red/pull/5740)